### PR TITLE
Add link to more documentation in README

### DIFF
--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -65,9 +65,9 @@ Count.main()
 
 In the code above, the `inputFile` and `outputFile` properties use the `@Argument` property wrapper. `ArgumentParser` uses this wrapper to denote a positional command-line input — because `inputFile` is specified first in the `Count` type, it's the first value read from the command-line, and `outputFile` is read second.
 
-We've implemented the command's logic in its `run()` method. Here, we're printing out a message confirming the names of the files the user gave. (You can find a full implementation of the completed command at the end of this guide.)
+We have implemented the command's logic in its `run()` method. Here, we are printing out a message confirming the names of the files the user gave. (You can find a full implementation of the completed command at the end of this guide.)
 
-Finally, you tell the parser to execute the `Count` command by calling its static `main()` method. This method parses the command-line arguments, verifies that they match up with what we've defined in `Count`, and either calls the `run()` method or exits with a helpful message.
+Finally, you tell the parser to execute the `Count` command by calling its static `main()` method. This method parses the command-line arguments, verifies that they match up with what we have defined in `Count`, and either calls the `run()` method or exits with a helpful message.
 
 
 ## Working with Named Options
@@ -179,7 +179,7 @@ struct Count: ParsableCommand {
 }
 ```
 
-The default name specification is `.long`, which uses a property's with a two-dash prefix. `.short` uses only the first letter of a property's name with a single-dash prefix, and allows combining groups of short options. You can specify custom short and long names with the `.customShort(_:)` and `.customLong(_:)` methods, respectively, or use the combined `.shortAndLong` property to specify the common case of both the short and long derived names.
+The default name specification is `.long`, which uses a property's name with a two-dash prefix. `.short` uses only the first letter of a property's name with a single-dash prefix, and allows combining groups of short options. You can specify custom short and long names with the `.customShort(_:)` and `.customLong(_:)` methods, respectively, or use the combined `.shortAndLong` property to specify the common case of both the short and long derived names.
 
 ## Providing Help
 

--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -65,9 +65,9 @@ Count.main()
 
 In the code above, the `inputFile` and `outputFile` properties use the `@Argument` property wrapper. `ArgumentParser` uses this wrapper to denote a positional command-line input — because `inputFile` is specified first in the `Count` type, it's the first value read from the command-line, and `outputFile` is read second.
 
-We have implemented the command's logic in its `run()` method. Here, we are printing out a message confirming the names of the files the user gave. (You can find a full implementation of the completed command at the end of this guide.)
+We've implemented the command's logic in its `run()` method. Here, we're printing out a message confirming the names of the files the user gave. (You can find a full implementation of the completed command at the end of this guide.)
 
-Finally, you tell the parser to execute the `Count` command by calling its static `main()` method. This method parses the command-line arguments, verifies that they match up with what we have defined in `Count`, and either calls the `run()` method or exits with a helpful message.
+Finally, you tell the parser to execute the `Count` command by calling its static `main()` method. This method parses the command-line arguments, verifies that they match up with what we've defined in `Count`, and either calls the `run()` method or exits with a helpful message.
 
 
 ## Working with Named Options

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -197,7 +197,7 @@ struct Example: ParsableCommand {
 }
 ```
 
-Since these flags are non-optional and don't have default values, they are now required when calling the command. The specified prefixes are prepended to the long names for the flags:
+Since these flags are non-optional and don't have default values, they're now required when calling the command. The specified prefixes are prepended to the long names for the flags:
 
 ```
 % example --index --enable-required-element

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -108,7 +108,7 @@ struct Example: ParsableCommand {
   % example --input-file file1.swift
   ```
 
-> **Note:** You can also pass `withSingleDash: true` to `.customLong` to create a single-dash flag or option, such as `-verbose`. Use this name specification only when necessary, such as when migrating a legacy command line interface. Using long names with a single-dash prefix can lead to ambiguity with combined short names: it may not be obvious whether `-file` is a single option or the combination of the four short options `-f`, `-i`, `-l`, and `-e`.
+> **Note:** You can also pass `withSingleDash: true` to `.customLong` to create a single-dash flag or option, such as `-verbose`. Use this name specification only when necessary, such as when migrating a legacy command line interface. Using long names with a single-dash prefix can lead to ambiguity with combined short names: it may not be obvious whether `-file` is a single option or the combination of the four short flags `-f`, `-i`, `-l`, and `-e`.
 
 ## Parsing custom types
 
@@ -197,7 +197,7 @@ struct Example: ParsableCommand {
 }
 ```
 
-Since these flags are non-optional and don't have default values, they're now required when calling the command. The specified prefixes are prepended to the long names for the flags:
+Since these flags are non-optional and don't have default values, they are now required when calling the command. The specified prefixes are prepended to the long names for the flags:
 
 ```
 % example --index --enable-required-element

--- a/Documentation/03 Commands and Subcommands.md
+++ b/Documentation/03 Commands and Subcommands.md
@@ -40,7 +40,7 @@ struct Math: ParsableCommand {
 }
 ```
 
-`Math` lists its three subcommands by their types; we'll see the definitions of `Math`, `Multiply`, and `Statistics` below. `Add` is also given as a default subcommand — this means that it is selected if a user leaves out a subcommand name:
+`Math` lists its three subcommands by their types; we'll see the definitions of `Add`, `Multiply`, and `Statistics` below. `Add` is also given as a default subcommand — this means that it is selected if a user leaves out a subcommand name:
 
 ```
 % math 10 15 7

--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -74,7 +74,7 @@ OPTIONS:
 
 ## Customizing Help for Commands
 
-In addition to the configuring the command name and subcommands, as described in [Command and Subcommands](03%20Commands%20and%20Subcommands.md), you can also configure a command's help text by providing and abstract and discussion.
+In addition to configuring the command name and subcommands, as described in [Command and Subcommands](03%20Commands%20and%20Subcommands.md), you can also configure a command's help text by providing an abstract and discussion.
 
 ```swift
 struct Repeat: ParsableCommand {

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 ## Usage
 
 Begin by declaring a type that defines the information you need to collect from the command line.
-Decorate each stored property with one of `ArgumentParser`'s property wrappers,
-and declare conformance to `ParsableCommand`.
+Decorate each stored property with one of `ArgumentParser`'s property wrappers.
 
 ```swift
 import ArgumentParser
 
-struct Repeat: ParsableCommand {
+struct Repeat {
     @Flag(help: "Include a counter with each repetition.")
     var includeCounter: Bool
 
@@ -21,14 +20,14 @@ struct Repeat: ParsableCommand {
 }
 ```
 
-Next, implement the `run()` method on your type, 
+Next, declare conformance to `ParsableCommand` and implement the `run()` method on your type, 
 and kick off execution by calling the type's static `main()` method.  
 The `ArgumentParser` library parses the command-line arguments,
 instantiates your command type, and then either executes your custom `run()` method 
 or exits with useful a message.
 
 ```swift
-extension Repeat {
+extension Repeat: ParsableCommand {
     func run() throws {
         let repeatCount = count ?? .max
 
@@ -68,6 +67,8 @@ OPTIONS:
   -c, --count <count>     The number of times to repeat 'phrase'.
   -h, --help              Show help for this command.
 ```
+
+For more information and documentation about all supported options, see [the `Documentation` folder at the root of the repository](https://github.com/apple/swift-argument-parser/tree/master/Documentation).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## Usage
 
 Begin by declaring a type that defines the information you need to collect from the command line.
-Decorate each stored property with one of `ArgumentParser`'s property wrappers.
+Decorate each stored property with one of `ArgumentParser`'s property wrappers,
+and declare conformance to `ParsableCommand`.
 
 ```swift
 import ArgumentParser
 
-struct Repeat {
+struct Repeat: ParsableCommand {
     @Flag(help: "Include a counter with each repetition.")
     var includeCounter: Bool
 
@@ -20,14 +21,14 @@ struct Repeat {
 }
 ```
 
-Next, declare conformance to `ParsableCommand` and implement the `run()` method on your type, 
+Next, implement the `run()` method on your type, 
 and kick off execution by calling the type's static `main()` method.  
 The `ArgumentParser` library parses the command-line arguments,
 instantiates your command type, and then either executes your custom `run()` method 
 or exits with useful a message.
 
 ```swift
-extension Repeat: ParsableCommand {
+extension Repeat {
     func run() throws {
         let repeatCount = count ?? .max
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ struct Repeat: ParsableCommand {
 
     @Argument(help: "The phrase to repeat.")
     var phrase: String
+
+    // continued below…
 }
 ```
 
@@ -28,7 +30,10 @@ instantiates your command type, and then either executes your custom `run()` met
 or exits with useful a message.
 
 ```swift
-extension Repeat {
+struct Repeat: ParsableCommand {
+
+    // continued from above…
+
     func run() throws {
         let repeatCount = count ?? .max
 


### PR DESCRIPTION
Also fixed some typos in the documentation

\<reverted> ~Also fixed protocol conformance part in README example because that surprised me that we declared conformance on type declaration but without implementing the conformance, and only implementing the conformance in extension later… which at least I thought would not compile… but now @harlanhaskins  made me doubt it was invalid 🤔)~ \</reverted>