### PR TITLE
Fix readme requirement name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ Add the following line to the dependencies in your `Package.swift` file:
 > **Note:** Because `ArgumentParser` is under active development,
 source-stability is only guaranteed within minor versions (e.g. between `0.0.3` and `0.0.4`).
 If you don't want potentially source-breaking package updates,
-you can specify your package dependency using `.upToNextMinorVersion(from: "0.0.1")` instead.
+you can specify your package dependency using `.upToNextMinor(from: "0.0.1")` instead.


### PR DESCRIPTION
I've checked on both SPM master and the swift-5.2 branch: 
it seems that the `Package.Dependency.Requirement` name is always [`.upToNextMinor(..)`](https://github.com/apple/swift-package-manager/blob/f2318da4f96b0607ade27eff51558206f57c2f98/Sources/PackageDescription/PackageRequirement.swift#L95).