### PR TITLE
Adding `.xcodesamplecode.plist` to give proper markdown rending inside Xcode

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
Same contents as my [merged PR into swift-standard-library-preview
](https://github.com/apple/swift-standard-library-preview/pull/1), [merged PR into swift-crypto](https://github.com/apple/swift-crypto/pull/11) and my [merged PR into swift-numerics](https://github.com/apple/swift-numerics/pull/34), giving proper markdown rendering inside Xcode.

As seen in [Apple's ARKit demo (inside `/ARKitExample.xcodeproj/` directory)](https://developer.apple.com/sample-code/wwdc/2017/PlacingObjects.zip)

### Motivation:

Reading of markdown becomes easier. Extra important in Swift packages, where the `README` is the first file opened by Xcode when opening said package.

### Modifications:

Just adding the `.xcodesamplecode.plist` file (to the root).

### Result:


This effectively disables editing markdown files from Xcode - or at least I have not found a way of doing so.

The "workaround" is just to open markdown files with your favourite alternative text editor, e.g. emacs, VIM, VI, Sublime Text or whatever

#### Before:
<img width="1680" alt="before" src="https://user-images.githubusercontent.com/864410/75570992-9912f600-5a58-11ea-8760-7b584c72bbb0.png">

#### After:
<img width="1680" alt="after" src="https://user-images.githubusercontent.com/864410/75570974-91ebe800-5a58-11ea-9503-8ff369f94488.png">

