### PR TITLE
Port to Android

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 let _exit: (Int32) -> Never = Glibc.exit
 #else

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -243,7 +243,7 @@ internal extension ParsableCommand {
   }
 }
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 func ioctl(_ a: Int32, _ b: Int32, _ p: UnsafeMutableRawPointer) -> Int32 {
   ioctl(CInt(a), UInt(b), p)


### PR DESCRIPTION
Should also get it working for the BSDs, Haiku, etc., as long as they have a working Swift toolchain. Tested with the Swift 5.1.4 package for Android, termux/termux-packages#4895, all 230 tests pass with the following commands:
```
swift build -j 5 --enable-test-discovery
swift test -j 5 --parallel --num-workers 3 --enable-test-discovery
```
Note the space required after `-j`, hopefully this library doesn't have the same problem.