### PR TITLE
Use EX_USAGE instead of EXIT_FAILURE for validation errors

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -129,7 +129,7 @@ extension ParsableArguments {
   /// with code `EXIT_SUCCESS`. If `error` represents a help request or
   /// another `CleanExit` error, this method prints help information and
   /// exits with code `EXIT_SUCCESS`. Otherwise, this method prints a relevant
-  /// error message and exits with code `EXIT_FAILURE`.
+  /// error message and exits with code `EX_USAGE` or `EXIT_FAILURE`.
   ///
   /// - Parameter error: The error to use when exiting, if any.
   public static func exit(
@@ -142,11 +142,10 @@ extension ParsableArguments {
     let messageInfo = MessageInfo(error: error, type: self)
     if messageInfo.shouldExitCleanly {
       print(messageInfo.fullText)
-      _exit(EXIT_SUCCESS)
     } else {
       print(messageInfo.fullText, to: &standardError)
-      _exit(EXIT_FAILURE)
     }
+    _exit(messageInfo.exitCode)
   }
   
   /// Parses a new instance of this type from command-line arguments or exits

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -102,4 +102,12 @@ enum MessageInfo {
     case .validation, .other: return false
     }
   }
+
+  var exitCode: Int32 {
+    switch self {
+    case .help: return EXIT_SUCCESS
+    case .validation: return EX_USAGE
+    case .other: return EXIT_FAILURE
+    }
+  }
 }


### PR DESCRIPTION
sysexits(3) documents the "preferable exit codes for programs". It defines

```
     EX_USAGE (64)         The command was used incorrectly, e.g., with the
                           wrong number of arguments, a bad flag, a bad syntax
                           in a parameter, or whatever.
```

So it seems to be a good choice for this use case.