### PR TITLE
add parentheses after `@OptionGroup`

### DIFF
--- a/Documentation/03 Commands and Subcommands.md
+++ b/Documentation/03 Commands and Subcommands.md
@@ -69,7 +69,7 @@ extension Math {
         static var configuration 
             = CommandConfiguration(abstract: "Print the sum of the values.")
 
-        @OptionGroup
+        @OptionGroup()
         var options: Math.Options
         
         func run() {
@@ -82,7 +82,7 @@ extension Math {
         static var configuration 
             = CommandConfiguration(abstract: "Print the product of the values.")
 
-        @OptionGroup
+        @OptionGroup()
         var options: Math.Options
         
         func run() {


### PR DESCRIPTION
I added parentheses after `@OptionGroup` on  `03 Commands and Subcommands.md`.

## Motivation

I faced compile error when I use `@OptionGroup` property wrapper. Eventually the reason was missing parentheses. 

We don't need to fix the living [example code](https://github.com/apple/swift-argument-parser/blob/f6ac7b8118ff5d1bc0faee7f37bf6f8fd8f95602/Examples/math/main.swift#L54), it works well.