### PR TITLE
Show default values for Bool properties in help

### DIFF
--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -43,7 +43,7 @@ This example shows how `ArgumentParser` provides defaults that speed up your ini
 - Option and flag names are derived from the names of your command's properties.
 - Whether arguments are required and what kinds of inputs are valid is based on your properties' types.
 
-In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option or argument with a `default` parameter can also be omitted by the user.
+In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option or flag with a `default` parameter can also be omitted by the user.
 
 Users must provide values for all properties with no implicit or specified default. For example, this command would require one integer argument and a string with the key `--user-name`.
 

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -185,10 +185,10 @@ Flags are most frequently used for `Bool` properties, with a default value of `f
 
 ```swift
 struct Example: ParsableCommand {
-    @Flag(inversion: .prefixedNo)
+    @Flag(default: true, inversion: .prefixedNo)
     var index: Bool
 
-    @Flag(inversion: .prefixedEnableDisable)
+    @Flag(default: nil, inversion: .prefixedEnableDisable)
     var requiredElement: Bool
     
     func run() throws {
@@ -197,13 +197,17 @@ struct Example: ParsableCommand {
 }
 ```
 
-Since these flags are non-optional and don't have default values, they're now required when calling the command. The specified prefixes are prepended to the long names for the flags:
+When providing a flag inversion, you can pass your own default as the `default` parameter. If you want to require that the user specify one of the two inversions, pass `nil` as the `default` parameter.
+
+In the `Example` command defined above, a flag is required for the `requiredElement` property. The specified prefixes are prepended to the long names for the flags:
 
 ```
-% example --index --enable-required-element
+% example --enable-required-element
 true true
 % example --no-index --disable-required-element
 false false
+% example --index
+Error: Missing one of: '--enable-required-element', '--disable-required-element'
 ```
 
 You can also use flags with types that are `CaseIterable` and `RawRepresentable` with a string raw value. This is useful for providing custom names for a Boolean value, for an exclusive choice between more than two names, or for collecting multiple values from a set of defined choices.

--- a/Documentation/03 Commands and Subcommands.md
+++ b/Documentation/03 Commands and Subcommands.md
@@ -69,7 +69,7 @@ extension Math {
         static var configuration 
             = CommandConfiguration(abstract: "Print the sum of the values.")
 
-        @OptionGroup
+        @OptionGroup()
         var options: Math.Options
         
         func run() {
@@ -82,7 +82,7 @@ extension Math {
         static var configuration 
             = CommandConfiguration(abstract: "Print the product of the values.")
 
-        @OptionGroup
+        @OptionGroup()
         var options: Math.Options
         
         func run() {

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -156,7 +156,8 @@ extension Flag where Value == Bool {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: The default value for this flag.
+  ///   - initial: The default value for this flag. If `initial` is `nil`, one
+  ///     of the two inversions is required.
   ///   - inversion: The method for converting this flags name into an on/off
   ///     pair.
   ///   - help: Information about how to use this flag.
@@ -198,7 +199,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value.RawValu
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
   ///   - initial: A default value to use for this property. If `initial` is
-  ///     non-`nil`, this flag is not required.
+  ///     `nil`, this flag is required.
   ///   - exclusivity: The behavior to use when multiple flags are specified.
   ///   - help: Information about how to use this flag.
   public init(

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 let _exit: (Int32) -> Never = Glibc.exit
 #else

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -247,7 +247,7 @@ internal extension ParsableCommand {
   }
 }
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 func ioctl(_ a: Int32, _ b: Int32, _ p: UnsafeMutableRawPointer) -> Int32 {
   ioctl(CInt(a), UInt(b), p)

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -172,11 +172,7 @@ internal struct HelpGenerator {
           i += 1
           
         } else {
-          let defaultValue = arg.help.defaultValue.flatMap {
-            return $0 == "true" || $0 == "false"
-              ? nil
-              : "(default: \($0))"
-            } ?? ""
+          let defaultValue = arg.help.defaultValue.flatMap { "(default: \($0))" } ?? ""
           synopsis = arg.synopsisForHelp ?? ""
           description = [arg.help.help?.abstract, defaultValue]
             .compactMap { $0 }

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -166,7 +166,9 @@ internal struct HelpGenerator {
           let nextArg = args[i + 1]
           let defaultValue = arg.help.defaultValue.map { "(default: \($0))" } ?? ""
           synopsis = "\(arg.synopsisForHelp ?? "")/\(nextArg.synopsisForHelp ?? "")"
-          description = [arg.help.help?.abstract ?? nextArg.help.help?.abstract ?? "", defaultValue].joined(separator: " ")
+          description = [arg.help.help?.abstract ?? nextArg.help.help?.abstract, defaultValue]
+            .compactMap { $0 }
+            .joined(separator: " ")
           i += 1
           
         } else {
@@ -176,7 +178,9 @@ internal struct HelpGenerator {
               : "(default: \($0))"
             } ?? ""
           synopsis = arg.synopsisForHelp ?? ""
-          description = [arg.help.help?.abstract ?? "", defaultValue].joined(separator: " ")
+          description = [arg.help.help?.abstract, defaultValue]
+            .compactMap { $0 }
+            .joined(separator: " ")
         }
         
         let element = Section.Element(label: synopsis, abstract: description, discussion: arg.help.help?.discussion ?? "")

--- a/Tests/PackageManagerTests/HelpTests.swift
+++ b/Tests/PackageManagerTests/HelpTests.swift
@@ -125,7 +125,7 @@ extension HelpTests {
                   --enable-package-manifest-caching/--disable-package-manifest-caching
                                           Cache Package.swift manifests (default: true)
                   --enable-prefetching/--disable-prefetching
-                                           (default: true)
+                                          (default: true)
                   --enable-sandbox/--disable-sandbox
                                           Use sandbox when executing subprocesses (default:
                                           true)

--- a/Tests/UnitTests/HelpGenerationTests.swift
+++ b/Tests/UnitTests/HelpGenerationTests.swift
@@ -74,4 +74,23 @@ extension HelpGenerationTests {
 
             """)
   }
+
+  struct Issue27: ParsableArguments {
+    @Option(default: "42")
+    var two: String
+    @Option(help: "The third option")
+    var three: String
+  }
+
+  func testHelpWithDefaultValueButNoDiscussion() {
+    AssertHelp(for: Issue27.self, equals: """
+            USAGE: issue27 [--two <two>] --three <three>
+
+            OPTIONS:
+              --two <two>             (default: 42)
+              --three <three>         The third option
+              -h, --help              Show help information.
+
+            """)
+  }
 }

--- a/Tests/UnitTests/HelpGenerationTests.swift
+++ b/Tests/UnitTests/HelpGenerationTests.swift
@@ -93,4 +93,29 @@ extension HelpGenerationTests {
 
             """)
   }
+
+  struct D: ParsableCommand {
+
+    @Option(default: "John", help: "Your name.")
+    var name: String
+
+    @Option(default: 20, help: "Your age.")
+    var age: Int
+
+    @Option(default: false, help: "Whether logging is enabled.")
+    var logging: Bool
+  }
+
+  func testHelpWithDefaultValues() {
+    AssertHelp(for: D.self, equals: """
+            USAGE: d [--name <name>] [--age <age>] [--logging <logging>]
+
+            OPTIONS:
+              --name <name>           Your name. (default: John)
+              --age <age>             Your age. (default: 20)
+              --logging <logging>     Whether logging is enabled. (default: false)
+              -h, --help              Show help information.
+
+            """)
+  }
 }


### PR DESCRIPTION
HelpGenerator currently filters out the default values for `Bool`s. Fixes #16 