### PR TITLE
Clean up InputOrigin

### DIFF
--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -16,19 +16,11 @@
 /// This is usually an index into the `SplitArguments`.
 /// In some cases it can be multiple indices.
 struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
-  enum Element: Comparable, Hashable {
+  enum Element: Hashable {
     case argumentIndex(SplitArguments.Index)
   }
   
   private var _elements: Set<Element> = []
-  var elements: [Element] {
-    get {
-      Array(_elements).sorted()
-    }
-    set {
-      _elements = Set(newValue)
-    }
-  }
   
   init() {
   }
@@ -41,20 +33,20 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
     _elements = Set([element])
   }
   
-  init(arrayLiteral elements: InputOrigin.Element...) {
+  init(arrayLiteral elements: Element...) {
     self.init(elements: elements)
   }
-  
-  static func argumentIndex(_ index: SplitArguments.Index) -> InputOrigin {
-    return InputOrigin(elements: [.argumentIndex(index)])
+
+  init(argumentIndex: SplitArguments.Index) {
+    self.init(element: .argumentIndex(argumentIndex))
   }
   
-  mutating func insert(_ other: InputOrigin.Element) {
+  mutating func insert(_ other: Element) {
     guard !_elements.contains(other) else { return }
     _elements.insert(other)
   }
   
-  func inserting(_ other: InputOrigin.Element) -> InputOrigin {
+  func inserting(_ other: Element) -> Self {
     guard !_elements.contains(other) else { return self }
     var result = self
     result.insert(other)
@@ -64,27 +56,8 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
   mutating func formUnion(_ other: InputOrigin) {
     _elements.formUnion(other._elements)
   }
-  
-  func union(_ other: InputOrigin) -> InputOrigin {
-    var result = self
-    result._elements.formUnion(other._elements)
-    return result
-  }
-  
-  func isSubset(of other: Self) -> Bool {
-    return _elements.isSubset(of: other._elements)
-  }
-  
+
   func forEach(_ closure: (Element) -> Void) {
     _elements.forEach(closure)
-  }
-}
-
-extension InputOrigin.Element {
-  static func < (lhs: Self, rhs: Self) -> Bool {
-    switch (lhs, rhs) {
-    case (.argumentIndex(let l), .argumentIndex(let r)):
-      return l < r
-    }
   }
 }

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -393,7 +393,7 @@ extension SplitArguments {
           input = originalInput[index.inputIndex.rawValue]
         }
       }
-      return (.argumentIndex(index), input)
+      return (.init(argumentIndex: index), input)
     }
   }
 }


### PR DESCRIPTION
This removes unused code from `InputOrigin` and replaces the lone `static func` with an `init` to better match the rest of the file.