### PR TITLE
Remove code that can be synthesized

### DIFF
--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -29,19 +29,6 @@ enum Name: Equatable {
       self = .longWithSingleDash(String(baseName.dropFirst()))
     }
   }
-  
-  static func == (lhs: Name, rhs: Name) -> Bool {
-    switch (lhs, rhs) {
-    case (.long(let lhs), .long(let rhs)):
-      return lhs == rhs
-    case (.short(let lhs), .short(let rhs)):
-      return lhs == rhs
-    case (.longWithSingleDash(let lhs), .longWithSingleDash(let rhs)):
-      return lhs == rhs
-    default:
-      return false
-    }
-  }
 }
 
 extension Name {

--- a/Sources/ArgumentParser/Parsing/ParsedValues.swift
+++ b/Sources/ArgumentParser/Parsing/ParsedValues.swift
@@ -41,11 +41,6 @@ struct ParsedValues {
   ///
   /// This is used for error output generation.
   var originalInput: [String]
-  
-  public init(elements: [Element] = [], originalInput: [String]) {
-    self.elements = elements
-    self.originalInput = originalInput
-  }
 }
 
 enum LenientParsedValues {

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -19,11 +19,7 @@ internal struct HelpGenerator {
   internal static var _screenWidthOverride: Int? = nil
   
   struct Usage {
-    public var components: [String]
-    
-    public init(components: [String]) {
-      self.components = components
-    }
+    var components: [String]
     
     var rendered: String {
       components
@@ -33,15 +29,9 @@ internal struct HelpGenerator {
   
   struct Section {
     struct Element {
-      public var label: String
-      public var abstract: String
-      public var discussion: String
-      
-      public init(label: String, abstract: String = "", discussion: String = "") {
-        self.label = label
-        self.abstract = abstract
-        self.discussion = discussion
-      }
+      var label: String
+      var abstract: String = ""
+      var discussion: String = ""
       
       var paddedLabel: String {
         String(repeating: " ", count: HelpGenerator.helpIndent) + label
@@ -86,15 +76,8 @@ internal struct HelpGenerator {
     
     var header: Header
     var elements: [Element]
-    var discussion: String
-    var isSubcommands: Bool
-    
-    init(header: Header, elements: [Element], discussion: String = "", isSubcommands: Bool = false) {
-      self.header = header
-      self.elements = elements
-      self.discussion = discussion
-      self.isSubcommands = isSubcommands
-    }
+    var discussion: String = ""
+    var isSubcommands: Bool = false
     
     var rendered: String {
       guard !elements.isEmpty else { return "" }
@@ -106,13 +89,8 @@ internal struct HelpGenerator {
   }
   
   struct DiscussionSection {
-    var title: String
+    var title: String = ""
     var content: String
-    
-    init(title: String = "", content: String) {
-      self.title = title
-      self.content = content
-    }
   }
   
   var abstract: String


### PR DESCRIPTION
This removes two types of redundant code:
- `internal` annotations (because they are the default)
- code that the compiler can synthesize, like memberwise initializers and `Equatable` conformances

Some `public init`s were removed, but those couldn't be accessed anyway, because they were nested in `internal` types - I've [complained](https://forums.swift.org/t/members-in-type-more-accessible-than-the-type-itself/24756) about the possibility of doing this before on the forums.