### PR TITLE
Remove extra space leading default value help text

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -166,7 +166,9 @@ internal struct HelpGenerator {
           let nextArg = args[i + 1]
           let defaultValue = arg.help.defaultValue.map { "(default: \($0))" } ?? ""
           synopsis = "\(arg.synopsisForHelp ?? "")/\(nextArg.synopsisForHelp ?? "")"
-          description = [arg.help.help?.abstract ?? nextArg.help.help?.abstract ?? "", defaultValue].joined(separator: " ")
+          description = [arg.help.help?.abstract ?? nextArg.help.help?.abstract, defaultValue]
+            .compactMap { $0 }
+            .joined(separator: " ")
           i += 1
           
         } else {
@@ -176,7 +178,9 @@ internal struct HelpGenerator {
               : "(default: \($0))"
             } ?? ""
           synopsis = arg.synopsisForHelp ?? ""
-          description = [arg.help.help?.abstract ?? "", defaultValue].joined(separator: " ")
+          description = [arg.help.help?.abstract, defaultValue]
+            .compactMap { $0 }
+            .joined(separator: " ")
         }
         
         let element = Section.Element(label: synopsis, abstract: description, discussion: arg.help.help?.discussion ?? "")

--- a/Tests/PackageManagerTests/HelpTests.swift
+++ b/Tests/PackageManagerTests/HelpTests.swift
@@ -125,7 +125,7 @@ extension HelpTests {
                   --enable-package-manifest-caching/--disable-package-manifest-caching
                                           Cache Package.swift manifests (default: true)
                   --enable-prefetching/--disable-prefetching
-                                           (default: true)
+                                          (default: true)
                   --enable-sandbox/--disable-sandbox
                                           Use sandbox when executing subprocesses (default:
                                           true)

--- a/Tests/UnitTests/HelpGenerationTests.swift
+++ b/Tests/UnitTests/HelpGenerationTests.swift
@@ -74,4 +74,23 @@ extension HelpGenerationTests {
 
             """)
   }
+
+  struct Issue27: ParsableArguments {
+    @Option(default: "42")
+    var two: String
+    @Option(help: "The third option")
+    var three: String
+  }
+
+  func testHelpWithDefaultValueButNoDiscussion() {
+    AssertHelp(for: Issue27.self, equals: """
+            USAGE: issue27 [--two <two>] --three <three>
+
+            OPTIONS:
+              --two <two>             (default: 42)
+              --three <three>         The third option
+              -h, --help              Show help information.
+
+            """)
+  }
 }


### PR DESCRIPTION
When generating help text, remove non-existent segments prior to joining
with an empty space. This ensures vertical visual alignment when
description for default value is the only segment.

Closes #27