### PR TITLE
Add a catch-all argument parsing strategy

### DIFF
--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -317,7 +317,6 @@ The default strategy for parsing options as arrays is to read each value from a 
 ```swift
 struct Example: ParsableCommand {
     @Option() var file: [String]
-    
     @Flag() var verbose: Bool
     
     func run() throws {
@@ -359,4 +358,36 @@ Finally, the `.remaining` parsing strategy uses all the inputs that follow the o
 Verbose: true, files: ["file1.swift", "file2.swift"]
 % example --file file1.swift file2.swift --verbose
 Verbose: false, files: ["file1.swift", "file2.swift", "--verbose"]
+```
+
+## Alternative positional argument parsing strategies
+
+The default strategy for parsing arrays of positional arguments is to ignore  all dash-prefixed command-line inputs. For example, this command accepts a `--verbose` flag and a list of file names as positional arguments:
+
+```swift
+struct Example: ParsableCommand {
+    @Flag() var verbose: Bool
+    @Argument() var files: [String]
+    
+    func run() throws {
+        print("Verbose: \(verbose), files: \(files)")
+    }
+}
+```
+
+The `files` argument array uses the default `.remaining` parsing strategy, so it only picks up values that don't have a prefix:
+
+```
+% example --verbose file1.swift file2.swift
+Verbose: true, files: ["file1.swift", "file2.swift"]
+% example --verbose file1.swift file2.swift --other
+Error: Unexpected argument '--other'
+Usage: example [--verbose] [<files> ...]
+```
+
+The `.unconditionalRemaining` parsing strategy uses whatever input is left after parsing known options and flags, even if that input is dash-prefixed. If `files` were defined as `@Argument(parsing: .unconditionalRemaining) var files: [String]`, then the resulting array would also include strings that look like options:
+
+```
+% example --verbose file1.swift file2.swift --other
+Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
 ```

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -385,9 +385,18 @@ Error: Unexpected argument '--other'
 Usage: example [--verbose] [<files> ...]
 ```
 
-The `.unconditionalRemaining` parsing strategy uses whatever input is left after parsing known options and flags, even if that input is dash-prefixed. If `files` were defined as `@Argument(parsing: .unconditionalRemaining) var files: [String]`, then the resulting array would also include strings that look like options:
+Any input after the `--` terminator is automatically treated as positional input, so users can provide dash-prefixed values that way even with the default configuration:
+
+```
+% example --verbose -- file1.swift file2.swift --other
+Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
+```
+
+The `.unconditionalRemaining` parsing strategy uses whatever input is left after parsing known options and flags, even if that input is dash-prefixed, including the terminator itself. If `files` were defined as `@Argument(parsing: .unconditionalRemaining) var files: [String]`, then the resulting array would also include strings that look like options:
 
 ```
 % example --verbose file1.swift file2.swift --other
 Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
+% example -- --verbose file1.swift file2.swift --other
+Verbose: false, files: ["--", "--verbose", "file1.swift", "file2.swift", "--other"]
 ```

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -104,7 +104,7 @@ public enum ArgumentArrayParsingStrategy {
   case remaining
   
   /// Parse all remaining inputs after parsing any known options or flags,
-  /// including dash-prefixed inputs.
+  /// including dash-prefixed inputs and the `--` terminator.
   ///
   /// For example, for a parsable type defined as following:
   ///
@@ -118,8 +118,11 @@ public enum ArgumentArrayParsingStrategy {
   /// `Options(verbose: true, words: ["one", "two", "--other"])`.
   ///
   /// - Note: This parsing strategy can be surprising for users, particularly
-  ///   when combined with options and flags. Use care when specifying the
-  ///   `unconditionalRemaining` parsing strategy.
+  ///   when combined with options and flags. Prefer `remaining` whenever
+  ///   possible, since users can always terminate options and flags with
+  ///   the `--` terminator. With the `remaining` parsing strategy, the input
+  ///   `--verbose -- one two --other` would have the same result as the above
+  ///   example: `Options(verbose: true, words: ["one", "two", "--other"])`.
   case unconditionalRemaining
 }
 

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -116,6 +116,10 @@ public enum ArgumentArrayParsingStrategy {
   /// Parsing the input `--verbose one two --other` would include the `--other`
   /// flag in `words`, resulting in
   /// `Options(verbose: true, words: ["one", "two", "--other"])`.
+  ///
+  /// - Note: This parsing strategy can be surprising for users, particularly
+  ///   when combined with options and flags. Use care when specifying the
+  ///   `unconditionalRemaining` parsing strategy.
   case unconditionalRemaining
 }
 

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -110,7 +110,7 @@ public enum ArgumentArrayParsingStrategy {
   ///
   ///     struct Options: ParsableArguments {
   ///         @Flag() var verbose: Bool
-  ///         @Argument(parsing: .remainingValues) var words: [String]
+  ///         @Argument(parsing: .unconditionalRemaining) var words: [String]
   ///     }
   ///
   /// Parsing the input `--verbose one two --other` would include the `--other`

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -83,6 +83,42 @@ extension Argument where Value: ExpressibleByArgument {
   }
 }
 
+/// The strategy to use when parsing multiple values from `@Option` arguments
+/// into an array.
+public enum ArgumentArrayParsingStrategy {
+  /// Parse only unprefixed values from the command-line input, ignoring
+  /// any inputs that have a dash prefix.
+  ///
+  /// For example, for a parsable type defined as following:
+  ///
+  ///     struct Options: ParsableArguments {
+  ///         @Flag() var verbose: Bool
+  ///         @Argument(parsing: .remaining) var words: [String]
+  ///     }
+  ///
+  /// Parsing the input `--verbose one two` or `one two --verbose` would result
+  /// in `Options(verbose: true, words: ["one", "two"])`. Parsing the input
+  /// `one two --other` would result in an unknown option error for `--other`.
+  ///
+  /// This is the default strategy for parsing argument arrays.
+  case remaining
+  
+  /// Parse all remaining inputs after parsing any known options or flags,
+  /// including dash-prefixed inputs.
+  ///
+  /// For example, for a parsable type defined as following:
+  ///
+  ///     struct Options: ParsableArguments {
+  ///         @Flag() var verbose: Bool
+  ///         @Argument(parsing: .remainingValues) var words: [String]
+  ///     }
+  ///
+  /// Parsing the input `--verbose one two --other` would include the `--other`
+  /// flag in `words`, resulting in
+  /// `Options(verbose: true, words: ["one", "two", "--other"])`.
+  case unconditionalRemaining
+}
+
 extension Argument {
   /// Creates a property that reads its value from an argument, parsing with
   /// the given closure.
@@ -111,17 +147,23 @@ extension Argument {
   ///
   /// - Parameter help: Information about how to use this argument.
   public init<Element>(
+    parsing parsingStrategy: ArgumentArrayParsingStrategy = .remaining,
     help: ArgumentHelp? = nil
   )
     where Element: ExpressibleByArgument, Value == Array<Element>
   {
     self.init(_parsedValue: .init { key in
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
-      let arg = ArgumentDefinition(kind: .positional, help: help, update: .appendToArray(forType: Element.self, key: key), initial: { origin, values in
-        values.set([], forKey: key, inputOrigin: origin)
-      })
+      let arg = ArgumentDefinition(
+        kind: .positional,
+        help: help,
+        parsingStrategy: parsingStrategy == .remaining ? .nextAsValue : .allRemainingInput,
+        update: .appendToArray(forType: Element.self, key: key),
+        initial: { origin, values in
+          values.set([], forKey: key, inputOrigin: origin)
+        })
       return ArgumentSet(alternatives: [arg])
-      })
+    })
   }
   
   /// Creates a property that reads an array from zero or more arguments,
@@ -134,6 +176,7 @@ extension Argument {
   ///   - transform: A closure that converts a string into this property's
   ///     element type or throws an error.
   public init<Element>(
+    parsing parsingStrategy: ArgumentArrayParsingStrategy = .remaining,
     help: ArgumentHelp? = nil,
     transform: @escaping (String) throws -> Element
   )
@@ -141,17 +184,21 @@ extension Argument {
   {
     self.init(_parsedValue: .init { key in
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
-      let arg = ArgumentDefinition(kind: .positional, help: help, update: .unary({
-        (origin, name, valueString, parsedValues) in
-        let element = try transform(valueString)
-        parsedValues.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
-          $0.append(element)
+      let arg = ArgumentDefinition(
+        kind: .positional,
+        help: help,
+        parsingStrategy: parsingStrategy == .remaining ? .nextAsValue : .allRemainingInput,
+        update: .unary({
+          (origin, name, valueString, parsedValues) in
+          let element = try transform(valueString)
+          parsedValues.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
+            $0.append(element)
+          })
+        }),
+        initial: { origin, values in
+          values.set([], forKey: key, inputOrigin: origin)
         })
-      }),
-                                   initial: { origin, values in
-                                    values.set([], forKey: key, inputOrigin: origin)
-      })
       return ArgumentSet(alternatives: [arg])
-      })
+    })
   }
 }

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -149,7 +149,10 @@ extension Argument {
   ///
   /// The property has an empty array as its default value.
   ///
-  /// - Parameter help: Information about how to use this argument.
+  /// - Parameters:
+  ///   - parsingStrategy: The behavior to use when parsing multiple values
+  ///     from the command-line arguments.
+  ///   - help: Information about how to use this argument.
   public init<Element>(
     parsing parsingStrategy: ArgumentArrayParsingStrategy = .remaining,
     help: ArgumentHelp? = nil
@@ -176,6 +179,8 @@ extension Argument {
   /// The property has an empty array as its default value.
   ///
   /// - Parameters:
+  ///   - parsingStrategy: The behavior to use when parsing multiple values
+  ///     from the command-line arguments.
   ///   - help: Information about how to use this argument.
   ///   - transform: A closure that converts a string into this property's
   ///     element type or throws an error.

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -396,6 +396,7 @@ extension ArgumentSet {
       case .terminator:
         // Mark the terminator as used:
         result.set(ParsedValues.Element(key: .terminator, value: 0, inputOrigin: [origin]))
+        unusedOptions.append((origin, all.originalInput(at: origin)))
       }
     }
     

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -206,6 +206,14 @@ extension SplitArguments {
       }?.1
   }
   
+  /// Returns the original input string at the given origin.
+  func originalInput(at origin: InputOrigin.Element) -> String {
+    switch origin {
+    case .argumentIndex(let index):
+      return originalInput[index.inputIndex.rawValue]
+    }
+  }
+  
   mutating func popNext() -> (InputOrigin.Element, Element)? {
     guard let (index, value) = elements.first else { return nil }
     elements.remove(at: 0)

--- a/Tests/EndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/EndToEndTests/RepeatingEndToEndTests.swift
@@ -331,6 +331,21 @@ extension RepeatingEndToEndTests {
       XCTAssertTrue(foozle.verbose)
       XCTAssertEqual(foozle.names, ["--other", "one", "two", "three"])
     }
+    
+    AssertParse(Foozle.self, ["--verbose", "--other", "one", "--", "two", "three"]) { foozle in
+      XCTAssertTrue(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["--other", "one", "--", "two", "three"])
+    }
+    
+    AssertParse(Foozle.self, ["--other", "one", "--", "two", "three", "--verbose"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["--other", "one", "--", "two", "three", "--verbose"])
+    }
+    
+    AssertParse(Foozle.self, ["--", "--verbose", "--other", "one", "two", "three"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["--", "--verbose", "--other", "one", "two", "three"])
+    }
   }
 }
 

--- a/Tests/EndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/EndToEndTests/RepeatingEndToEndTests.swift
@@ -300,6 +300,42 @@ extension RepeatingEndToEndTests {
 
 // MARK: -
 
+fileprivate struct Foozle: ParsableArguments {
+  @Flag() var verbose: Bool
+  @Argument(parsing: .unconditionalRemaining) var names: [String]
+}
+
+extension RepeatingEndToEndTests {
+  func testParsing_repeatingUnconditionalArgument() throws {
+    AssertParse(Foozle.self, []) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertEqual(foozle.names, [])
+    }
+    
+    AssertParse(Foozle.self, ["--other"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["--other"])
+    }
+    
+    AssertParse(Foozle.self, ["--verbose", "one", "two", "three"]) { foozle in
+      XCTAssertTrue(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["one", "two", "three"])
+    }
+    
+    AssertParse(Foozle.self, ["one", "two", "three", "--other", "--verbose"]) { foozle in
+      XCTAssertTrue(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["one", "two", "three", "--other"])
+    }
+    
+    AssertParse(Foozle.self, ["--verbose", "--other", "one", "two", "three"]) { foozle in
+      XCTAssertTrue(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["--other", "one", "two", "three"])
+    }
+  }
+}
+
+// MARK: -
+
 struct PerformanceTest: ParsableCommand {
   @Option(name: .short) var bundleIdentifiers: [String]
   


### PR DESCRIPTION
### Description
We don't currently have a way for `@Argument` arrays to capture command-line inputs that look like options. This capability is important for tools like SwiftPM that need to forward input to another command.

For example, the `swift-run` command needs to be able to parse all three of the arguments here into an array, including `--count`:

```
% swift run repeat --count 5 hello
``` 

### Detailed Design
This introduces an `ArgumentArrayParsingStrategy` enum with a `remaining` case that  matches the current behavior, as well as an `unconditionalRemaining` case that captures all remaining input.

```swift
/// The strategy to use when parsing multiple values from `@Option` arguments
/// into an array.
public enum ArgumentArrayParsingStrategy {
  /// Parse only unprefixed values from the command-line input, ignoring
  /// any inputs that have a dash prefix.
  ///
  /// For example, for a parsable type defined as following:
  ///
  ///     struct Options: ParsableArguments {
  ///         @Flag() var verbose: Bool
  ///         @Argument(parsing: .remaining) var words: [String]
  ///     }
  ///
  /// Parsing the input `--verbose one two` or `one two --verbose` would result
  /// in `Options(verbose: true, words: ["one", "two"])`. Parsing the input
  /// `one two --other` would result in an unknown option error for `--other`.
  ///
  /// This is the default strategy for parsing argument arrays.
  case remaining
  
  /// Parse all remaining inputs after parsing any known options or flags,
  /// including dash-prefixed inputs and the `--` terminator.
  ///
  /// For example, for a parsable type defined as following:
  ///
  ///     struct Options: ParsableArguments {
  ///         @Flag() var verbose: Bool
  ///         @Argument(parsing: .unconditionalRemaining) var words: [String]
  ///     }
  ///
  /// Parsing the input `--verbose one two --other` would include the `--other`
  /// flag in `words`, resulting in
  /// `Options(verbose: true, words: ["one", "two", "--other"])`.
  ///
  /// - Note: This parsing strategy can be surprising for users, particularly
  ///   when combined with options and flags. Prefer `remaining` whenever
  ///   possible, since users can always terminate options and flags with
  ///   the `--` terminator. With the `remaining` parsing strategy, the input
  ///   `--verbose -- one two --other` would have the same result as the above
  ///   example: `Options(verbose: true, words: ["one", "two", "--other"])`.
  case unconditionalRemaining
}
```

The two array-based `@Argument` initializers gain defaulted parameters for the parsing strategy:

```swift
  /// Creates a property that reads an array from zero or more arguments.
  ///
  /// The property has an empty array as its default value.
  ///
  /// - Parameters:
  ///   - parsingStrategy: The behavior to use when parsing multiple values
  ///     from the command-line arguments.
  ///   - help: Information about how to use this argument.
  public init<Element>(
    parsing parsingStrategy: ArgumentArrayParsingStrategy = .remaining,
    help: ArgumentHelp? = nil
  ) where Element: ExpressibleByArgument, Value == Array<Element>

  /// Creates a property that reads an array from zero or more arguments,
  /// parsing each element with the given closure.
  ///
  /// The property has an empty array as its default value.
  ///
  /// - Parameters:
  ///   - parsingStrategy: The behavior to use when parsing multiple values
  ///     from the command-line arguments.
  ///   - help: Information about how to use this argument.
  ///   - transform: A closure that converts a string into this property's
  ///     element type or throws an error.
  public init<Element>(
    parsing parsingStrategy: ArgumentArrayParsingStrategy = .remaining,
    help: ArgumentHelp? = nil,
    transform: @escaping (String) throws -> Element
  ) where Value == Array<Element>
```

### Documentation Plan
This includes documentation for the new enumeration and for the new parameters, as well as a new "Alternative positional argument parsing strategies" section in the _Arguments, Options, and Flags_ guide.

### Test Plan
End to end tests that use the `. unconditionalRemaining` strategy.

### Source Impact
This adds a defaulted parameter to two initializers, so it shouldn't have a significant source impact.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary