### PR TITLE
Show default values for Bool properties in help

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -172,11 +172,7 @@ internal struct HelpGenerator {
           i += 1
           
         } else {
-          let defaultValue = arg.help.defaultValue.flatMap {
-            return $0 == "true" || $0 == "false"
-              ? nil
-              : "(default: \($0))"
-            } ?? ""
+          let defaultValue = arg.help.defaultValue.flatMap { "(default: \($0))" } ?? ""
           synopsis = arg.synopsisForHelp ?? ""
           description = [arg.help.help?.abstract, defaultValue]
             .compactMap { $0 }

--- a/Tests/UnitTests/HelpGenerationTests.swift
+++ b/Tests/UnitTests/HelpGenerationTests.swift
@@ -93,4 +93,29 @@ extension HelpGenerationTests {
 
             """)
   }
+
+  struct D: ParsableCommand {
+
+    @Option(default: "John", help: "Your name.")
+    var name: String
+
+    @Option(default: 20, help: "Your age.")
+    var age: Int
+
+    @Option(default: false, help: "Whether logging is enabled.")
+    var logging: Bool
+  }
+
+  func testHelpWithDefaultValues() {
+    AssertHelp(for: D.self, equals: """
+            USAGE: d [--name <name>] [--age <age>] [--logging <logging>]
+
+            OPTIONS:
+              --name <name>           Your name. (default: John)
+              --age <age>             Your age. (default: 20)
+              --logging <logging>     Whether logging is enabled. (default: false)
+              -h, --help              Show help information.
+
+            """)
+  }
 }


### PR DESCRIPTION
HelpGenerator currently filters out the default values for Bools. Fixes #16 

(replaces #20 which I can't reopen)