### PR TITLE
Allow run to be mutating

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -28,7 +28,7 @@ public protocol ParsableCommand: ParsableArguments {
   /// application by calling the static `main()` method on the root type.
   /// This method has a default implementation that prints help text
   /// for this command.
-  func run() throws
+  mutating func run() throws
 }
 
 extension ParsableCommand {
@@ -78,7 +78,7 @@ extension ParsableCommand {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   public static func main(_ arguments: [String]? = nil) -> Never {
     do {
-      let command = try parseAsRoot(arguments)
+      var command = try parseAsRoot(arguments)
       try command.run()
       exit()
     } catch {


### PR DESCRIPTION
I noticed that I was allowed to mark the run method as mutating, however, this caused issues where it was always thinking it was expecting arguments... which is strange. 

But is there a reason to not mark this as possibly mutating?