### PR TITLE
typo fix in "04 Customizing Help.md"

### DIFF
--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -125,8 +125,8 @@ Users can see the help screen for a command by passing either `-h` or `--help` f
 
 ```swift
 struct Example: ParsableCommand {
-    static let configuration: CommandConfiguration(
-        helpName: [.long, .customShort("?")])
+    static let configuration = CommandConfiguration(
+        helpNames: [.long, .customShort("?")])
         
     @Option(name: .shortAndLong, help: "The number of history entries to show.")
     var historyDepth: Int


### PR DESCRIPTION
fix typo in code example to configure the help flags.