### PR TITLE
Fix a code example

### DIFF
--- a/Documentation/06 Manual Parsing and Testing.md
+++ b/Documentation/06 Manual Parsing and Testing.md
@@ -88,7 +88,7 @@ All of the parsing methods â€” `parse()`, `parseOrExit()`, and `parseAsRoot()` â
 Let's update our `select` script above to strip out any words that contain all capital letters before parsing the inputs.
 
 ```swift
-let noShoutingArguments = CommandLine.arguments.filter { phrase in
+let noShoutingArguments = CommandLine.arguments.dropFirst().filter { phrase in
     phrase.uppercased() != phrase
 }
 let options = SelectOptions.parseOrExit(noShoutingArguments)


### PR DESCRIPTION
`ParsableCommand.parseAsRoot()` drops the first item from `CommandLine.arguments` when it receives a `nil` array as a parameter, so it is necessary to do the same before pre-processing arguments to feed to any `ParsableCommand`.