### PR TITLE
port to Windows

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -12,9 +12,12 @@
 #if canImport(Glibc)
 import Glibc
 let _exit: (Int32) -> Never = Glibc.exit
-#else
+#elseif canImport(Darwin)
 import Darwin
 let _exit: (Int32) -> Never = Darwin.exit
+#elseif canImport(MSVCRT)
+import MSVCRT
+let _exit: (Int32) -> Never = ucrt._exit
 #endif
 
 /// A type that can be parsed from a program's command-line arguments.


### PR DESCRIPTION
This adjusts the imports to enable building for Windows.

The major change here is that `_terminalHeight` and `_terminalWidth`
have been merged into a `_terminalSize` which returns a tuple of the
width and the height.  This is then implemented for Windows as well.