### PR TITLE
build: add a CMake based build for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+project(swift-argument-parser
+  LANGUAGES Swift)
+
+option(BUILD_EXAMPLES "Build Example Programs" TRUE)
+
+include(CTest)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+find_package(Foundation QUIET)
+find_package(XCTest QUIET)
+
+add_subdirectory(Sources)
+if(BUILD_EXAMPLES)
+  add_subdirectory(Examples)
+endif()
+if(BUILD_TESTING)
+  add_subdirectory(Tests)
+endif()
+
+export(TARGETS ArgumentParser
+  FILE swift-argument-parser-config.cmake)

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(math)
+add_subdirectory(repeat)
+add_subdirectory(roll)

--- a/Examples/math/CMakeLists.txt
+++ b/Examples/math/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(math
+  main.swift)
+target_link_libraries(math PRIVATE
+  ArgumentParser)

--- a/Examples/repeat/CMakeLists.txt
+++ b/Examples/repeat/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(repeat
+  main.swift)
+target_link_libraries(repeat PRIVATE
+  ArgumentParser)

--- a/Examples/roll/CMakeLists.txt
+++ b/Examples/roll/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(roll
+  main.swift
+  SplitMix64.swift)
+target_link_libraries(roll PRIVATE
+  ArgumentParser)

--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_library(ArgumentParser
+  "Parsable Properties/Argument.swift"
+  "Parsable Properties/ArgumentHelp.swift"
+  "Parsable Properties/Flag.swift"
+  "Parsable Properties/NameSpecification.swift"
+  "Parsable Properties/Option.swift"
+  "Parsable Properties/OptionGroup.swift"
+  "Parsable Properties/ValidationError.swift"
+
+  "Parsable Types/CommandConfiguration.swift"
+  "Parsable Types/ExpressibleByArgument.swift"
+  "Parsable Types/ParsableArguments.swift"
+  "Parsable Types/ParsableCommand.swift"
+
+  Parsing/ArgumentDecoder.swift
+  Parsing/ArgumentDefinition.swift
+  Parsing/ArgumentSet.swift
+  Parsing/ArgumentSetSequence.swift
+  Parsing/CommandParser.swift
+  Parsing/InputOrigin.swift
+  Parsing/Name.swift
+  Parsing/Parsed.swift
+  Parsing/ParsedValues.swift
+  Parsing/ParserError.swift
+  Parsing/SplitArguments.swift
+
+  Usage/HelpCommand.swift
+  Usage/HelpGenerator.swift
+  Usage/MessageInfo.swift
+  Usage/UsageGenerator.swift
+
+  Utilities/StringExtensions.swift
+  Utilities/Tree.swift)
+set_target_properties(ArgumentParser PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_options(ArgumentParser PRIVATE
+  $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
+target_link_libraries(ArgumentParser PRIVATE
+  Foundation)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(ArgumentParser)
+if(BUILD_TESTING)
+  add_subdirectory(TestHelpers)
+endif()

--- a/Sources/TestHelpers/CMakeLists.txt
+++ b/Sources/TestHelpers/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(TestHelpers
+  StringHelpers.swift
+  TestHelpers.swift)
+set_target_properties(TestHelpers PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(TestHelpers PUBLIC
+  ArgumentParser
+  XCTest)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(EndToEndTests)
+add_subdirectory(UnitTests)

--- a/Tests/EndToEndTests/CMakeLists.txt
+++ b/Tests/EndToEndTests/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(EndToEndTests
+  CustomParsingEndToEndTests.swift
+  DefaultsEndToEndTests.swift
+  EnumEndToEndTests.swift
+  FlagsEndToEndTests.swift
+  LongNameWithShortDashEndToEndTests.swift
+  NestedCommandEndToEndTests.swift
+  OptionalEndToEndTests.swift
+  OptionGroupEndToEndTests.swift
+  PositionalEndToEndTests.swift
+  RawRepresentableEndToEndTests.swift
+  RepeatingEndToEndTests.swift
+  ShortNameEndToEndTests.swift
+  SimpleEndToEndTests.swift
+  SingleValueParsingStrategyTests.swift
+  SubcommandEndToEndTests.swift
+  ValidationEndToEndTests.swift)
+target_link_libraries(EndToEndTests PUBLIC
+  TestHelpers)

--- a/Tests/PackageManagerTests/CMakeLists.txt
+++ b/Tests/PackageManagerTests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(PackageManagerTests
+  HelpTests.swift
+  PackageManager/Clean.swift
+  PackageManager/Config.swift
+  PackageManager/Describe.swift
+  PackageManager/GenerateXcodeProject.swift
+  PackageManager/Options.swift
+  Tests.swift)

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(UnitTests
+  ErrorMessageTests.swift
+  HelpGenerationTests.swift
+  NameSpecificationTests.swift
+  SplitArgumentTests.swift
+  StringWrappingTests.swift
+  TreeTests.swift
+  UsageGenerationTests.swift)
+target_link_libraries(UnitTests PRIVATE
+  ArgumentParser
+  TestHelpers)


### PR DESCRIPTION
Since swift-package-manager doesn't work on Windows yet, add a CMake
based build system.