### PR TITLE
treat empty default strings and nil default strings the same way in help output

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -150,7 +150,7 @@ internal struct HelpGenerator {
           i += 1
           
         } else {
-          let defaultValue = arg.help.defaultValue.flatMap { "(default: \($0))" } ?? ""
+          let defaultValue = arg.help.defaultValue.flatMap { $0.isEmpty ? nil : "(default: \($0))" } ?? ""
           synopsis = arg.synopsisForHelp ?? ""
           description = [arg.help.help?.abstract, defaultValue]
             .compactMap { $0 }

--- a/Tests/UnitTests/HelpGenerationTests.swift
+++ b/Tests/UnitTests/HelpGenerationTests.swift
@@ -80,15 +80,21 @@ extension HelpGenerationTests {
     var two: String
     @Option(help: "The third option")
     var three: String
+    @Option(default: nil, help: "A fourth option")
+    var four: String?
+    @Option(default: "", help: "A fifth option")
+    var five: String
   }
 
   func testHelpWithDefaultValueButNoDiscussion() {
     AssertHelp(for: Issue27.self, equals: """
-            USAGE: issue27 [--two <two>] --three <three>
+            USAGE: issue27 [--two <two>] --three <three> [--four <four>] [--five <five>]
 
             OPTIONS:
               --two <two>             (default: 42)
               --three <three>         The third option
+              --four <four>           A fourth option
+              --five <five>           A fifth option
               -h, --help              Show help information.
 
             """)


### PR DESCRIPTION
Previously, if one defined an option thusly:
```
  @Option(name: .long, default: "", help: "help text")
  var option: String
```

the corresponding line of help output would be:
```
  --option <option>       help text (default: )
```

After this patch, the output becomes:
```
  --option <option>       help text
```

This did not affect the tests.