### PR TITLE
Add support for exiting without printing an error

### DIFF
--- a/Documentation/05 Validation and Errors.md
+++ b/Documentation/05 Validation and Errors.md
@@ -57,7 +57,7 @@ hey
 
 ## Handling Post-Validation Errors
 
-The `ValidationError` type is a special `ArgumentParser` error — a validation error's message is always accompanied by an appropriate usage string. You can throw other errors, from either the `validate()` or `run()` method to indicate that something has gone wrong that isn't validation-specific.
+The `ValidationError` type is a special `ArgumentParser` error — a validation error's message is always accompanied by an appropriate usage string. You can throw other errors, from either the `validate()` or `run()` method to indicate that something has gone wrong that isn't validation-specific. Errors that conform to `CustomStringConvertible` or `LocalizedError` provide the best experience for users.
 
 ```swift
 struct LineCount: ParsableCommand {
@@ -79,4 +79,24 @@ The throwing `String(contentsOfFile:encoding:)` initializer fails when the user 
 % line-count non-existing-file.swift
 Error: The file “non-existing-file.swift” couldn’t be opened because
 there is no such file.
+```
+
+If you print your error output yourself, you still need to throw an error from `validate()` or `run()`, so that your command exits with the appropriate exit code. To avoid printing an extra error message, use the `ExitCode` error, which has static properties for success, failure, and validation errors, or lets you specify a specific exit code.
+
+```swift
+struct RuntimeError: Error, CustomStringConvertible {
+    var description: String
+}
+
+struct Example: ParsableCommand {
+    @Argument() var inputFile: String
+    
+    func run() throws {
+        if !ExampleCore.processFile(inputFile) {
+            // ExampleCore.processFile(_:) prints its own errors
+            // and returns `false` on failure.
+            throw ExitCode.failure
+        }
+    }
+}
 ```

--- a/Examples/math/main.swift
+++ b/Examples/math/main.swift
@@ -186,6 +186,34 @@ extension Math.Statistics {
 
         @Argument(help: "A group of floating-point values to operate on.")
         var values: [Double]
+
+        // These args and the validation method are for testing exit codes:
+        @Flag(help: .hidden)
+        var testSuccessExitCode: Bool
+        @Flag(help: .hidden)
+        var testFailureExitCode: Bool
+        @Flag(help: .hidden)
+        var testValidationExitCode: Bool
+        @Option(help: .hidden)
+        var testCustomExitCode: Int32?
+      
+        func validate() throws {
+            if testSuccessExitCode {
+                throw ExitCode.success
+            }
+            
+            if testFailureExitCode {
+                throw ExitCode.failure
+            }
+            
+            if testValidationExitCode {
+                throw ExitCode.validationFailure
+            }
+            
+            if let exitCode = testCustomExitCode {
+                throw ExitCode(exitCode)
+            }
+        }
     }
 }
 

--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_library(ArgumentParser
   "Parsable Properties/Argument.swift"
   "Parsable Properties/ArgumentHelp.swift"
+  "Parsable Properties/Errors.swift"
   "Parsable Properties/Flag.swift"
   "Parsable Properties/NameSpecification.swift"
   "Parsable Properties/Option.swift"
   "Parsable Properties/OptionGroup.swift"
-  "Parsable Properties/ValidationError.swift"
 
   "Parsable Types/CommandConfiguration.swift"
   "Parsable Types/ExpressibleByArgument.swift"

--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -9,6 +9,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
 /// An error type that is presented to the user as an error with parsing their
 /// command-line input.
 public struct ValidationError: Error, CustomStringConvertible {
@@ -22,6 +30,29 @@ public struct ValidationError: Error, CustomStringConvertible {
   public var description: String {
     message
   }
+}
+
+/// An error type that only includes an exit code.
+///
+/// If you're printing custom errors messages yourself, you can throw this error
+/// to specify the exit code without adding any additional output to standard
+/// out or standard error.
+public struct ExitCode: Error {
+  var code: Int32
+
+  /// Creates a new `ExitCode` with the given code.
+  public init(_ code: Int32) {
+    self.code = code
+  }
+  
+  /// An exit code that indicates successful completion of a command.
+  public static let success = ExitCode(EXIT_SUCCESS)
+  
+  /// An exit code that indicates that the command failed.
+  public static let failure = ExitCode(EXIT_FAILURE)
+  
+  /// An exit code that indicates that the user provided invalid input.
+  public static let validationFailure = ExitCode(EX_USAGE)
 }
 
 /// An error type that represents a clean (i.e. non-error state) exit of the

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -139,14 +139,16 @@ extension ParsableArguments {
     withError error: Error? = nil
   ) -> Never {
     guard let error = error else {
-      _exit(EXIT_SUCCESS)
+      _exit(ExitCode.success.code)
     }
     
     let messageInfo = MessageInfo(error: error, type: self)
-    if messageInfo.shouldExitCleanly {
-      print(messageInfo.fullText)
-    } else {
-      print(messageInfo.fullText, to: &standardError)
+    if !messageInfo.fullText.isEmpty {
+      if messageInfo.shouldExitCleanly {
+        print(messageInfo.fullText)
+      } else {
+        print(messageInfo.fullText, to: &standardError)
+      }
     }
     _exit(messageInfo.exitCode)
   }

--- a/Sources/TestHelpers/TestHelpers.swift
+++ b/Sources/TestHelpers/TestHelpers.swift
@@ -136,7 +136,7 @@ extension XCTest {
   public func AssertExecuteCommand(
     command: String,
     expected: String? = nil,
-    shouldError: Bool = false,
+    exitCode: Int32 = 0,
     file: StaticString = #file, line: UInt = #line)
   {
     let splitCommand = command.split(separator: " ")
@@ -171,10 +171,7 @@ extension XCTest {
     if let expected = expected {
       AssertEqualStringsIgnoringTrailingWhitespace(expected, errorActual + outputActual, file: file, line: line)
     }
-    if shouldError {
-      XCTAssertNotEqual(process.terminationStatus, 0, file: file, line: line)
-    } else {
-      XCTAssertEqual(process.terminationStatus, 0, file: file, line: line)
-    }
+
+    XCTAssertEqual(process.terminationStatus, exitCode, file: file, line: line)
   }
 }

--- a/Tests/ExampleTests/MathExampleTests.swift
+++ b/Tests/ExampleTests/MathExampleTests.swift
@@ -105,9 +105,28 @@ final class MathExampleTests: XCTestCase {
             Error: Please provide at least one value to calculate the mode.
             Usage: math stats average [--kind <kind>] [<values> ...]
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
   }
 
+  func testMath_ExitCodes() throws {
+    AssertExecuteCommand(
+      command: "math stats quantiles --test-success-exit-code",
+      expected: "",
+      exitCode: EXIT_SUCCESS)
+    AssertExecuteCommand(
+      command: "math stats quantiles --test-failure-exit-code",
+      expected: "",
+      exitCode: EXIT_FAILURE)
+    AssertExecuteCommand(
+      command: "math stats quantiles --test-validation-exit-code",
+      expected: "",
+      exitCode: EX_USAGE)
+    AssertExecuteCommand(
+      command: "math stats quantiles --test-custom-exit-code 42",
+      expected: "",
+      exitCode: 42)
+  }
+  
   func testMath_Fail() throws {
     AssertExecuteCommand(
       command: "math --foo",
@@ -115,7 +134,7 @@ final class MathExampleTests: XCTestCase {
             Error: Unknown option '--foo'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
     
     AssertExecuteCommand(
       command: "math ZZZ",
@@ -123,6 +142,6 @@ final class MathExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '<values>'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
   }
 }

--- a/Tests/ExampleTests/RepeatExampleTests.swift
+++ b/Tests/ExampleTests/RepeatExampleTests.swift
@@ -48,7 +48,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing expected argument '<phrase>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
     
     AssertExecuteCommand(
       command: "repeat hello --count",
@@ -56,7 +56,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing value for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
     
     AssertExecuteCommand(
       command: "repeat hello --count ZZZ",
@@ -64,6 +64,6 @@ final class RepeatExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
   }
 }

--- a/Tests/ExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ExampleTests/RollDiceExampleTests.swift
@@ -41,7 +41,7 @@ final class RollDiceExampleTests: XCTestCase {
             Error: Missing value for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
     
     AssertExecuteCommand(
       command: "roll --times ZZZ",
@@ -49,6 +49,6 @@ final class RollDiceExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      shouldError: true)
+      exitCode: EX_USAGE)
   }
 }


### PR DESCRIPTION
### Description

This adds an `ExitCode` error type that stores an exit code, and updates the exit machinery (1) to use `ExitCode` as the source for exit codes, and (2) to silently exit when the provided error is an `ExitCode` instance.

New API:

```swift
/// An error type that only includes an exit code.
///
/// If you're printing custom errors messages yourself, you can throw this error
/// to specify the exit code without adding any additional output to standard
/// out or standard error.
public struct ExitCode: Error {
   /// Creates a new `ExitCode` with the given code.
   public init(_ code: Int32)

   /// An exit code that indicates successful completion of a command.
   public static let success

   /// An exit code that indicates that the command failed.
   public static let failure

   /// An exit code that indicates that the user provided invalid input.
   public static let validationFailure
}
```

### Documentation Plan
Included API documentation and expanded a section in the [Validation & Errors guide](https://github.com/apple/swift-argument-parser/pull/51/files#diff-d57fe4925b10ddced8a151a63627b3de).

### Test Plan
Added tests for failing silently and for exiting with each preset error code and a custom error code.

### Source Impact
The new type is an additive change. There's an additional behavior change that I'd call a bug fix, where errors that convert to an empty string now don't print the `"Error:"` prefix by itself.
