### PR TITLE
Pass information to ParserError in order to show user a better error message

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -222,7 +222,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value.RawValu
           switch (hasUpdated, previous, exclusivity) {
           case (true, let p?, .exclusive):
             // This value has already been set.
-            throw ParserError.duplicateExclusiveValues(previous: p.inputOrigin, duplicate: origin)
+            throw ParserError.duplicateExclusiveValues(previous: p.inputOrigin, duplicate: origin, originalInput: values.originalInput)
           case (false, _, _), (_, _, .chooseLast):
             values.set(value, forKey: key, inputOrigin: origin)
           default:

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -16,11 +16,14 @@
 /// This is usually an index into the `SplitArguments`.
 /// In some cases it can be multiple indices.
 struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
-  enum Element: Hashable {
+  enum Element: Comparable, Hashable {
     case argumentIndex(SplitArguments.Index)
   }
   
   private var _elements: Set<Element> = []
+  var elements: [Element] {
+    Array(_elements).sorted()
+  }
   
   init() {
   }
@@ -59,5 +62,14 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
 
   func forEach(_ closure: (Element) -> Void) {
     _elements.forEach(closure)
+  }
+}
+
+extension InputOrigin.Element {
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.argumentIndex(let l), .argumentIndex(let r)):
+      return l < r
+    }
   }
 }

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -21,7 +21,7 @@ enum ParserError: Error {
   case missingValueForOption(InputOrigin, Name)
   case unexpectedValueForOption(InputOrigin.Element, Name, String)
   case unexpectedExtraValues([(InputOrigin, String)])
-  case duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin)
+  case duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin, originalInput: [String])
   /// We need a value for the given key, but it’s not there. Some non-optional option or argument is missing.
   case noValue(forKey: InputKey)
   case unableToParseValue(InputOrigin, Name?, String, forKey: InputKey)

--- a/Tests/UnitTests/ErrorMessageTests.swift
+++ b/Tests/UnitTests/ErrorMessageTests.swift
@@ -134,3 +134,19 @@ extension ErrorMessageTests {
     AssertErrorMessage(Qwz.self, ["-x"], "Unknown option '-x'")
   }
 }
+
+private enum OutputBehaviour: String, CaseIterable { case stats, count, list }
+private struct Options: ParsableArguments {
+  @Flag(name: .shortAndLong, help: "Program output")
+  var behaviour: OutputBehaviour
+
+  @Flag() var bool: Bool
+}
+
+extension ErrorMessageTests {
+  func testDuplicateFlags() {
+    AssertErrorMessage(Options.self, ["--list", "--bool", "-s"], "Value to be set with flag \'-s\' had already been set with flag \'--list\'")
+    AssertErrorMessage(Options.self, ["-cbl"], "Value to be set with flag \'l\' in \'-cbl\' had already been set with flag \'c\' in \'-cbl\'")
+    AssertErrorMessage(Options.self, ["-bc", "--stats", "-l"], "Value to be set with flag \'--stats\' had already been set with flag \'c\' in \'-bc\'")
+  }
+}


### PR DESCRIPTION
This is an attempt to fix https://github.com/apple/swift-argument-parser/issues/49

Questions about this proposed fix:
- Would it be better to simply extract the strings at the point where the error is thrown?
  I touched every place where "duplicateExclusiveValues" appears, so it's not clear that error case would have another use than this one.
- Is the proposed replacement message any good?