### PR TITLE
Add @Flag initializer for Optional<Bool>

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -125,33 +125,18 @@ extension Flag where Value == Optional<Bool> {
   ///     @Flag(inversion: .prefixedNo)
   ///     var useHTTPS: Bool?
   ///
-  /// To customize the names of the two states further, define a
-  /// `CaseIterable` enumeration with a case for each state, and use that
-  /// as the type for your flag. In this case, the user can specify either
-  /// `--use-production-server` or `--use-development-server` to set the
-  /// flag's value.
-  ///
-  ///     enum ServerChoice {
-  ///         case useProductionServer
-  ///         case useDevelopmentServer
-  ///     }
-  ///
-  ///     @Flag() var serverChoice: ServerChoice
-  ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: The default value for this flag.
   ///   - inversion: The method for converting this flags name into an on/off
   ///     pair.
   ///   - help: Information about how to use this flag.
   public init(
     name: NameSpecification = .long,
-    default initial: Bool? = nil,
     inversion: FlagInversion,
     help: ArgumentHelp? = nil
   ) {
     self.init(_parsedValue: .init { key in
-      .flag(key: key, name: name, default: initial, inversion: inversion, help: help)
+      .flag(key: key, name: name, default: nil, inversion: inversion, help: help)
     })
   }
 }

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -112,6 +112,50 @@ public enum FlagExclusivity {
   case chooseLast
 }
 
+extension Flag where Value == Optional<Bool> {
+  /// Creates a Boolean property that reads its value from the presence of
+  /// one or more inverted flags.
+  ///
+  /// Use this initializer to create an optional Boolean flag with an on/off
+  /// pair. With the following declaration, for example, the user can specify
+  /// either `--use-https` or `--no-use-https` to set the `useHTTPS` flag to
+  /// `true` or `false`, respectively. If neither is specified, the resulting
+  /// flag value would be `nil`.
+  ///
+  ///     @Flag(inversion: .prefixedNo)
+  ///     var useHTTPS: Bool?
+  ///
+  /// To customize the names of the two states further, define a
+  /// `CaseIterable` enumeration with a case for each state, and use that
+  /// as the type for your flag. In this case, the user can specify either
+  /// `--use-production-server` or `--use-development-server` to set the
+  /// flag's value.
+  ///
+  ///     enum ServerChoice {
+  ///         case useProductionServer
+  ///         case useDevelopmentServer
+  ///     }
+  ///
+  ///     @Flag() var serverChoice: ServerChoice
+  ///
+  /// - Parameters:
+  ///   - name: A specification for what names are allowed for this flag.
+  ///   - initial: The default value for this flag.
+  ///   - inversion: The method for converting this flags name into an on/off
+  ///     pair.
+  ///   - help: Information about how to use this flag.
+  public init(
+    name: NameSpecification = .long,
+    default initial: Bool? = nil,
+    inversion: FlagInversion,
+    help: ArgumentHelp? = nil
+  ) {
+    self.init(_parsedValue: .init { key in
+      .flag(key: key, name: name, default: initial, inversion: inversion, help: help)
+    })
+  }
+}
+
 extension Flag where Value == Bool {
   /// Creates a Boolean property that reads its value from the presence of a
   /// flag.

--- a/Tests/EndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/EndToEndTests/FlagsEndToEndTests.swift
@@ -24,6 +24,9 @@ fileprivate struct Bar: ParsableArguments {
   
   @Flag(inversion: .prefixedNo)
   var extattr: Bool
+
+  @Flag(inversion: .prefixedNo)
+  var extattr2: Bool?
 }
 
 extension FlagsEndToEndTests {
@@ -31,6 +34,7 @@ extension FlagsEndToEndTests {
     AssertParse(Bar.self, []) { options in
       XCTAssertEqual(options.verbose, false)
       XCTAssertEqual(options.extattr, false)
+      XCTAssertEqual(options.extattr2, nil)
     }
   }
   
@@ -38,11 +42,19 @@ extension FlagsEndToEndTests {
     AssertParse(Bar.self, ["--verbose"]) { options in
       XCTAssertEqual(options.verbose, true)
       XCTAssertEqual(options.extattr, false)
+      XCTAssertEqual(options.extattr2, nil)
     }
     
     AssertParse(Bar.self, ["--extattr"]) { options in
       XCTAssertEqual(options.verbose, false)
       XCTAssertEqual(options.extattr, true)
+      XCTAssertEqual(options.extattr2, nil)
+    }
+
+    AssertParse(Bar.self, ["--extattr2"]) { options in
+      XCTAssertEqual(options.verbose, false)
+      XCTAssertEqual(options.extattr, false)
+      XCTAssertEqual(options.extattr2, .some(true))
     }
   }
   


### PR DESCRIPTION
### Description
Per [discussion][], add an initializer for `Flag<Optional<Bool>>` that
allows the default value to be `nil`, enabling capacity to distinguish
the lack of a supplied flag vs the default value from user.

[discussion]: https://forums.swift.org/t/flag-default-value-where-did-it-come-from/34204/10

### Detailed Design

Newly added initializer enables the following `Flag` declaration.

```swift
@Flag(inversion: .prefixedNo)
var throwingAwayMyShot: Bool?
```

When neither `--no-throwing-away-my-shot` nor `--throwing-away-my-shot` is supplied as command-line argument in this scenario, this flag value is `nil`. Otherwise it has same behavior as the non-optional variant.

### Documentation Plan
This is variant of the existing `Flag<Bool>` flag. Current documentation does not explicitly point out this new API. It may be reasonable to expect user to discover it organically when they try things out since the behavior is (IMO) natural.

### Test Plan

Unit tested.

### Source Impact

This adds a new API. No source impact to existing users.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary