### PR TITLE
Constrain `ExpressibleByArgument` implementation for `LosslessStringC…

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -44,7 +44,7 @@ extension RawRepresentable where Self: ExpressibleByArgument, RawValue: Expressi
 
 // MARK: LosslessStringConvertible
 
-extension LosslessStringConvertible {
+extension LosslessStringConvertible where Self: ExpressibleByArgument {
   public init?(argument: String) {
     self.init(argument)
   }


### PR DESCRIPTION
…onvertible`.

This extension provides default implementation for `ExpressibleByArgument` to types conforming to `LosslessStringConvertible`.
It should be restricted only to ones that wants to conform to `ExpressibleByArgument`.