### PR TITLE
Add an EnumerableFlag protocol

### DIFF
--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -211,7 +211,7 @@ false false
 Error: Missing one of: '--enable-required-element', '--disable-required-element'
 ```
 
-To create a flag with custom names for a Boolean value, to provide an exclusive choice between more than two names, or for collecting multiple values from a set of defined choices, define an enumeration that conforms to the `EnumerableFlag` documentation.
+To create a flag with custom names for a Boolean value, to provide an exclusive choice between more than two names, or for collecting multiple values from a set of defined choices, define an enumeration that conforms to the `EnumerableFlag` protocol.
 
 ```swift
 enum CacheMethod: EnumerableFlag {

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -115,10 +115,10 @@ struct Example: ParsableCommand {
 
 Arguments and options can be parsed from any type that conforms to the `ExpressibleByArgument` protocol. Standard library integer and floating-point types, strings, and Booleans all conform to `ExpressibleByArgument`.
 
-You can make your own custom types conform to `ExpressibleByArgument` by implementing `init(argument:)`:
+You can make your own custom types conform to `ExpressibleByArgument` by implementing `init?(argument:)`:
 
 ```swift
-struct Path {
+struct Path: ExpressibleByArgument {
     var pathString: String
     
     init?(argument: String) {
@@ -178,7 +178,7 @@ struct Example: ParsableCommand {
 }
 ```
 
-Throw an error from the `transform` function to indicate that the user provided an invalid value for that type.
+Throw an error from the `transform` function to indicate that the user provided an invalid value for that type. See [Handling Transform Errors](./05%20Validation%20and%20Errors.md#handling-transform-errors) for more about customizing `transform` function errors.
 
 ## Using flag inversions, enumerations, and counts
 
@@ -211,15 +211,15 @@ false false
 Error: Missing one of: '--enable-required-element', '--disable-required-element'
 ```
 
-You can also use flags with types that are `CaseIterable` and `RawRepresentable` with a string raw value. This is useful for providing custom names for a Boolean value, for an exclusive choice between more than two names, or for collecting multiple values from a set of defined choices.
+To create a flag with custom names for a Boolean value, to provide an exclusive choice between more than two names, or for collecting multiple values from a set of defined choices, define an enumeration that conforms to the `EnumerableFlag` documentation.
 
 ```swift
-enum CacheMethod: String, CaseIterable {
+enum CacheMethod: EnumerableFlag {
     case inMemoryCache
     case persistentCache
 }
 
-enum Color: String, CaseIterable {
+enum Color: EnumerableFlag {
     case pink, purple, silver
 }
 
@@ -235,7 +235,7 @@ struct Example: ParsableCommand {
 }
 ``` 
 
-The flag names in this case are drawn from the raw values:
+The flag names in this case are drawn from the raw values — for information about customizing the names and help text, see the  [`EnumerableFlag` documentation](../Sources/ArgumentParser/Parsable%20Types/EnumerableFlag.swift).
 
 ```
 % example --in-memory-cache --pink --silver

--- a/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
@@ -19,6 +19,9 @@ public struct ArgumentHelp {
   
   /// An alternative name to use for the argument's value when showing usage
   /// information.
+  ///
+  /// - Note: This property is ignored when generating help for flags, since
+  ///   flags don't include a value.
   public var valueName: String?
   
   /// A Boolean value indicating whether this argument should be shown in

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -249,10 +249,14 @@ extension Flag where Value: EnumerableFlag {
       var hasUpdated = false
       let defaultValue = initial.map(String.init(describing:))
 
-      let args = Value.allCases.map { value -> ArgumentDefinition in
+      let caseHelps = Value.allCases.map { Value.help(for: $0) }
+      let hasCustomCaseHelp = caseHelps.contains(where: { $0 != nil })
+      
+      let args = Value.allCases.enumerated().map { (i, value) -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: String(describing: value))
         let name = Value.name(for: value)
-        let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, defaultValue: defaultValue, key: key)
+        let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
+        let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: helpForCase, defaultValue: defaultValue, key: key, isComposite: !hasCustomCaseHelp)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
@@ -275,11 +279,15 @@ extension Flag {
       // This gets flipped to `true` the first time one of these flags is
       // encountered.
       var hasUpdated = false
+      
+      let caseHelps = Element.allCases.map { Element.help(for: $0) }
+      let hasCustomCaseHelp = caseHelps.contains(where: { $0 != nil })
 
-      let args = Element.allCases.map { value -> ArgumentDefinition in
+      let args = Element.allCases.enumerated().map { (i, value) -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: String(describing: value))
         let name = Element.name(for: value)
-        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
+        let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
+        let help = ArgumentDefinition.Help(options: .isOptional, help: helpForCase, key: key, isComposite: !hasCustomCaseHelp)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
@@ -304,10 +312,14 @@ extension Flag {
     help: ArgumentHelp? = nil
   ) where Value == Array<Element>, Element: EnumerableFlag {
     self.init(_parsedValue: .init { key in
-      let args = Element.allCases.map { value -> ArgumentDefinition in
+      let caseHelps = Element.allCases.map { Element.help(for: $0) }
+      let hasCustomCaseHelp = caseHelps.contains(where: { $0 != nil })
+
+      let args = Element.allCases.enumerated().map { (i, value) -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: String(describing: value))
         let name = Element.name(for: value)
-        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
+        let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
+        let help = ArgumentDefinition.Help(options: .isOptional, help: helpForCase, key: key, isComposite: !hasCustomCaseHelp)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: [Element](), update: .nullary({ (origin, name, values) in
           values.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
             $0.append(value)
@@ -346,7 +358,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value: Equata
 
       let args = Value.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
-        let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, defaultValue: defaultValue, key: key)
+        let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, defaultValue: defaultValue, key: key, isComposite: true)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
@@ -374,7 +386,7 @@ extension Flag {
       
       let args = Element.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
-        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
+        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key, isComposite: true)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
@@ -402,7 +414,7 @@ extension Flag {
     self.init(_parsedValue: .init { key in
       let args = Element.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
-        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
+        let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key, isComposite: true)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: [Element](), update: .nullary({ (origin, name, values) in
           values.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
             $0.append(value)

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -230,7 +230,7 @@ extension Flag where Value == Int {
 
 extension Flag where Value: EnumerableFlag {
   /// Creates a property that gets its value from the presence of a flag,
-  /// where the allowed flags are defined by a `CaseIterable` type.
+  /// where the allowed flags are defined by an `EnumerableFlag` type.
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
@@ -270,7 +270,7 @@ extension Flag where Value: EnumerableFlag {
 
 extension Flag {
   /// Creates a property that gets its value from the presence of a flag,
-  /// where the allowed flags are defined by a case-iterable type.
+  /// where the allowed flags are defined by an `EnumerableFlag` type.
   public init<Element>(
     exclusivity: FlagExclusivity = .exclusive,
     help: ArgumentHelp? = nil
@@ -300,8 +300,8 @@ extension Flag {
   }
   
   /// Creates an array property that gets its values from the presence of
-  /// zero or more flags, where the allowed flags are defined by a
-  /// case-iterable type.
+  /// zero or more flags, where the allowed flags are defined by an
+  /// `EnumerableFlag` type.
   ///
   /// This property has an empty array as its default value.
   ///

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -21,12 +21,12 @@
 /// `verbose` has a default value of `false`, but becomes `true` if `--verbose`
 /// is provided on the command line.
 ///
-/// A flag can have a value that is a `Bool`, an `Int`, or any `CaseIterable`
-/// type. When using a `CaseIterable` type as a flag, the individual cases
+/// A flag can have a value that is a `Bool`, an `Int`, or any `EnumerableFlag`
+/// type. When using an `EnumerableFlag` type as a flag, the individual cases
 /// form the flags that are used on the command line.
 ///
 ///     struct Options {
-///         enum Operation: CaseIterable, ... {
+///         enum Operation: EnumerableFlag {
 ///             case add
 ///             case multiply
 ///         }

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -188,7 +188,9 @@ extension Flag where Value == Bool {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: The default value for this flag.
+  ///   - initial: A default value to use for this property. If `initial` is
+  ///     `nil`, one of the flags declared by this `@Flag` attribute is required
+  ///     from the user.
   ///   - inversion: The method for converting this flag's name into an on/off
   ///     pair.
   ///   - exclusivity: The behavior to use when an on/off pair of flags is
@@ -235,7 +237,8 @@ extension Flag where Value: EnumerableFlag {
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
   ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, this flag is required.
+  ///     `nil`, one of the flags declared by this `@Flag` attribute is required
+  ///     from the user.
   ///   - exclusivity: The behavior to use when multiple flags are specified.
   ///   - help: Information about how to use this flag.
   public init(

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -78,7 +78,8 @@ extension Option where Value: ExpressibleByArgument {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property.
+  ///   - initial: A default value to use for this property. If `initial` is
+  ///     `nil`, this option and value are required from the user.
   ///   - help: Information about how to use this option.
   public init(
     name: NameSpecification = .long,
@@ -224,7 +225,8 @@ extension Option {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property.
+  ///   - initial: A default value to use for this property. If `initial` is
+  ///     `nil`, this option and value are required from the user.
   ///   - help: Information about how to use this option.
   ///   - transform: A closure that converts a string into this property's
   ///     type or throws an error.

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -1,0 +1,9 @@
+public protocol EnumerableFlag: CaseIterable, Equatable {
+  static func name(for value: Self) -> NameSpecification
+}
+
+extension EnumerableFlag {
+  public static func name(for value: Self) -> NameSpecification {
+    .long
+  }
+}

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -49,15 +49,31 @@
 ///
 /// With this extension, a user can use short or long versions of the flags:
 ///
-///     $ example -s -x --medium
-///     [.small, .extraLarge, .medium]
+///     $ example -s -l -x --medium
+///     [.small, .large, .extraLarge, .medium]
 public protocol EnumerableFlag: CaseIterable, Equatable {
   /// Returns the name specification to use for the given flag.
+  ///
+  /// The default implementation for this method always returns `.long`.
+  /// Implement this method for your custom `EnumerableFlag` type to provide
+  /// different name specifications for different cases.
   static func name(for value: Self) -> NameSpecification
+  
+  /// Returns the help information to show for the given flag.
+  ///
+  /// The default implementation for this method always returns `nil`, which
+  /// groups the flags together with the help provided in the `@Flag`
+  /// declaration. Implement this method for your custom type to provide
+  /// different help information for each flag.
+  static func help(for value: Self) -> ArgumentHelp?
 }
 
 extension EnumerableFlag {
   public static func name(for value: Self) -> NameSpecification {
     .long
+  }
+  
+  public static func help(for value: Self) -> ArgumentHelp? {
+    nil
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -1,4 +1,58 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A type that represents the different possible flags to be used by a
+/// `@Flag` property.
+///
+/// For example, the `Size` enumeration declared here can be used as the type of
+/// a `@Flag` property:
+///
+///     enum Size: String, EnumerableFlag {
+///         case small, medium, large, extraLarge
+///     }
+///
+///     struct Example: ParsableCommand {
+///         @Flag() var sizes: [Size]
+///
+///         func run() {
+///             print(sizes)
+///         }
+///     }
+///
+/// By default, each case name is converted to a flag by using the `.long` name
+/// specification, so a user can call `example` like this:
+///
+///     $ example --small --large
+///     [.small, .large]
+///
+/// Provide alternative or additional name specifications for each case by
+/// implementing the `name(for:)` static method on your `EnumerableFlag` type.
+///
+///     extension Size {
+///         static func name(for value: Self) -> NameSpecification {
+///             switch value {
+///             case .extraLarge:
+///                 return [.customShort("x"), .long]
+///             default:
+///                 return .shortAndLong
+///             }
+///         }
+///     }
+///
+/// With this extension, a user can use short or long versions of the flags:
+///
+///     $ example -s -x --medium
+///     [.small, .extraLarge, .medium]
 public protocol EnumerableFlag: CaseIterable, Equatable {
+  /// Returns the name specification to use for the given flag.
   static func name(for value: Self) -> NameSpecification
 }
 

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -31,6 +31,7 @@ struct ArgumentDefinition {
     var discussion: String?
     var defaultValue: String?
     var keys: [InputKey]
+    var isComposite: Bool
     
     struct Options: OptionSet {
       var rawValue: UInt
@@ -39,11 +40,12 @@ struct ArgumentDefinition {
       static let isRepeating = Options(rawValue: 1 << 1)
     }
     
-    init(options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey) {
+    init(options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey, isComposite: Bool = false) {
       self.options = options
       self.help = help
       self.defaultValue = defaultValue
       self.keys = [key]
+      self.isComposite = isComposite
     }
   }
   

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -130,7 +130,7 @@ extension ArgumentSet {
     // The flag is required if initialValue is `nil`, otherwise it's optional
     let helpOptions: ArgumentDefinition.Help.Options = initialValue != nil ? .isOptional : []
     
-    let help = ArgumentDefinition.Help(options: helpOptions, help: help, defaultValue: initialValue.map(String.init), key: key)
+    let help = ArgumentDefinition.Help(options: helpOptions, help: help, defaultValue: initialValue.map(String.init), key: key, isComposite: true)
     let (enableNames, disableNames) = inversion.enableDisableNamePair(for: key, name: name)
 
     var hasUpdated = false

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -144,8 +144,9 @@ internal struct HelpGenerator {
         let synopsis: String
         let description: String
         
-        if i < args.count - 1 && args[i + 1].help.keys == arg.help.keys {
-          // If the next argument has the same keys as this one, we have a group of arguments to output together
+        if args[i].help.isComposite {
+          // If this argument is composite, we have a group of arguments to
+          // output together.
           var groupedArgs = [arg]
           let defaultValue = arg.help.defaultValue.map { "(default: \($0))" } ?? ""
           while i < args.count - 1 && args[i + 1].help.keys == arg.help.keys {

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -145,8 +145,10 @@ enum Size: String, EnumerableFlag {
   
   static func name(for value: Size) -> NameSpecification {
     switch value {
-    case .humongous: return .customLong("huge")
-    default: return .long
+    case .humongous:
+      return [.long, .customLong("huge")]
+    default:
+      return .long
     }
   }
 }
@@ -217,6 +219,18 @@ extension FlagsEndToEndTests {
     }
     
     AssertParse(Baz.self, ["--pink", "--huge"]) { options in
+      XCTAssertEqual(options.color, .pink)
+      XCTAssertEqual(options.size, .humongous)
+      XCTAssertEqual(options.shape, nil)
+    }
+    
+    AssertParse(Baz.self, ["--pink", "--humongous"]) { options in
+      XCTAssertEqual(options.color, .pink)
+      XCTAssertEqual(options.size, .humongous)
+      XCTAssertEqual(options.shape, nil)
+    }
+    
+    AssertParse(Baz.self, ["--pink", "--huge", "--humongous"]) { options in
       XCTAssertEqual(options.color, .pink)
       XCTAssertEqual(options.size, .humongous)
       XCTAssertEqual(options.shape, nil)

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -145,10 +145,25 @@ enum Size: String, EnumerableFlag {
   
   static func name(for value: Size) -> NameSpecification {
     switch value {
+    case .small, .medium, .large:
+      return .shortAndLong
     case .humongous:
       return [.long, .customLong("huge")]
     default:
       return .long
+    }
+  }
+  
+  static func help(for value: Size) -> ArgumentHelp? {
+    switch value {
+    case .small:
+      return "A smallish size"
+    case .medium:
+      return "Not too big, not too small"
+    case .humongous:
+      return "Roughly the size of a barge"
+    case .large, .extraLarge:
+      return nil
     }
   }
 }
@@ -331,6 +346,7 @@ fileprivate struct DeprecatedFlags: ParsableArguments {
   @Flag() var single: One
   @Flag() var optional: Two?
   @Flag() var array: [Three]
+  @Flag(name: .long) var size: Size?
 }
 
 extension FlagsEndToEndTests {


### PR DESCRIPTION
### Description
This addresses the need for providing name specifications for `enum` flags, since property wrappers can't be used for enumeration cases.

### Detailed Design
This includes a new `EnumerableFlag` protocol:

```swift
/// A type that represents the different possible flags to be used by a
/// `@Flag` property.
public protocol EnumerableFlag: CaseIterable {
  /// Returns the name specification to use for the given flag.
  static func name(for value: Self) -> NameSpecification

  /// Returns the help information to show for the given flag.
  static func help(for value: Self) -> ArgumentHelp?
}
```

As well as new `EnumerableFlag`-constrained `@Flag` initializers that replace the current ones that are constrained to `String`/`CaseIterable`.

### Documentation Plan
Wrote type- and symbol-level documentation for `EnumerableFlag`, revised docs for the new initializers, and updated the "Argument, Options, and Flags" guide.

### Test Plan
Modified unit tests to use the new protocol and added tests that use the original, deprecated versions.

### Source Impact
This deprecates the `@Flag` initializers that are constrained to `CaseIterable`/`RawRepresentable` and `RawValue == String`. These initializers will continue to work, and can be removed in a future version. 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
