### PR TITLE
make FlagExclusivity.chooseFirst work

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -176,12 +176,14 @@ extension ArgumentSet {
     case(true, let previous?, .exclusive):
       // This value has already been set.
       throw ParserError.duplicateExclusiveValues(previous: previous.inputOrigin, duplicate: origin, originalInput: values.originalInput)
+    case (true, _, .chooseFirst):
+      values.update(forKey: key, inputOrigin: origin, initial: value, closure: { _ in })
     case (false, _, _), (_, _, .chooseLast):
       values.set(value, forKey: key, inputOrigin: origin)
-      return true
     default:
-      return hasUpdated
+      break
     }
+    return true
   }
   
   /// Creates an argument set for a pair of inverted Boolean flags.

--- a/Tests/EndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/EndToEndTests/FlagsEndToEndTests.swift
@@ -80,10 +80,9 @@ extension FlagsEndToEndTests {
     AssertParse(Bar.self, ["--enable-logging"]) { options in
       XCTAssertEqual(options.logging, true)
     }
-// Can't test this yet, because .chooseFirst flags don't work
-//    AssertParse(Bar.self, ["--enable-logging", "--disable-logging"]) { options in
-//      XCTAssertEqual(options.logging, false)
-//    }
+    AssertParse(Bar.self, ["--disable-logging", "--enable-logging"]) { options in
+      XCTAssertEqual(options.logging, false)
+    }
   }
 }
 
@@ -261,5 +260,27 @@ extension FlagsEndToEndTests {
   
   func testParsingCaseIterableArray_Fails() throws {
     XCTAssertThrowsError(try Qux.parse(["--pink", "--small", "--bloop"]))
+  }
+}
+
+fileprivate struct RepeatOK: ParsableArguments {
+  @Flag(exclusivity: .chooseFirst)
+  var color: Color
+
+  @Flag(exclusivity: .chooseLast)
+  var shape: Shape
+}
+
+extension FlagsEndToEndTests {
+  func testParsingCaseIterable_RepeatableFlags() throws {
+    AssertParse(RepeatOK.self, ["--pink", "--purple", "--square"]) { options in
+      XCTAssertEqual(options.color, .pink)
+      XCTAssertEqual(options.shape, .square)
+    }
+
+    AssertParse(RepeatOK.self, ["--round", "--oblong", "--silver"]) { options in
+      XCTAssertEqual(options.color, .silver)
+      XCTAssertEqual(options.shape, .oblong)
+    }
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Previously, using a set of flags declared with FlagExclusivity.chooseFirst would result in an error instead of choosing the first from the command line. (See https://github.com/apple/swift-argument-parser/issues/66).

### Detailed Design
Added a case handling repeating arguments in the `ArgumentSet.updateFlag` function.
The previous behaviour had the repeating-arguments-with-.chooseFirst situation going through the `default` case, which didn't add the current argument to the list of used arguments, which later caused an error due to the argument being incorrectly deemed to have not been used.

### Documentation Plan
No change to documentation is needed.

### Test Plan
Tests added to `FlagsEndToEndTests.testParsing_invert` and `FlagsEndToEndTests.testParsingCaseIterable_RepeatableFlags`.

### Source Impact
None.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

This PR fixes https://github.com/apple/swift-argument-parser/issues/66