### PR TITLE
Fix duplicate options showing up in command help output

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -28,7 +28,7 @@ internal struct HelpGenerator {
   }
   
   struct Section {
-    struct Element {
+    struct Element: Hashable {
       var label: String
       var abstract: String = ""
       var discussion: String = ""
@@ -125,7 +125,9 @@ internal struct HelpGenerator {
   static func generateSections(commandStack: [ParsableCommand.Type]) -> [Section] {
     var positionalElements: [Section.Element] = []
     var optionElements: [Section.Element] = []
-    
+    /// Used to keep track of elements already seen from parent commands.
+    var alreadySeenElements = Set<Section.Element>()
+
     for commandType in commandStack {
       let args = Array(ArgumentSet(commandType))
       
@@ -158,10 +160,13 @@ internal struct HelpGenerator {
         }
         
         let element = Section.Element(label: synopsis, abstract: description, discussion: arg.help.help?.discussion ?? "")
-        if case .positional = arg.kind {
-          positionalElements.append(element)
-        } else {
-          optionElements.append(element)
+        if !alreadySeenElements.contains(element) {
+          alreadySeenElements.insert(element)
+          if case .positional = arg.kind {
+            positionalElements.append(element)
+          } else {
+            optionElements.append(element)
+          }
         }
       }
     }

--- a/Tests/EndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/EndToEndTests/SubcommandEndToEndTests.swift
@@ -87,7 +87,6 @@ extension SubcommandEndToEndTests {
 
             OPTIONS:
               --name <name>
-              --name <name>
               --bar <bar>
               -h, --help              Show help information.
 
@@ -96,7 +95,6 @@ extension SubcommandEndToEndTests {
             USAGE: foo b --name <name> --baz <baz>
 
             OPTIONS:
-              --name <name>
               --name <name>
               --baz <baz>
               -h, --help              Show help information.


### PR DESCRIPTION
When using option groups to bring options into subcommands that are also
used in parent commands, the help system duplicates the options in the
generated output.

For instance, in the `SubcommandEndToEndTest` example, the `--name`
argument is listed twice for both the subcommands `CommandA` and
`CommandB`, and expected by the test assertion.

It is annoying in a simple case like this but causes a lot of unhelpful
noise in help output when you share more and more options across a
command heirarchy.

To solve this we need to keep track of what
`HelpGenerator.Section.Element` values have already been processed from
parent commands in the command stack. I acheived this by making
`Element` conform to `Hashable` to track in a `Set`.

This assumes that we don't need to support re-using command names up and
down a command heirarchy. It doesn't work at all today (you get an error
when trying to use the exact same option in a parent and child
command). If we choose to support this eventually then we'll need to
augment this solution to keep track of where the `Element` was generated
in the heirarchy.

This also updates the test to properly assert that the `--name` option
is only output once for the subcommands in `SubcommandEndToEndTest`.
### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
