### PR TITLE
simplify a switch statement

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -171,17 +171,16 @@ extension ArgumentSet {
   }
 
   static func updateFlag(key: InputKey, value: Any, origin: InputOrigin, values: inout ParsedValues, hasUpdated: Bool, exclusivity: FlagExclusivity) throws -> Bool {
-    let previous = values.element(forKey: key)
-    switch (hasUpdated, previous, exclusivity) {
-    case(true, let previous?, .exclusive):
+    switch (hasUpdated, exclusivity) {
+    case (true, .exclusive):
       // This value has already been set.
-      throw ParserError.duplicateExclusiveValues(previous: previous.inputOrigin, duplicate: origin, originalInput: values.originalInput)
-    case (true, _, .chooseFirst):
+      if let previous = values.element(forKey: key) {
+        throw ParserError.duplicateExclusiveValues(previous: previous.inputOrigin, duplicate: origin, originalInput: values.originalInput)
+      }
+    case (true, .chooseFirst):
       values.update(forKey: key, inputOrigin: origin, initial: value, closure: { _ in })
-    case (false, _, _), (_, _, .chooseLast):
+    case (false, _), (_, .chooseLast):
       values.set(value, forKey: key, inputOrigin: origin)
-    default:
-      break
     }
     return true
   }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This change has no effect on functionality, documentation or testing.

The switch in `ArgumentSet.flagUpdate` (originally in one of the Flag constructors) switches on 3 items, one of which (the return value of `values.element(forKey:)`) is needed in only one of the 12 possibilities. This moves the call to `values.element(forKey:)` into the one `case` where it is needed. The function becomes slightly more efficient, and the `switch` is more readable (down to 6 possibilities), and no longer needs a `default` case. Note that the probably-impossible failure mode where `values.element(forKey: key` returns `nil` and `hasUpdated` is `true` still results in the same behaviour, namely the argument is unused and the function returns `true`; this eventually leads to a call to `ErrorMessageGenerator.unknownOptionMessage`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
