### PR TITLE
Remove side-effects in HelpCommand

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -18,8 +18,8 @@ struct HelpCommand: ParsableCommand {
   
   init() {}
   
-  func run() {
-    print(generateHelp())
+  func run() throws {
+    throw CommandError(commandStack: commandStack, parserError: .helpRequested)
   }
   
   mutating func buildCommandStack(with parser: CommandParser) throws {


### PR DESCRIPTION
<!--
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Currently `HelpCommand` is launching a side-effect in `run` method (printing in the console the help). This PR fixes it and throw the effect to the next layer, who will catch it and treat the effect properly. Effects should be handled on the `main` method inside `exit(withError:)` or **let to the user decided how to manage them**

This change will let us write something like:
```swift
enum ParsableCommandError: Error {
    case general(String)
}

extension ParsableCommand {
    func parse(_ arguments: [String]? = nil) -> Result<ParsableCommand, ParsableCommandError> {
        do {
            let command = try Self.parseAsRoot(arguments)
            try command.run()
            return .success(command)
        } catch {
            let info = Self.fullMessage(for: error)
            return .failure(.general(info))
        }
    }
}
```

In the end, delegate the responsibility about when executing the effects and how handling

> I have tested it using ParsableCommand with subcommands and without them. It works properly in both cases.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary