### PR TITLE
Add support for default Argument value

### DIFF
--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -43,7 +43,7 @@ This example shows how `ArgumentParser` provides defaults that speed up your ini
 - Option and flag names are derived from the names of your command's properties.
 - Whether arguments are required and what kinds of inputs are valid is based on your properties' types.
 
-In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option or flag with a `default` parameter can also be omitted by the user.
+In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option, flag or argument with a `default` parameter can also be omitted by the user.
 
 Users must provide values for all properties with no implicit or specified default. For example, this command would require one integer argument and a string with the key `--user-name`.
 

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -43,7 +43,7 @@ This example shows how `ArgumentParser` provides defaults that speed up your ini
 - Option and flag names are derived from the names of your command's properties.
 - Whether arguments are required and what kinds of inputs are valid is based on your properties' types.
 
-In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option, flag or argument with a `default` parameter can also be omitted by the user.
+In this example, all of the properties have default values — Boolean flags always default to `false`, optional properties default to `nil`, and arrays default to an empty array. An option, flag, or argument with a `default` parameter can also be omitted by the user.
 
 Users must provide values for all properties with no implicit or specified default. For example, this command would require one integer argument and a string with the key `--user-name`.
 

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -73,7 +73,7 @@ extension Argument where Value: ExpressibleByArgument {
   /// If the property has an `Optional` type, the argument is optional and
   /// defaults to `nil`.
   ///
-  /// - Parameters
+  /// - Parameters:
   ///   - initial: A default value to use for this property.
   ///   - help: Information about how to use this argument.
   public init(

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -73,12 +73,15 @@ extension Argument where Value: ExpressibleByArgument {
   /// If the property has an `Optional` type, the argument is optional and
   /// defaults to `nil`.
   ///
-  /// - Parameter help: Information about how to use this argument.
+  /// - Parameters
+  ///   - initial: A default value to use for this property.
+  ///   - help: Information about how to use this argument.
   public init(
+    default initial: Value? = nil,
     help: ArgumentHelp? = nil
   ) {
     self.init(_parsedValue: .init { key in
-      ArgumentSet(key: key, kind: .positional, parseType: Value.self, name: NameSpecification.long, default: nil, help: help)
+      ArgumentSet(key: key, kind: .positional, parseType: Value.self, name: NameSpecification.long, default: initial, help: help)
       })
   }
 }
@@ -131,10 +134,12 @@ extension Argument {
   /// the given closure.
   ///
   /// - Parameters:
+  ///   - initial: A default value to use for this property.
   ///   - help: Information about how to use this argument.
   ///   - transform: A closure that converts a string into this property's
   ///     type or throws an error.
   public init(
+    default initial: Value? = nil,
     help: ArgumentHelp? = nil,
     transform: @escaping (String) throws -> Value
   ) {
@@ -143,7 +148,11 @@ extension Argument {
       let arg = ArgumentDefinition(kind: .positional, help: help, update: .unary({
         (origin, _, valueString, parsedValues) in
         parsedValues.set(try transform(valueString), forKey: key, inputOrigin: origin)
-      }))
+      }), initial: { origin, values in
+        if let v = initial {
+          values.set(v, forKey: key, inputOrigin: origin)
+        }
+      })
       return ArgumentSet(alternatives: [arg])
       })
   }

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -336,3 +336,40 @@ extension DefaultsEndToEndTests {
     XCTAssertThrowsError(try Baz.parse(["--bool", "truthy"]))
   }
 }
+
+fileprivate struct Qux: ParsableArguments {
+  @Argument(default: "quux")
+  var name: String
+}
+
+extension PositionalEndToEndTests {
+  func testParsing_Defaults() throws {
+    AssertParse(Qux.self, []) { qux in
+      XCTAssertEqual(qux.name, "quux")
+    }
+    AssertParse(Qux.self, ["Bar"]) { qux in
+      XCTAssertEqual(qux.name, "Bar")
+    }
+    AssertParse(Qux.self, ["Bar-"]) { qux in
+      XCTAssertEqual(qux.name, "Bar-")
+    }
+    AssertParse(Qux.self, ["Bar--"]) { qux in
+      XCTAssertEqual(qux.name, "Bar--")
+    }
+    AssertParse(Qux.self, ["--", "-Bar"]) { qux in
+      XCTAssertEqual(qux.name, "-Bar")
+    }
+    AssertParse(Qux.self, ["--", "--Bar"]) { qux in
+      XCTAssertEqual(qux.name, "--Bar")
+    }
+    AssertParse(Qux.self, ["--", "--"]) { qux in
+      XCTAssertEqual(qux.name, "--")
+    }
+  }
+
+  func testParsing_Defaults_Fails() throws {
+    XCTAssertThrowsError(try Qux.parse(["--name"]))
+    XCTAssertThrowsError(try Qux.parse(["Foo", "Bar"]))
+  }
+}
+

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -72,11 +72,14 @@ extension UsageGenerationTests {
     
     @Option(default: 0)
     var count: Int
+
+    @Argument(default: "no-arg")
+    var arg: String
   }
   
   func testSynopsisWithDefaults() {
     let help = UsageGenerator(toolName: "bar", parsable: E())
-    XCTAssertEqual(help.synopsis, "bar [--name <name>] [--count <count>]")
+    XCTAssertEqual(help.synopsis, "bar [--name <name>] [--count <count>] [<arg>]")
   }
   
   struct F: ParsableArguments {


### PR DESCRIPTION
### Description

I added support default value for `@Argument` property wrapper.

Related issue is #64. and Swift Forums thread is [`Default Argument values?  - Related Projects / ArgumentParser`](https://forums.swift.org/t/default-argument-values/34174)

### Detailed Design

The way to implement is same as `@Option` property wrapper. Just add a optional `default` parameter on its `init` method and default value is nil. `ArgumentSet` and` ArgumentDefinition` do all the work in the `init` method.

### Documentation Plan

> How has the new feature been documented? 

I added documents on methods I changed.

> Have the relevant portions of the guide been updated in addition to symbol-level documentation?

I fixed a bit talking about `default` parameter on `02 Arguments, Options, and Flags.md`.

### Test Plan

> How is the new feature tested?

I added tests similar to the existing test code to `DefaultsEndToEndTests.swift`.

For example, if there is no argument when the `Default` value is given Whether the` Default` value is stored. If there is an argument when giving the `Default` value, whether the value will be overridden properly.

### Source Impact

> What is the impact of this change on existing users?

`default` value is Optional and default parameter is nil, so no impact on existing users.

> Does it deprecate or remove any existing API?

No it doesn't.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary