### PR TITLE
Fix optional argument is listed as mandatory

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -238,7 +238,7 @@ extension Option {
     self.init(_parsedValue: .init { key in
       let kind = ArgumentDefinition.Kind.name(key: key, specification: name)
       let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, key: key)
-      let arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
+      var arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
         (origin, _, valueString, parsedValues) in
         parsedValues.set(try transform(valueString), forKey: key, inputOrigin: origin)
       }), initial: { origin, values in
@@ -246,6 +246,7 @@ extension Option {
           values.set(v, forKey: key, inputOrigin: origin)
         }
       })
+      arg.help.defaultValue = initial.map { "\($0)" }
       return ArgumentSet(alternatives: [arg])
       })
   }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -237,7 +237,7 @@ extension Option {
   ) {
     self.init(_parsedValue: .init { key in
       let kind = ArgumentDefinition.Kind.name(key: key, specification: name)
-      let help = ArgumentDefinition.Help(options: [], help: help, key: key)
+      let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, key: key)
       let arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
         (origin, _, valueString, parsedValues) in
         parsedValues.set(try transform(valueString), forKey: key, inputOrigin: origin)

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -101,6 +101,22 @@ extension HelpGenerationTests {
   }
 
   enum OptionFlags: String, CaseIterable { case optional, required }
+  enum Degree {
+    case bachelor, master, doctor
+    static func degreeTransform(_ string: String) throws -> Degree {
+      switch string {
+      case "bachelor":
+        return .bachelor
+      case "master":
+        return .master
+      case "doctor":
+        return .doctor
+      default:
+        throw ValidationError("Not a valid string for 'Degree'")
+      }
+    }
+  }
+
   struct D: ParsableCommand {
     @Argument(default: "--", help: "Your occupation.")
     var occupation: String
@@ -119,11 +135,14 @@ extension HelpGenerationTests {
 
     @Flag(default: .optional, help: "Vegan diet.")
     var nda: OptionFlags
+
+    @Option(default: .bachelor, help: "Your degree.", transform: Degree.degreeTransform)
+    var degree: Degree
   }
 
   func testHelpWithDefaultValues() {
     AssertHelp(for: D.self, equals: """
-            USAGE: d [<occupation>] [--name <name>] [--middle-name <middle-name>] [--age <age>] [--logging <logging>] [--optional] [--required]
+            USAGE: d [<occupation>] [--name <name>] [--middle-name <middle-name>] [--age <age>] [--logging <logging>] [--optional] [--required] [--degree <degree>]
 
             ARGUMENTS:
               <occupation>            Your occupation. (default: --)
@@ -135,6 +154,7 @@ extension HelpGenerationTests {
               --age <age>             Your age. (default: 20)
               --logging <logging>     Whether logging is enabled. (default: false)
               --optional/--required   Vegan diet. (default: optional)
+              --degree <degree>       Your degree. (default: bachelor)
               -h, --help              Show help information.
 
             """)

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -117,26 +117,20 @@ extension UsageGenerationTests {
 
   struct I: ParsableArguments {
     enum Color {
-      case red
-      case blue
-
-      public static func color(from: String) -> Color? {
-        switch from {
-        case "red":
-          return .red
-        case "blue":
-          return .blue
-        default:
-          return nil
+        case red, blue
+        static func transform(_ string: String) throws -> Color {
+          switch string {
+          case "red":
+            return .red
+          case "blue":
+            return .blue
+          default:
+            throw ValidationError("Not a valid string for 'Color'")
+          }
         }
-      }
     }
 
-    static func transform(_ string: String) throws -> Color {
-        Color.color(from: string)!
-    }
-
-    @Option(default: .red, transform: transform)
+    @Option(default: .red, transform: Color.transform)
     var color: Color
   }
 

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -114,4 +114,34 @@ extension UsageGenerationTests {
     let help = UsageGenerator(toolName: "bar", parsable: H())
     XCTAssertEqual(help.synopsis, "bar")
   }
+
+  struct I: ParsableArguments {
+    enum Color {
+      case red
+      case blue
+
+      public static func color(from: String) -> Color? {
+        switch from {
+        case "red":
+          return .red
+        case "blue":
+          return .blue
+        default:
+          return nil
+        }
+      }
+    }
+
+    static func transform(_ string: String) throws -> Color {
+        Color.color(from: string)!
+    }
+
+    @Option(default: .red, transform: transform)
+    var color: Color
+  }
+
+  func testSynopsisWithDefaultValueAndTransform() {
+    let help = UsageGenerator(toolName: "bar", parsable: I())
+    XCTAssertEqual(help.synopsis, "bar [--color <color>]")
+  }
 }


### PR DESCRIPTION
- [x] I've completed this task

I fixed a bug #76. The cause of the bug was that the option of `ArgumentDefinition.Help` was not correctly given only for `init(name:, default:, parsing:, help:, transform:)`.

I added tests HelpGenerationTests and UsageGenerationTests.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
