### PR TITLE
Fix ParsableArguments sharing between cmds & subcommands

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -47,6 +47,9 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
       self.init(_parsedValue: .value(value))
     } else {
       try self.init(_decoder: decoder)
+      if let d = decoder as? SingleValueDecoder {
+        d.saveValue(wrappedValue)
+      }
     }
     
     do {


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Previously, we were only storing full-decoded ParsableCommand instances for subcommands to pick up with the @OptionGroup() wrapper. This change stores all decoded @OptionGroup() values as well, so that they can be shared from super- to subcommand.

In this example from the test, the `Sub` command would never actually see a value in its `options.name` property, since the `--name Tom` inputs get consumed the first time that `Options` is decoded:

```swift
struct Options: ParsableArguments {
    @Option() var name: String?
}

struct Super: ParsableCommand {
    static let configuration = CommandConfiguration(subcommands: [Sub.self])

    @OptionGroup() var options: Options

    struct Sub: ParsableCommand {
        @OptionGroup() var options: Options
    }
}
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
