### PR TITLE
Add an API for converting an error to an exit code

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -37,12 +37,17 @@ public struct ValidationError: Error, CustomStringConvertible {
 /// If you're printing custom errors messages yourself, you can throw this error
 /// to specify the exit code without adding any additional output to standard
 /// out or standard error.
-public struct ExitCode: Error {
-  var code: Int32
+public struct ExitCode: Error, RawRepresentable, Hashable {
+  /// The exit code represented by this instance.
+  public var rawValue: Int32
 
   /// Creates a new `ExitCode` with the given code.
   public init(_ code: Int32) {
-    self.code = code
+    self.rawValue = code
+  }
+  
+  public init(rawValue: Int32) {
+    self.init(rawValue)
   }
   
   /// An exit code that indicates successful completion of a command.
@@ -53,6 +58,12 @@ public struct ExitCode: Error {
   
   /// An exit code that indicates that the user provided invalid input.
   public static let validationFailure = ExitCode(EX_USAGE)
+
+  /// A Boolean value indicated whether this exit code represents the successful
+  /// completion of a command.
+  public var isSuccess: Bool {
+    self == Self.success
+  }
 }
 
 /// An error type that represents a clean (i.e. non-error state) exit of the

--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -59,8 +59,8 @@ public struct ExitCode: Error, RawRepresentable, Hashable {
   /// An exit code that indicates that the user provided invalid input.
   public static let validationFailure = ExitCode(EX_USAGE)
 
-  /// A Boolean value indicated whether this exit code represents the successful
-  /// completion of a command.
+  /// A Boolean value indicating whether this exit code represents the
+  /// successful completion of a command.
   public var isSuccess: Bool {
     self == Self.success
   }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -132,7 +132,7 @@ extension ParsableArguments {
   public static func exitCode(
     for error: Error
   ) -> ExitCode {
-    ExitCode(MessageInfo(error: error, type: self).exitCode)
+    MessageInfo(error: error, type: self).exitCode
   }
 
   /// Terminates execution with a message and exit code that is appropriate
@@ -149,7 +149,7 @@ extension ParsableArguments {
     withError error: Error? = nil
   ) -> Never {
     guard let error = error else {
-      _exit(ExitCode.success.code)
+      _exit(ExitCode.success.rawValue)
     }
     
     let messageInfo = MessageInfo(error: error, type: self)
@@ -160,7 +160,7 @@ extension ParsableArguments {
         print(messageInfo.fullText, to: &standardError)
       }
     }
-    _exit(messageInfo.exitCode)
+    _exit(messageInfo.exitCode.rawValue)
   }
   
   /// Parses a new instance of this type from command-line arguments or exits

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -125,6 +125,16 @@ extension ParsableArguments {
     MessageInfo(error: error, type: self).fullText
   }
   
+  /// Returns the exit code for the given error.
+  ///
+  /// - Parameter error: An error to generate a message for.
+  /// - Returns: The exit code for the `error`.
+  public static func exitCode(
+    for error: Error
+  ) -> ExitCode {
+    ExitCode(MessageInfo(error: error, type: self).exitCode)
+  }
+
   /// Terminates execution with a message and exit code that is appropriate
   /// for the given error.
   ///

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -127,8 +127,11 @@ extension ParsableArguments {
   
   /// Returns the exit code for the given error.
   ///
-  /// - Parameter error: An error to generate a message for.
-  /// - Returns: The exit code for the `error`.
+  /// The returned code is the same exit code that is used if `error` is passed
+  /// to `exit(withError:)`.
+  ///
+  /// - Parameter error: An error to generate an exit code for.
+  /// - Returns: The exit code for `error`.
   public static func exitCode(
     for error: Error
   ) -> ExitCode {

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -62,7 +62,7 @@ enum MessageInfo {
           self = .help(text: message)
         }
       case let error as ExitCode:
-        self = .other(message: "", exitCode: error.code)
+        self = .other(message: "", exitCode: error.rawValue)
       case let error as LocalizedError where error.errorDescription != nil:
         self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
       default:
@@ -106,11 +106,11 @@ enum MessageInfo {
     }
   }
 
-  var exitCode: Int32 {
+  var exitCode: ExitCode {
     switch self {
-    case .help: return ExitCode.success.code
-    case .validation: return ExitCode.validationFailure.code
-    case .other(_, let exitCode): return exitCode
+    case .help: return ExitCode.success
+    case .validation: return ExitCode.validationFailure
+    case .other(_, let code): return ExitCode(code)
     }
   }
 }

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -136,7 +136,7 @@ extension XCTest {
   public func AssertExecuteCommand(
     command: String,
     expected: String? = nil,
-    exitCode: Int32 = ExitCode.success.rawValue,
+    exitCode: ExitCode = .success,
     file: StaticString = #file, line: UInt = #line)
   {
     let splitCommand = command.split(separator: " ")
@@ -172,6 +172,6 @@ extension XCTest {
       AssertEqualStringsIgnoringTrailingWhitespace(expected, errorActual + outputActual, file: file, line: line)
     }
 
-    XCTAssertEqual(process.terminationStatus, exitCode, file: file, line: line)
+    XCTAssertEqual(process.terminationStatus, exitCode.rawValue, file: file, line: line)
   }
 }

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -136,7 +136,7 @@ extension XCTest {
   public func AssertExecuteCommand(
     command: String,
     expected: String? = nil,
-    exitCode: Int32 = 0,
+    exitCode: Int32 = ExitCode.success.rawValue,
     file: StaticString = #file, line: UInt = #line)
   {
     let splitCommand = command.split(separator: " ")

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -106,26 +106,26 @@ final class MathExampleTests: XCTestCase {
             Error: Please provide at least one value to calculate the mode.
             Usage: math stats average [--kind <kind>] [<values> ...]
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
   }
 
   func testMath_ExitCodes() throws {
     AssertExecuteCommand(
       command: "math stats quantiles --test-success-exit-code",
       expected: "",
-      exitCode: ExitCode.success.rawValue)
+      exitCode: .success)
     AssertExecuteCommand(
       command: "math stats quantiles --test-failure-exit-code",
       expected: "",
-      exitCode: ExitCode.failure.rawValue)
+      exitCode: .failure)
     AssertExecuteCommand(
       command: "math stats quantiles --test-validation-exit-code",
       expected: "",
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
     AssertExecuteCommand(
       command: "math stats quantiles --test-custom-exit-code 42",
       expected: "",
-      exitCode: 42)
+      exitCode: ExitCode(42))
   }
   
   func testMath_Fail() throws {
@@ -135,7 +135,7 @@ final class MathExampleTests: XCTestCase {
             Error: Unknown option '--foo'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
     
     AssertExecuteCommand(
       command: "math ZZZ",
@@ -143,6 +143,6 @@ final class MathExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '<values>'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
   }
 }

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import ArgumentParser
 import ArgumentParserTestHelpers
 
 final class MathExampleTests: XCTestCase {
@@ -105,22 +106,22 @@ final class MathExampleTests: XCTestCase {
             Error: Please provide at least one value to calculate the mode.
             Usage: math stats average [--kind <kind>] [<values> ...]
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
   }
 
   func testMath_ExitCodes() throws {
     AssertExecuteCommand(
       command: "math stats quantiles --test-success-exit-code",
       expected: "",
-      exitCode: EXIT_SUCCESS)
+      exitCode: ExitCode.success.rawValue)
     AssertExecuteCommand(
       command: "math stats quantiles --test-failure-exit-code",
       expected: "",
-      exitCode: EXIT_FAILURE)
+      exitCode: ExitCode.failure.rawValue)
     AssertExecuteCommand(
       command: "math stats quantiles --test-validation-exit-code",
       expected: "",
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
     AssertExecuteCommand(
       command: "math stats quantiles --test-custom-exit-code 42",
       expected: "",
@@ -134,7 +135,7 @@ final class MathExampleTests: XCTestCase {
             Error: Unknown option '--foo'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
     
     AssertExecuteCommand(
       command: "math ZZZ",
@@ -142,6 +143,6 @@ final class MathExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '<values>'
             Usage: math add [--hex-output] [<values> ...]
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
   }
 }

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -49,7 +49,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing expected argument '<phrase>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
     
     AssertExecuteCommand(
       command: "repeat hello --count",
@@ -57,7 +57,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing value for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
     
     AssertExecuteCommand(
       command: "repeat hello --count ZZZ",
@@ -65,6 +65,6 @@ final class RepeatExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
   }
 }

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import ArgumentParser
 import ArgumentParserTestHelpers
 
 final class RepeatExampleTests: XCTestCase {
@@ -48,7 +49,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing expected argument '<phrase>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
     
     AssertExecuteCommand(
       command: "repeat hello --count",
@@ -56,7 +57,7 @@ final class RepeatExampleTests: XCTestCase {
             Error: Missing value for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
     
     AssertExecuteCommand(
       command: "repeat hello --count ZZZ",
@@ -64,6 +65,6 @@ final class RepeatExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--count <count>'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
   }
 }

--- a/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import ArgumentParser
 import ArgumentParserTestHelpers
 
 final class RollDiceExampleTests: XCTestCase {
@@ -41,7 +42,7 @@ final class RollDiceExampleTests: XCTestCase {
             Error: Missing value for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
     
     AssertExecuteCommand(
       command: "roll --times ZZZ",
@@ -49,6 +50,6 @@ final class RollDiceExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      exitCode: EX_USAGE)
+      exitCode: ExitCode.validationFailure.rawValue)
   }
 }

--- a/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
@@ -42,7 +42,7 @@ final class RollDiceExampleTests: XCTestCase {
             Error: Missing value for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
     
     AssertExecuteCommand(
       command: "roll --times ZZZ",
@@ -50,6 +50,6 @@ final class RollDiceExampleTests: XCTestCase {
             Error: The value 'ZZZ' is invalid for '--times <n>'
             Usage: roll [--times <n>] [--sides <m>] [--seed <seed>] [--verbose]
             """,
-      exitCode: ExitCode.validationFailure.rawValue)
+      exitCode: .validationFailure)
   }
 }

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -32,4 +32,16 @@ extension ExitCodeTests {
       XCTAssertEqual(ExitCode.success, A.exitCode(for: error))
     }
   }
+
+  func testExitCode_Success() {
+    XCTAssertFalse(A.exitCode(for: E()).isSuccess)
+    XCTAssertFalse(A.exitCode(for: ValidationError("")).isSuccess)
+    
+    do {
+      _ = try A.parse(["-h"])
+      XCTFail("Didn't throw help request error.")
+    } catch {
+      XCTAssertTrue(A.exitCode(for: error).isSuccess)
+    }
+  }
 }

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import ArgumentParser
+
+final class ExitCodeTests: XCTestCase {
+}
+
+// MARK: -
+
+extension ExitCodeTests {
+  struct A: ParsableArguments {}
+  struct E: Error {}
+
+  func testExitCodes() {
+    XCTAssertEqual(ExitCode.failure, A.exitCode(for: E()))
+    XCTAssertEqual(ExitCode.validationFailure, A.exitCode(for: ValidationError("")))
+    
+    do {
+      _ = try A.parse(["-h"])
+      XCTFail("Didn't throw help request error.")
+    } catch {
+      XCTAssertEqual(ExitCode.success, A.exitCode(for: error))
+    }
+  }
+}


### PR DESCRIPTION
### Description
This provides a method on all `ParsableArguments`/`ParsableCommand` types that lets you retrieve the exit code associated with an error.

### Detailed Design
1) Add an `exitCode(for:)` method that converts an error to an `ExitCode` instance. 

```swift
extension ParsableArguments {
  /// Returns the exit code for the given error.
  ///
  /// - Parameter error: An error to generate a message for.
  /// - Returns: The exit code for the `error`.
  public static func exitCode(for error: Error) -> ExitCode
}
```

2) Upgrade the `ExitCode` type to be a bit more useful, making it `RawRepresentable` and  `Hashable`. The represented code is now available through the `rawValue` property.

### Documentation Plan
I included symbol documentation for the new APIs.

### Test Plan
I added unit tests for the `exitCode(for)` method and converted the integration test helper to use `ExitCode`s instead of plain `Int32`s.

### Source Impact
No source impact or deprecations.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
