### PR TITLE
URL + ExpressibleByArgument

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 /// A type that can be expressed as a command-line argument.
 public protocol ExpressibleByArgument {
   /// Creates a new instance of this type from a command-line-specified
@@ -38,6 +40,17 @@ extension RawRepresentable where Self: ExpressibleByArgument, RawValue: Expressi
       self.init(rawValue: value)
     } else {
       return nil
+    }
+  }
+}
+
+extension URL: ExpressibleByArgument {
+  public init?(argument: String) {
+    if let url = URL(string: argument), url.scheme != nil {
+      self.init(string: argument)
+    } else {
+      // Assuming it is a file url.
+      self.init(fileURLWithPath: argument)
     }
   }
 }

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
+import Foundation
 
 enum MessageInfo {
   case help(text: String)

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
+import Foundation
 
 struct UsageGenerator {
   var toolName: String

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(UnitTests
   SplitArgumentTests.swift
   StringWrappingTests.swift
   TreeTests.swift
+  URLArgumentTests.swift
   UsageGenerationTests.swift)
 target_link_libraries(UnitTests PRIVATE
   ArgumentParser

--- a/Tests/ArgumentParserUnitTests/URLArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/URLArgumentTests.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import ArgumentParser
+
+final class URLArgumentTests: XCTestCase {}
+
+extension URLArgumentTests {
+  func testURLArguments() {
+    XCTAssertEqual(URL(argument: "/System")?.path, URL(fileURLWithPath: "/System").path)
+    XCTAssertEqual(URL(argument: ".")?.path, URL(fileURLWithPath: FileManager.default.currentDirectoryPath).path)
+    XCTAssertEqual(URL(argument: "..")?.path, URL(fileURLWithPath: FileManager.default.currentDirectoryPath).deletingLastPathComponent().path)
+    XCTAssertEqual(URL(argument: "subfolder/data.file")?.path, URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("subfolder/data.file").path)
+    XCTAssertEqual(URL(argument: "data.file")?.path, URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("data.file").path)
+    XCTAssertEqual(URL(argument: "https://github.com"), URL(string: "https://github.com"))
+    XCTAssertEqual(URL(argument: "ftp://192.168.1.100"), URL(string: "ftp://192.168.1.100"))
+    XCTAssertEqual(URL(argument: "https://localhost:8080"), URL(string: "https://localhost:8080"))
+  }
+}


### PR DESCRIPTION
### Description
PR for #82 

### Detailed Design
```swift
import Foundation
extension URL: ExpressibleByArgument {}
```

### Documentation Plan
The code is self-explanatory. Do we need to point out this conformance in one of the documentation?

### Test Plan
Added `URLArgumentTests`.

### Source Impact
There is no change to existing API. Additive change only.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary