### PR TITLE
Improve help generation when command abstract is empty

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -44,16 +44,19 @@ internal struct HelpGenerator {
         let wrappedDiscussion = self.discussion.isEmpty
           ? ""
           : self.discussion.wrapped(to: HelpGenerator.screenWidth, wrappingIndent: HelpGenerator.helpIndent * 4) + "\n"
-        
-        if paddedLabel.count < HelpGenerator.labelColumnWidth {
-          return paddedLabel
-            + wrappedAbstract.dropFirst(paddedLabel.count) + "\n"
-            + wrappedDiscussion
-        } else {
-          return paddedLabel + "\n"
-            + wrappedAbstract + "\n"
-            + wrappedDiscussion
-        }
+        let renderedAbstract: String = {
+          guard !abstract.isEmpty else { return "" }
+          if paddedLabel.count < HelpGenerator.labelColumnWidth {
+            // Render after padded label.
+            return String(wrappedAbstract.dropFirst(paddedLabel.count))
+          } else {
+            // Render in a new line.
+            return "\n" + wrappedAbstract
+          }
+        }()
+        return paddedLabel
+          + renderedAbstract + "\n"
+          + wrappedDiscussion
       }
     }
     

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -203,4 +203,33 @@ extension HelpGenerationTests {
 
                """)
   }
+  
+  struct H: ParsableCommand {
+    struct CommandWithVeryLongName: ParsableCommand {}
+    struct ShortCommand: ParsableCommand {
+      static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Test short command name.")
+    }
+    struct AnotherCommandWithVeryLongName: ParsableCommand {
+      static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Test long command name.")
+    }
+    struct AnotherCommand: ParsableCommand {}
+    static var configuration = CommandConfiguration(subcommands: [CommandWithVeryLongName.self,ShortCommand.self,AnotherCommandWithVeryLongName.self,AnotherCommand.self])
+  }
+  
+  func testHelpWithSubcommands() {
+    AssertHelp(for: H.self, equals: """
+    USAGE: h <subcommand>
+
+    OPTIONS:
+      -h, --help              Show help information.
+
+    SUBCOMMANDS:
+      command-with-very-long-name
+      short-command           Test short command name.
+      another-command-with-very-long-name
+                              Test long command name.
+      another-command
+
+    """)
+  }
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -212,7 +212,22 @@ extension HelpGenerationTests {
     struct AnotherCommandWithVeryLongName: ParsableCommand {
       static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Test long command name.")
     }
-    struct AnotherCommand: ParsableCommand {}
+    struct AnotherCommand: ParsableCommand {
+      @Option(default: nil)
+      var someOptionWithVeryLongName: String?
+      
+      @Option(default: nil)
+      var option: String?
+      
+      @Argument(default: "", help: "This is an argument with a long name.")
+      var argumentWithVeryLongNameAndHelp: String
+      
+      @Argument(default: "")
+      var argumentWithVeryLongName: String
+      
+      @Argument(default: "")
+      var argument: String
+    }
     static var configuration = CommandConfiguration(subcommands: [CommandWithVeryLongName.self,ShortCommand.self,AnotherCommandWithVeryLongName.self,AnotherCommand.self])
   }
   
@@ -229,6 +244,22 @@ extension HelpGenerationTests {
       another-command-with-very-long-name
                               Test long command name.
       another-command
+
+    """)
+    
+    AssertHelp(for: H.AnotherCommand.self, equals: """
+    USAGE: another-command [--some-option-with-very-long-name <some-option-with-very-long-name>] [--option <option>] [<argument-with-very-long-name-and-help>] [<argument-with-very-long-name>] [<argument>]
+
+    ARGUMENTS:
+      <argument-with-very-long-name-and-help>
+                              This is an argument with a long name.
+      <argument-with-very-long-name>
+      <argument>
+
+    OPTIONS:
+      --some-option-with-very-long-name <some-option-with-very-long-name>
+      --option <option>
+      -h, --help              Show help information.
 
     """)
   }


### PR DESCRIPTION
When there's a subcommand with a long name and empty abstract, the help is generated with an extra new line below the command name.

For example:
```
USAGE: h <subcommand>

    OPTIONS:
      -h, --help              Show help information.

    SUBCOMMANDS:
      command-a
      command-with-very-long-name

      short-command           Test short command name.

```

This patch removes the extra new line in help.

```
USAGE: h <subcommand>

    OPTIONS:
      -h, --help              Show help information.

    SUBCOMMANDS:
      command-a
      command-with-very-long-name
      short-command           Test short command name.
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
