### PR TITLE
Add support for customizing default value string displayed in Help (#87)

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -14,6 +14,11 @@ public protocol ExpressibleByArgument {
   /// Creates a new instance of this type from a command-line-specified
   /// argument.
   init?(argument: String)
+
+  /// Default representation value in help.
+  ///
+  /// Implement this method to customize default value representation in help.
+  var defaultValueDescription: String { get }
 }
 
 extension String: ExpressibleByArgument {
@@ -68,7 +73,7 @@ extension Bool: ExpressibleByArgument {}
 
 extension ExpressibleByArgument {
 
-  var defaultValueDescription: String {
+  public var defaultValueDescription: String {
 
     let mirror = Mirror(reflecting: self)
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -16,6 +16,21 @@ import ArgumentParserTestHelpers
 final class HelpGenerationTests: XCTestCase {
 }
 
+extension URL: ExpressibleByArgument {
+    public init?(argument: String) {
+        guard let url = URL(string: argument) else {
+            return nil
+        }
+        self = url
+    }
+
+    public var defaultValueDescription: String {
+        self.absoluteString == FileManager.default.currentDirectoryPath
+        ? "current directory"
+        : String(describing: self)
+    }
+}
+
 // MARK: -
 
 extension HelpGenerationTests {
@@ -117,6 +132,7 @@ extension HelpGenerationTests {
     }
   }
 
+
   struct D: ParsableCommand {
     @Argument(default: "--", help: "Your occupation.")
     var occupation: String
@@ -138,11 +154,14 @@ extension HelpGenerationTests {
 
     @Option(default: .bachelor, help: "Your degree.", transform: Degree.degreeTransform)
     var degree: Degree
+
+    @Option(default: URL(string: FileManager.default.currentDirectoryPath)!, help: "Directory.")
+    var directory: URL
   }
 
   func testHelpWithDefaultValues() {
     AssertHelp(for: D.self, equals: """
-            USAGE: d [<occupation>] [--name <name>] [--middle-name <middle-name>] [--age <age>] [--logging <logging>] [--optional] [--required] [--degree <degree>]
+            USAGE: d [<occupation>] [--name <name>] [--middle-name <middle-name>] [--age <age>] [--logging <logging>] [--optional] [--required] [--degree <degree>] [--directory <directory>]
 
             ARGUMENTS:
               <occupation>            Your occupation. (default: --)
@@ -155,6 +174,7 @@ extension HelpGenerationTests {
               --logging <logging>     Whether logging is enabled. (default: false)
               --optional/--required   Vegan diet. (default: optional)
               --degree <degree>       Your degree. (default: bachelor)
+              --directory <directory> Directory. (default: current directory)
               -h, --help              Show help information.
 
             """)

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -17,18 +17,18 @@ final class HelpGenerationTests: XCTestCase {
 }
 
 extension URL: ExpressibleByArgument {
-    public init?(argument: String) {
-        guard let url = URL(string: argument) else {
-            return nil
-        }
-        self = url
+  public init?(argument: String) {
+    guard let url = URL(string: argument) else {
+      return nil
     }
+    self = url
+  }
 
-    public var defaultValueDescription: String {
-        self.absoluteString == FileManager.default.currentDirectoryPath
-        ? "current directory"
-        : String(describing: self)
-    }
+  public var defaultValueDescription: String {
+    self.absoluteString == FileManager.default.currentDirectoryPath
+      ? "current directory"
+      : String(describing: self)
+  }
 }
 
 // MARK: -


### PR DESCRIPTION
- [x] I've completed this task

This PR fixes #87.

## Plan

Simply we can add `defaultValueDescription` in `ExpressibleByArgument` protocol

```
/// A type that can be expressed as a command-line argument.
public protocol ExpressibleByArgument {
  /// Creates a new instance of this type from a command-line-specified
  /// argument.
  init?(argument: String)

  /// Add this ↓
  var defaultValueDescription: String { get }
}
```

## Source Impact

Default behavior is given by default implementation declared in `ExpressibleByArgument` as Protocol Extensions.  Only users who want to customize need to override `defaultValueDescription`.

## Related Forum Thread

[How can I change the default value string displayed in Help? \- Related Projects / ArgumentParser \- Swift Forums](https://forums.swift.org/t/how-can-i-change-the-default-value-string-displayed-in-help/34527/3)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
