### PR TITLE
Don't repeat single-dash arguments with unconditionalRemaining arrays

### DIFF
--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -206,12 +206,13 @@ extension SplitArguments {
       }?.1
   }
   
-  /// Returns the original input string at the given origin.
-  func originalInput(at origin: InputOrigin.Element) -> String {
-    switch origin {
-    case .argumentIndex(let index):
-      return originalInput[index.inputIndex.rawValue]
+  /// Returns the original input string at the given origin, or `nil` if
+  /// `origin` is a sub-index.
+  func originalInput(at origin: InputOrigin.Element) -> String? {
+    guard case let .argumentIndex(index) = origin else {
+      return nil
     }
+    return originalInput[index.inputIndex.rawValue]
   }
   
   mutating func popNext() -> (InputOrigin.Element, Element)? {

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -302,6 +302,8 @@ extension RepeatingEndToEndTests {
 
 fileprivate struct Foozle: ParsableArguments {
   @Flag() var verbose: Bool
+  @Flag(name: .customShort("f")) var useFiles: Bool
+  @Flag(name: .customShort("i")) var useStandardInput: Bool
   @Argument(parsing: .unconditionalRemaining) var names: [String]
 }
 
@@ -346,6 +348,25 @@ extension RepeatingEndToEndTests {
       XCTAssertFalse(foozle.verbose)
       XCTAssertEqual(foozle.names, ["--", "--verbose", "--other", "one", "two", "three"])
     }
+    
+    AssertParse(Foozle.self, ["-one", "-two", "three"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertFalse(foozle.useFiles)
+      XCTAssertFalse(foozle.useStandardInput)
+      XCTAssertEqual(foozle.names, ["-one", "-two", "three"])
+    }
+    
+    AssertParse(Foozle.self, ["-one", "-two", "three", "-if"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertTrue(foozle.useFiles)
+      XCTAssertTrue(foozle.useStandardInput)
+      XCTAssertEqual(foozle.names, ["-one", "-two", "three"])
+    }
+  }
+  
+  func testParsing_repeatingUnconditionalArgument_Fails() throws {
+    // Only partially matches the `-fob` argument
+    XCTAssertThrowsError(try Foozle.parse(["-fib"]))
   }
 }
 


### PR DESCRIPTION
Because of the way we split out single-dash arguments into both the whole string and each individual character, we were capturing single-dash arguments multiple times. This fixes #88.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
