### PR TITLE
Add `PositionalArgumentsValidator`

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -13,13 +13,77 @@ fileprivate protocol ParsableArgumentsValidator {
   static func validate(_ type: ParsableArguments.Type) throws
 }
 
+struct ParsableArgumentsValidationError: Error, CustomStringConvertible {
+  let parsableArgumentsType: ParsableArguments.Type
+  let underlayingErrors: [Error]
+  var description: String {
+    """
+    Validation failed for `\(parsableArgumentsType)`:
+    \(underlayingErrors.map({"- \($0)"}).joined(separator: "\n"))
+    
+    """
+  }
+}
+
 extension ParsableArguments {
   static func _validate() throws {
     let validators: [ParsableArgumentsValidator.Type] = [
+      PositionalArgumentsValidator.self,
       ParsableArgumentsCodingKeyValidator.self
     ]
-    for validator in validators {
-      try validator.validate(self)
+    let errors: [Error] = validators.compactMap { validator in
+      do {
+        try validator.validate(self)
+        return nil
+      } catch {
+        return error
+      }
+    }
+    if errors.count > 0 {
+      throw ParsableArgumentsValidationError(parsableArgumentsType: self, underlayingErrors: errors)
+    }
+  }
+}
+
+/// For positional arguments to be valid, there must be at most one
+/// positional array argument, and it must be the last positional argument
+/// in the argument list. Any other configuration leads to ambiguity in
+/// parsing the arguments.
+struct PositionalArgumentsValidator: ParsableArgumentsValidator {
+  
+  struct Error: Swift.Error, CustomStringConvertible {
+    let repeatedPositionalArgument: String
+    let positionalArgumentFollowingRepeated: String
+    var description: String {
+      "Can't have a positional argument `\(positionalArgumentFollowingRepeated)` following an array of positional arguments `\(repeatedPositionalArgument)`."
+    }
+  }
+  
+  static func validate(_ type: ParsableArguments.Type) throws {
+    let sets: [(key: InputKey, argumentSet: ArgumentSet)] = Mirror(reflecting: type.init())
+      .children
+      .compactMap { child in
+        guard
+          var codingKey = child.label,
+          let parsed = child.value as? ArgumentSetProvider
+          else { return nil }
+        
+        // Property wrappers have underscore-prefixed names
+        codingKey = String(codingKey.first == "_" ? codingKey.dropFirst(1) : codingKey.dropFirst(0))
+        
+        let key = InputKey(rawValue: codingKey)
+        return (key, parsed.argumentSet(for: key))
+    }
+    
+    guard let repeatedPositional = sets.firstIndex(where: { $0.argumentSet.hasRepeatingPositional })
+      else { return }
+    let positionalFollowingRepeated = sets[repeatedPositional...]
+      .dropFirst()
+      .first(where: { $0.argumentSet.hasPositional })
+    
+    if let positionalFollowingRepeated = positionalFollowingRepeated {
+      throw Error(repeatedPositionalArgument: sets[repeatedPositional].key.rawValue,
+                  positionalArgumentFollowingRepeated: positionalFollowingRepeated.key.rawValue)
     }
   }
 }
@@ -59,13 +123,12 @@ struct ParsableArgumentsCodingKeyValidator: ParsableArgumentsValidator {
   /// This error indicates that an option, a flag, or an argument of
   /// a `ParsableArguments` is defined without a corresponding `CodingKey`.
   struct Error: Swift.Error, CustomStringConvertible {
-    let parsableArgumentsType: ParsableArguments.Type
     let missingCodingKeys: [String]
     var description: String {
       if missingCodingKeys.count > 1 {
-        return "Arguments \(missingCodingKeys.map({ "`\($0)`" }).joined(separator: ",")) of `\(parsableArgumentsType)` are defined without corresponding `CodingKey`s."
+        return "Arguments \(missingCodingKeys.map({ "`\($0)`" }).joined(separator: ",")) are defined without corresponding `CodingKey`s."
       } else {
-        return "Argument `\(missingCodingKeys[0])` of `\(parsableArgumentsType)` is defined without a corresponding `CodingKey`."
+        return "Argument `\(missingCodingKeys[0])` is defined without a corresponding `CodingKey`."
       }
     }
   }
@@ -91,7 +154,7 @@ struct ParsableArgumentsCodingKeyValidator: ParsableArgumentsValidator {
     } catch let result as Validator.ValidationResult {
       switch result {
       case .missingCodingKeys(let keys):
-        throw Error(parsableArgumentsType: type, missingCodingKeys: keys)
+        throw Error(missingCodingKeys: keys)
       case .success:
         break
       }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -104,8 +104,8 @@ struct PositionalArgumentsValidator: ParsableArgumentsValidator {
     if let positionalFollowingRepeated = positionalFollowingRepeated {
       let firstRepeatedPositionalArgument: ArgumentDefinition = sets[repeatedPositional].firstRepeatedPositionalArgument!
       let positionalFollowingRepeatedArgument: ArgumentDefinition = positionalFollowingRepeated.firstPositionalArgument!
-      throw Error(repeatedPositionalArgument: firstRepeatedPositionalArgument.valueName,
-                  positionalArgumentFollowingRepeated: positionalFollowingRepeatedArgument.valueName)
+      throw Error(repeatedPositionalArgument: firstRepeatedPositionalArgument.help.keys.first!.rawValue,
+                  positionalArgumentFollowingRepeated: positionalFollowingRepeatedArgument.help.keys.first!.rawValue)
     }
   }
 }

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -90,26 +90,6 @@ extension ArgumentSet {
   }
 }
 
-extension ArgumentSet {
-  var hasPositional: Bool {
-    switch content {
-    case .arguments(let arguments):
-      return arguments.contains(where: { $0.isPositional })
-    case .sets(let sets):
-      return sets.contains(where: { $0.hasPositional })
-    }
-  }
-  
-  var hasRepeatingPositional: Bool {
-    switch content {
-    case .arguments(let arguments):
-      return arguments.contains(where: { $0.isRepeatingPositional })
-    case .sets(let sets):
-      return sets.contains(where: { $0.hasRepeatingPositional })
-    }
-  }
-}
-
 // MARK: Flag
 
 extension ArgumentSet {

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(UnitTests
-  CodingKeyValidationTests.swift
+  ParsableArgumentsValidationTests.swift
   ErrorMessageTests.swift
   HelpGenerationTests.swift
   NameSpecificationTests.swift

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -185,7 +185,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     XCTAssertThrowsError(try PositionalArgumentsValidator.validate(J.self)) { error in
       if let error = error as? PositionalArgumentsValidator.Error {
         XCTAssert(error.positionalArgumentFollowingRepeated == "phrase")
-        XCTAssert(error.repeatedPositionalArgument == "number-of-items")
+        XCTAssert(error.repeatedPositionalArgument == "numberOfItems")
       } else {
         XCTFail()
       }

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -88,7 +88,6 @@ final class CodingKeyValidationTests: XCTestCase {
     XCTAssertThrowsError(try ParsableArgumentsCodingKeyValidator.validate(C.self)) { (error) in
       if let error = error as? ParsableArgumentsCodingKeyValidator.Error {
         XCTAssert(error.missingCodingKeys == ["count"])
-        XCTAssert(error.parsableArgumentsType.init() is C)
       } else {
         XCTFail()
       }
@@ -97,7 +96,6 @@ final class CodingKeyValidationTests: XCTestCase {
     XCTAssertThrowsError(try ParsableArgumentsCodingKeyValidator.validate(D.self)) { (error) in
       if let error = error as? ParsableArgumentsCodingKeyValidator.Error {
         XCTAssert(error.missingCodingKeys == ["phrase"])
-        XCTAssert(error.parsableArgumentsType.init() is D)
       } else {
         XCTFail()
       }
@@ -106,11 +104,48 @@ final class CodingKeyValidationTests: XCTestCase {
     XCTAssertThrowsError(try ParsableArgumentsCodingKeyValidator.validate(E.self)) { (error) in
       if let error = error as? ParsableArgumentsCodingKeyValidator.Error {
         XCTAssert(error.missingCodingKeys == ["phrase", "includeCounter"])
-        XCTAssert(error.parsableArgumentsType.init() is E)
       } else {
         XCTFail()
       }
     }
   }
   
+  private struct F: ParsableArguments {
+    @Argument()
+    var phrase: String
+    
+    @Argument()
+    var items: [Int]
+  }
+  
+  private struct G: ParsableArguments {
+    @Argument()
+    var items: [Int]
+    
+    @Argument()
+    var phrase: String
+  }
+  
+  private struct H: ParsableArguments {
+    @Argument()
+    var items: [Int]
+    
+    @Option()
+    var option: Bool
+  }
+  
+  func testPositionalArgumentsValidation() throws {
+    try PositionalArgumentsValidator.validate(A.self)
+    try PositionalArgumentsValidator.validate(F.self)
+    XCTAssertThrowsError(try PositionalArgumentsValidator.validate(G.self)) { error in
+      if let error = error as? PositionalArgumentsValidator.Error {
+        XCTAssert(error.positionalArgumentFollowingRepeated == "phrase")
+        XCTAssert(error.repeatedPositionalArgument == "items")
+      } else {
+        XCTFail()
+      }
+      XCTAssert(error is PositionalArgumentsValidator.Error)
+    }
+    try PositionalArgumentsValidator.validate(H.self)
+  }
 }


### PR DESCRIPTION
### Abstract

Continue restructuring the `ParsableArguments` validation layer. (Previous discussions: #91)

### Detail

- Move the "positional argument following an array of positional arguments" check to a new struct `PositionalArgumentsValidator`.

- Make `ParsableArguments._validation` throw a combination of validation errors, and add the proper error description.

- Add tests for `PositionalArgumentsValidator`

So a `ParsableArguments` with both coding key error and positional arguments error is now reported in the following form:
```
Fatal error: Validation failed for `Repeat`:
- Can't have a positional argument `phrase` following an array of positional arguments `items`.
- Arguments `includeCounter`,`items` are defined without corresponding `CodingKey`s.
: file /Users/***/Developer/swift-argument-parser/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift, line 196
```


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
