### PR TITLE
Add built-in support for --version flag

### DIFF
--- a/Examples/math/main.swift
+++ b/Examples/math/main.swift
@@ -18,6 +18,9 @@ struct Math: ParsableCommand {
         // Optional abstracts and discussions are used for help output.
         abstract: "A utility for performing maths.",
 
+        // Commands can define a version for automatic '--version' support.
+        version: "1.0.0",
+
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be
         // provided by automatically finding nested `ParsableCommand` types.
@@ -89,7 +92,8 @@ extension Math {
 extension Math.Statistics {
     struct Average: ParsableCommand {
         static var configuration = CommandConfiguration(
-            abstract: "Print the average of the values.")
+            abstract: "Print the average of the values.",
+            version: "1.5.0-alpha")
         
         enum Kind: String, ExpressibleByArgument {
             case mean, median, mode

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -24,6 +24,9 @@ public struct CommandConfiguration {
   /// display.
   public var discussion: String
   
+  /// Version information for this command.
+  public var version: String
+
   /// A Boolean value indicating whether this command should be shown in
   /// the extended help display.
   public var shouldDisplay: Bool
@@ -57,6 +60,7 @@ public struct CommandConfiguration {
     commandName: String? = nil,
     abstract: String = "",
     discussion: String = "",
+    version: String = "",
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
@@ -65,6 +69,7 @@ public struct CommandConfiguration {
     self.commandName = commandName
     self.abstract = abstract
     self.discussion = discussion
+    self.version = version
     self.shouldDisplay = shouldDisplay
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -48,6 +48,9 @@ public struct CommandConfiguration {
   ///     the name of the command type to hyphen-separated lowercase words.
   ///   - abstract: A one-line description of the command.
   ///   - discussion: A longer description of the command.
+  ///   - version: The version number for this command. When you provide a
+  ///     non-empty string, the arguemnt parser prints it if the user provides
+  ///     a `--version` flag.
   ///   - shouldDisplay: A Boolean value indicating whether the command
   ///     should be shown in the extended help display.
   ///   - subcommands: An array of the types that define subcommands for the

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -12,6 +12,7 @@
 /// Gets thrown while parsing and will be handled by the error output generation.
 enum ParserError: Error {
   case helpRequested
+  case versionRequested
   case notImplemented
   case invalidState
   case unknownOption(InputOrigin.Element, Name)

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -44,4 +44,3 @@ struct HelpCommand: ParsableCommand {
     self._subcommands = Argument(_parsedValue: .value(commandStack.map { $0._commandName }))
   }
 }
-

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -190,6 +190,10 @@ internal struct HelpGenerator {
       }
     }
     
+    if commandStack.contains(where: { !$0.configuration.version.isEmpty }) {
+      optionElements.append(.init(label: "--version", abstract: "Show the version."))
+    }
+
     let helpLabels = commandStack
       .first!
       .getHelpNames()
@@ -198,7 +202,7 @@ internal struct HelpGenerator {
     if !helpLabels.isEmpty {
       optionElements.append(.init(label: helpLabels, abstract: "Show help information."))
     }
-    
+
     let subcommandElements: [Section.Element] =
       commandStack.last!.configuration.subcommands.compactMap { command in
         guard command.configuration.shouldDisplay else { return nil }

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -24,9 +24,20 @@ enum MessageInfo {
     case let e as CommandError:
       commandStack = e.commandStack
       parserError = e.parserError
-      if case .helpRequested = e.parserError {
+
+      switch e.parserError {
+      case .helpRequested:
         self = .help(text: HelpGenerator(commandStack: e.commandStack).rendered)
         return
+      case .versionRequested:
+        let versionString = commandStack
+          .map { $0.configuration.version }
+          .last(where: { !$0.isEmpty })
+          ?? "Unspecified version"
+        self = .help(text: versionString)
+        return
+      default:
+        break
       }
     case let e as ParserError:
       commandStack = [type.asCommand]

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -176,6 +176,11 @@ struct ErrorMessageGenerator {
 extension ErrorMessageGenerator {
   func makeErrorMessage() -> String? {
     switch error {
+    case .helpRequested:
+      return nil
+    case .versionRequested:
+      return nil
+
     case .notImplemented:
       return notImplementedMessage
     case .invalidState:
@@ -194,8 +199,6 @@ extension ErrorMessageGenerator {
       return noValueMessage(key: k)
     case .unableToParseValue(let o, let n, let v, forKey: let k):
       return unableToParseValueMessage(origin: o, name: n, value: v, key: k)
-    case .helpRequested:
-      return nil
     case .invalidOption(let str):
       return "Invalid option: \(str)"
     case .nonAlphanumericShortOption(let c):

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -143,3 +143,29 @@ extension SubcommandEndToEndTests {
   }
 }
 
+// MARK: Version flags
+
+private struct A: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    version: "1.0.0",
+    subcommands: [HasVersionFlag.self, NoVersionFlag.self])
+  
+  struct HasVersionFlag: ParsableCommand {
+    @Flag() var version: Bool
+  }
+  
+  struct NoVersionFlag: ParsableCommand {
+    @Flag() var hello: Bool
+  }
+}
+
+extension SubcommandEndToEndTests {
+  func testParsingVersionFlags() throws {
+    AssertErrorMessage(A.self, ["--version"], "1.0.0")
+    AssertErrorMessage(A.self, ["no-version-flag", "--version"], "1.0.0")
+
+    AssertParseCommand(A.self, A.HasVersionFlag.self, ["has-version-flag", "--version"]) { cmd in
+      XCTAssertTrue(cmd.version)
+    }
+  }
+}

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -108,6 +108,18 @@ final class MathExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
   }
+  
+  func testMath_Versions() throws {
+    AssertExecuteCommand(
+      command: "math --version",
+      expected: "1.0.0")
+    AssertExecuteCommand(
+      command: "math stats --version",
+      expected: "1.0.0")
+    AssertExecuteCommand(
+      command: "math stats average --version",
+      expected: "1.5.0-alpha")
+  }
 
   func testMath_ExitCodes() throws {
     AssertExecuteCommand(

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -26,6 +26,7 @@ final class MathExampleTests: XCTestCase {
         USAGE: math <subcommand>
 
         OPTIONS:
+          --version               Show the version.
           -h, --help              Show help information.
 
         SUBCOMMANDS:
@@ -50,6 +51,7 @@ final class MathExampleTests: XCTestCase {
 
         OPTIONS:
           -x, --hex-output        Use hexadecimal notation for the result.
+          --version               Show the version.
           -h, --help              Show help information.
         """
     
@@ -69,6 +71,7 @@ final class MathExampleTests: XCTestCase {
 
         OPTIONS:
           --kind <kind>           The kind of average to provide. (default: mean)
+          --version               Show the version.
           -h, --help              Show help information.
         """
     
@@ -87,6 +90,7 @@ final class MathExampleTests: XCTestCase {
           <values>                A group of floating-point values to operate on.
 
         OPTIONS:
+          --version               Show the version.
           -h, --help              Show help information.
         """
     

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -50,7 +50,7 @@ final class RepeatExampleTests: XCTestCase {
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
       exitCode: .validationFailure)
-    
+
     AssertExecuteCommand(
       command: "repeat hello --count",
       expected: """
@@ -63,6 +63,14 @@ final class RepeatExampleTests: XCTestCase {
       command: "repeat hello --count ZZZ",
       expected: """
             Error: The value 'ZZZ' is invalid for '--count <count>'
+            Usage: repeat [--count <count>] [--include-counter] <phrase>
+            """,
+      exitCode: .validationFailure)
+    
+    AssertExecuteCommand(
+      command: "repeat --version hello",
+      expected: """
+            Error: Unknown option '--version'
             Usage: repeat [--count <count>] [--include-counter] <phrase>
             """,
       exitCode: .validationFailure)

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -20,7 +20,10 @@ final class ExitCodeTests: XCTestCase {
 extension ExitCodeTests {
   struct A: ParsableArguments {}
   struct E: Error {}
-
+  struct C: ParsableCommand {
+    static var configuration = CommandConfiguration(version: "v1")
+  }
+  
   func testExitCodes() {
     XCTAssertEqual(ExitCode.failure, A.exitCode(for: E()))
     XCTAssertEqual(ExitCode.validationFailure, A.exitCode(for: ValidationError("")))
@@ -30,6 +33,20 @@ extension ExitCodeTests {
       XCTFail("Didn't throw help request error.")
     } catch {
       XCTAssertEqual(ExitCode.success, A.exitCode(for: error))
+    }
+    
+    do {
+      _ = try A.parse(["--version"])
+      XCTFail("Didn't throw unrecognized --version error.")
+    } catch {
+      XCTAssertEqual(ExitCode.validationFailure, A.exitCode(for: error))
+    }
+
+    do {
+      _ = try C.parse(["--version"])
+      XCTFail("Didn't throw version request error.")
+    } catch {
+      XCTAssertEqual(ExitCode.success, C.exitCode(for: error))
     }
   }
 
@@ -42,6 +59,20 @@ extension ExitCodeTests {
       XCTFail("Didn't throw help request error.")
     } catch {
       XCTAssertTrue(A.exitCode(for: error).isSuccess)
+    }
+    
+    do {
+      _ = try A.parse(["--version"])
+      XCTFail("Didn't throw unrecognized --version error.")
+    } catch {
+      XCTAssertFalse(A.exitCode(for: error).isSuccess)
+    }
+    
+    do {
+      _ = try C.parse(["--version"])
+      XCTFail("Didn't throw version request error.")
+    } catch {
+      XCTAssertTrue(C.exitCode(for: error).isSuccess)
     }
   }
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -283,4 +283,20 @@ extension HelpGenerationTests {
 
     """)
   }
+
+  struct I: ParsableCommand {
+    static var configuration = CommandConfiguration(version: "1.0.0")
+  }
+
+  func testHelpWithVersion() {
+    AssertHelp(for: I.self, equals: """
+    USAGE: i
+
+    OPTIONS:
+      --version               Show the version.
+      -h, --help              Show help information.
+
+    """)
+
+  }
 }


### PR DESCRIPTION
### Description
Adds built-in support for responding to a `--version` flag. This flag is only valid when a command provides a `version:` parameter in its configuration. Fixes #25.

### Detailed Design
If a command in the tree has specified a version, the `--version` flag is checked for only after evaluating any explicitly defined arguments. This allows commands to define their own `--version` flags or options and not have them be overridden by the auto-generated version.

Nested commands inherit their version from their parent commands, and can override their parent by providing their own version string.

`version` is added to the `CommandConfiguration` type and to the initializer:

```swift
  /// Creates the configuration for a command.
  ///
  /// - Parameters:
  ///   - commandName: The name of the command to use on the command line. If
  ///     `commandName` is `nil`, the command name is derived by converting
  ///     the name of the command type to hyphen-separated lowercase words.
  ///   - abstract: A one-line description of the command.
  ///   - discussion: A longer description of the command.
  ///   - version: The version number for this command. When you provide a
  ///     non-empty string, the arguemnt parser prints it if the user provides
  ///     a `--version` flag.
  ///   - shouldDisplay: A Boolean value indicating whether the command
  ///     should be shown in the extended help display.
  ///   - subcommands: An array of the types that define subcommands for the
  ///     command.
  ///   - defaultSubcommand: The default command type to run if no subcommand
  ///     is given.
  ///   - helpNames: The flag names to use for requesting help, simulating
  ///     a Boolean property named `help`.
  public init(
    commandName: String? = nil,
    abstract: String = "",
    discussion: String = "",
    version: String = "",
    shouldDisplay: Bool = true,
    subcommands: [ParsableCommand.Type] = [],
    defaultSubcommand: ParsableCommand.Type? = nil,
    helpNames: NameSpecification = [.short, .long]
  )
```

### Documentation Plan
How has the new feature been documented? Have the relevant portions of the guide been updated in addition to symbol-level documentation?

### Test Plan
- Unit tests for generating the version string.
- End-to-end tests to verify that the version is being rendered as the correct value when defined, and that commands that explicitly define `--version` get that behavior.
- Example tests with versions defined in `Math`.

### Source Impact
Because the `version:` parameter is defaulted, this has no source impact. In addition, since there's no change in behavior unless the command defines a version, there's no impact on existing tools' behavior.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary