### PR TITLE
Call validate on the entire command stack

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -61,15 +61,7 @@ extension ParsableCommand {
   ) throws -> ParsableCommand {
     var parser = CommandParser(self)
     let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
-    var result = try parser.parse(arguments: arguments).get()
-    do {
-      try result.validate()
-    } catch {
-      throw CommandError(
-        commandStack: parser.commandStack,
-        parserError: ParserError.userValidationError(error))
-    }
-    return result
+    return try parser.parse(arguments: arguments).get()
   }
   
   /// Parses an instance of this type, or one of its subcommands, from


### PR DESCRIPTION
This change calls validate on every ParsableCommand in the command stack, instead of just the leaf command to fix issue #103 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
