### PR TITLE
Modified convertedToSnakeCase to match the Xcode behaviour

### DIFF
--- a/Sources/ArgumentParser/Utilities/StringExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/StringExtensions.swift
@@ -97,20 +97,25 @@ extension String {
     var result = ""
     // Whether we should append a separator when we see a uppercase character.
     var separateOnUppercase = true
+    var justGotLastDigit = false
     for index in indices {
       let nextIndex = self.index(after: index)
       let character = self[index]
-      if character.isUppercase {
-        if separateOnUppercase && !result.isEmpty {
+      if justGotLastDigit && character != separator {
+        result += "\(separator)"
+      }
+      if character.isUppercase || character.isNumber {
+        if !justGotLastDigit && separateOnUppercase && !result.isEmpty {
           // Append the separator.
           result += "\(separator)"
         }
         // If the next character is uppercase and the next-next character is lowercase, like "L" in "URLSession", we should separate words.
-        separateOnUppercase = nextIndex < endIndex && self[nextIndex].isUppercase && self.index(after: nextIndex) < endIndex && self[self.index(after: nextIndex)].isLowercase
+        separateOnUppercase = nextIndex < endIndex && ((self[nextIndex].isUppercase && self.index(after: nextIndex) < endIndex && self[self.index(after: nextIndex)].isLowercase) || (!character.isNumber && self[nextIndex].isNumber))
       } else {
         // If the character is `separator`, we do not want to append another separator when we see the next uppercase character.
         separateOnUppercase = character != separator
       }
+      justGotLastDigit = character.isNumber && nextIndex < endIndex && !self[nextIndex].isNumber
       // Append the lowercased character.
       result += character.lowercased()
     }

--- a/Tests/ArgumentParserUnitTests/StringSnakeCaseTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringSnakeCaseTests.swift
@@ -25,14 +25,16 @@ extension StringSnakeCaseTests {
       ("", ""), // don't die on empty string
       ("a", "a"), // single character
       ("aA", "a_a"), // two characters
-      ("version4Thing", "version4_thing"), // numerics
+      ("version4Thing", "version_4_thing"), // numerics
       ("partCAPS", "part_caps"), // only insert underscore before first all caps
       ("partCAPSLowerAGAIN", "part_caps_lower_again"), // switch back and forth caps.
       ("manyWordsInThisThing", "many_words_in_this_thing"), // simple lowercase + underscore + more
       ("asdfĆqer", "asdf_ćqer"),
       ("already_snake_case", "already_snake_case"),
-      ("dataPoint22", "data_point22"),
-      ("dataPoint22Word", "data_point22_word"),
+      ("dataPoint22", "data_point_22"),
+      ("dataPoint22Word", "data_point_22_word"),
+      ("svg2png", "svg_2_png"),
+      ("PDF2Text", "pdf_2_text"),
       ("_oneTwoThree", "_one_two_three"),
       ("oneTwoThree_", "one_two_three_"),
       ("__oneTwoThree", "__one_two_three"),
@@ -67,14 +69,16 @@ extension StringSnakeCaseTests {
       ("", ""), // don't die on empty string
       ("a", "a"), // single character
       ("aA", "a-a"), // two characters
-      ("version4Thing", "version4-thing"), // numerics
+      ("version4Thing", "version-4-thing"), // numerics
       ("partCAPS", "part-caps"), // only insert underscore before first all caps
       ("partCAPSLowerAGAIN", "part-caps-lower-again"), // switch back and forth caps.
       ("manyWordsInThisThing", "many-words-in-this-thing"), // simple lowercase + underscore + more
       ("asdfĆqer", "asdf-ćqer"),
       ("already_snake_case", "already_snake_case"),
-      ("dataPoint22", "data-point22"),
-      ("dataPoint22Word", "data-point22-word"),
+      ("dataPoint22", "data-point-22"),
+      ("dataPoint22Word", "data-point-22-word"),
+      ("svg2png", "svg-2-png"),
+      ("PDF2Text", "pdf-2-text"),
       ("_oneTwoThree", "_one-two-three"),
       ("oneTwoThree_", "one-two-three_"),
       ("__oneTwoThree", "__one-two-three"),


### PR DESCRIPTION
There is no unanimous agreement on the _right_ way to treat numbers while converting to snake cases.

`”PDF2Text".convertedToSnakeCase` could have been giving `pdf2text`, `pdf2_text` or `pdf_2_text`.

Today, the second option is used but, arguably, according to the development tools on the Mac platform, the last option seems to be more natural.

Indeed, when increasing, sub-word by sub-word, the selection of this camelCased formatted identifier (1), Xcode will detect 3 parts : `PDF`, `2` and `Text` — hence this modification proposal.

(1) check by placing the caret at the beginning of the identifier and, holding down the alternate and shift keys simultaneously, press the right arrow key.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
