### PR TITLE
Parse from environment

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -145,7 +145,7 @@ extension Argument {
   ) {
     self.init(_parsedValue: .init { key in
       let help = ArgumentDefinition.Help(options: [], help: help, key: key)
-      let arg = ArgumentDefinition(kind: .positional, help: help, update: .unary({
+      let arg = ArgumentDefinition(kind: .positional, environmentNames: [], help: help, update: .unary({
         (origin, _, valueString, parsedValues) in
         parsedValues.set(try transform(valueString), forKey: key, inputOrigin: origin)
       }), initial: { origin, values in
@@ -175,14 +175,15 @@ extension Argument {
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
       let arg = ArgumentDefinition(
         kind: .positional,
+        environmentNames: [],
         help: help,
         parsingStrategy: parsingStrategy == .remaining ? .nextAsValue : .allRemainingInput,
         update: .appendToArray(forType: Element.self, key: key),
         initial: { origin, values in
           values.set([], forKey: key, inputOrigin: origin)
-        })
+      })
       return ArgumentSet(alternatives: [arg])
-    })
+      })
   }
   
   /// Creates a property that reads an array from zero or more arguments,
@@ -207,6 +208,7 @@ extension Argument {
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
       let arg = ArgumentDefinition(
         kind: .positional,
+        environmentNames: [],
         help: help,
         parsingStrategy: parsingStrategy == .remaining ? .nextAsValue : .allRemainingInput,
         update: .unary({

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -140,7 +140,7 @@ extension Flag where Value == Optional<Bool> {
   ) {
     self.init(_parsedValue: .init { key in
       .flag(key: key, name: name, default: nil, inversion: inversion, exclusivity: exclusivity, help: help)
-    })
+      })
   }
 }
 
@@ -245,14 +245,14 @@ extension Flag where Value: CaseIterable, Value: Equatable, Value: RawRepresenta
     self.init(_parsedValue: .init { key in
       // This gets flipped to `true` the first time one of these flags is
       // encountered.
-      var hasUpdated = false
+      var didUpdate = false
       let defaultValue = initial.map(String.init(describing:))
 
       let args = Value.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
         let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, defaultValue: defaultValue, key: key)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
-          hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
+          didUpdate = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, didUpdate: didUpdate, exclusivity: exclusivity)
         }))
       }
       return exclusivity == .exclusive
@@ -281,13 +281,13 @@ extension Flag {
     self.init(_parsedValue: .init { key in
       // This gets flipped to `true` the first time one of these flags is
       // encountered.
-      var hasUpdated = false
+      var didUpdate = false
       
       let args = Element.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
         let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
         return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
-          hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
+          didUpdate = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, didUpdate: didUpdate, exclusivity: exclusivity)
         }))
       }
       return exclusivity == .exclusive
@@ -326,7 +326,7 @@ extension Flag {
 
 extension ArgumentDefinition {
   static func flag<V>(name: NameSpecification, key: InputKey, caseKey: InputKey, help: Help, parsingStrategy: ArgumentDefinition.ParsingStrategy, initialValue: V?, update: Update) -> ArgumentDefinition {
-    return ArgumentDefinition(kind: .name(key: caseKey, specification: name), help: help, parsingStrategy: parsingStrategy, update: update, initial: { origin, values in
+    return ArgumentDefinition(kind: .name(key: caseKey, specification: name), environmentNames: name.makeEnvironmentNames(caseKey), help: help, parsingStrategy: parsingStrategy, update: update, initial: { origin, values in
       if let initial = initialValue {
         values.set(initial, forKey: key, inputOrigin: origin)
       }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -238,7 +238,7 @@ extension Option {
     self.init(_parsedValue: .init { key in
       let kind = ArgumentDefinition.Kind.name(key: key, specification: name)
       let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, key: key)
-      var arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
+      var arg = ArgumentDefinition(kind: kind, environmentNames: name.makeEnvironmentNames(key), help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
         (origin, _, valueString, parsedValues) in
         parsedValues.set(try transform(valueString), forKey: key, inputOrigin: origin)
       }), initial: { origin, values in
@@ -269,7 +269,7 @@ extension Option {
     self.init(_parsedValue: .init { key in
       let kind = ArgumentDefinition.Kind.name(key: key, specification: name)
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
-      let arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .appendToArray(forType: Element.self, key: key), initial: { origin, values in
+      let arg = ArgumentDefinition(kind: kind, environmentNames: name.makeEnvironmentNames(key), help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .appendToArray(forType: Element.self, key: key), initial: { origin, values in
         values.set([], forKey: key, inputOrigin: origin)
       })
       return ArgumentSet(alternatives: [arg])
@@ -297,7 +297,7 @@ extension Option {
     self.init(_parsedValue: .init { key in
       let kind = ArgumentDefinition.Kind.name(key: key, specification: name)
       let help = ArgumentDefinition.Help(options: [.isOptional, .isRepeating], help: help, key: key)
-      let arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
+      let arg = ArgumentDefinition(kind: kind, environmentNames: name.makeEnvironmentNames(key), help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .unary({
         (origin, name, valueString, parsedValues) in
         let element = try transform(valueString)
         parsedValues.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -83,10 +83,11 @@ extension ParsableArguments {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   /// - Returns: A new instance of this type.
   public static func parse(
-    _ arguments: [String]? = nil
+    _ arguments: [String]? = nil,
+    environment: [String: String]? = nil
   ) throws -> Self {
     // Parse the command and unwrap the result if necessary.
-    switch try self.asCommand.parseAsRoot(arguments) {
+    switch try self.asCommand.parseAsRoot(arguments, environment: environment) {
     case is HelpCommand:
       throw ParserError.helpRequested
     case let result as _WrappedParsableCommand<Self>:

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -54,14 +54,19 @@ extension ParsableCommand {
   ///
   /// - Parameter arguments: An array of arguments to use for parsing. If
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
+  /// - Parameter environment: Environment variables to use for parsing. if
+  ///   `environment` is `nil`, this will use the current environment variables.
+  ///   Some values may specify that they can be read from the environment, in
+  ///   which case they will be read from this dictionary.
   /// - Returns: A new instance of this type, one of its subcommands, or a
   ///   command type internal to the `ArgumentParser` library.
   public static func parseAsRoot(
-    _ arguments: [String]? = nil
+    _ arguments: [String]? = nil,
+    environment: [String: String]? = nil
   ) throws -> ParsableCommand {
     var parser = CommandParser(self)
-    let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
-    var result = try parser.parse(arguments: arguments).get()
+    let input = OriginalInput(arguments: arguments, environment: environment)
+    var result = try parser.parse(originalInput: input).get()
     do {
       try result.validate()
     } catch {
@@ -78,9 +83,12 @@ extension ParsableCommand {
   ///
   /// - Parameter arguments: An array of arguments to use for parsing. If
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
-  public static func main(_ arguments: [String]? = nil) -> Never {
+  public static func main(
+    _ arguments: [String]? = nil,
+    environment: [String: String]? = nil
+  ) -> Never {
     do {
-      let command = try parseAsRoot(arguments)
+      let command = try parseAsRoot(arguments, environment: environment)
       try command.run()
       exit()
     } catch {

--- a/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
@@ -41,6 +41,9 @@ final class ArgumentDecoder: Decoder {
   }
   
   let values: ParsedValues
+  var environment: [EnvironmentName: String] {
+    return values.originalInput.environment
+  }
   var usedOrigins: InputOrigin
   var nextCommandIndex = 0
   var previouslyDecoded: [DecodedArguments] = []

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -64,6 +64,7 @@ struct ArgumentDefinition {
   }
   
   var kind: Kind
+  var environmentVariableNames: [EnvironmentName]
   var help: Help
   var parsingStrategy: ParsingStrategy
   var update: Update
@@ -83,12 +84,13 @@ struct ArgumentDefinition {
       ?? "value"
   }
   
-  init(kind: Kind, help: Help, parsingStrategy: ParsingStrategy = .nextAsValue, update: Update, initial: @escaping Initial = { _, _ in }) {
+  init(kind: Kind, environmentNames: [EnvironmentName], help: Help, parsingStrategy: ParsingStrategy = .nextAsValue, update: Update, initial: @escaping Initial = { _, _ in }) {
     if case (.positional, .nullary) = (kind, update) {
       preconditionFailure("Can't create a nullary positional argument.")
     }
     
     self.kind = kind
+    self.environmentVariableNames = environmentNames
     self.help = help
     self.parsingStrategy = parsingStrategy
     self.update = update

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -54,7 +54,7 @@ extension CommandParser {
   fileprivate func consumeNextCommand(split: inout SplitArguments) -> Tree<ParsableCommand.Type>? {
     guard let (origin, element) = split.peekNext(),
       element.isValue,
-      let value = split.originalInput(at: origin),
+      let value = split.originalInput[completeIndex: origin],
       let subcommandNode = currentNode.firstChild(withName: value)
     else { return nil }
     _ = split.popNextValue()
@@ -92,7 +92,7 @@ extension CommandParser {
           throw ParserError.unknownOption(InputOrigin.Element.argumentIndex(index), argument.name)
         }
       }
-       
+
       let extra = split.coalescedExtraElements()
       throw ParserError.unexpectedExtraValues(extra)
     }
@@ -181,10 +181,10 @@ extension CommandParser {
   ///
   /// - Parameter arguments: The array of arguments to parse. This should not
   ///   include the command name as the first argument.
-  mutating func parse(arguments: [String]) -> Result<ParsableCommand, CommandError> {
+  mutating func parse(originalInput: OriginalInput) -> Result<ParsableCommand, CommandError> {
     var split: SplitArguments
     do {
-      split = try SplitArguments(arguments: arguments)
+      split = try SplitArguments(originalInput: originalInput)
     } catch let error as ParserError {
       return .failure(CommandError(commandStack: [commandTree.element], parserError: error))
     } catch {

--- a/Sources/ArgumentParser/Parsing/EnvironmentName.swift
+++ b/Sources/ArgumentParser/Parsing/EnvironmentName.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// An environment variable name
+///
+/// Wrapped as `RawRepresentable` for type safety.
+struct EnvironmentName: RawRepresentable, Hashable {
+  var rawValue: String
+}

--- a/Sources/ArgumentParser/Parsing/OriginalInput.swift
+++ b/Sources/ArgumentParser/Parsing/OriginalInput.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+struct OriginalInput {
+  var arguments: [String]
+  var environment: [EnvironmentName: String]
+}
+
+extension OriginalInput {
+  init(arguments: [String]?, environment: [String: String]?) {
+    self.arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
+    let env = environment ?? ProcessInfo.processInfo.environment
+    self.environment = Dictionary(uniqueKeysWithValues: env.map {
+      (EnvironmentName(rawValue: $0), $1)
+    })
+  }
+}
+
+extension OriginalInput {
+  subscript(_ origin: InputOrigin) -> String {
+    return origin.elements.map { self[$0] }.joined(separator: " ")
+  }
+
+  subscript(_ origin: InputOrigin.Element) -> String {
+    switch origin {
+    case .argumentIndex(let index):
+      return self[index]
+    case .environment(let name):
+      return environment[name] ?? "<empty>"
+    }
+  }
+
+  /// Returns the original input string at the given origin, or `nil` if
+  /// `origin` is a sub-index.
+  subscript(completeIndex origin: InputOrigin.Element) -> String? {
+    switch origin {
+    case .argumentIndex(let index):
+      guard case .complete = index.subIndex else { return nil }
+      return self[index]
+    case .environment(let name):
+      return environment[name] ?? "<empty>"
+    }
+  }
+
+  subscript(_ index: SplitArguments.Index) -> String {
+    return arguments[index.inputIndex.rawValue]
+  }
+}

--- a/Sources/ArgumentParser/Parsing/ParsedValues.swift
+++ b/Sources/ArgumentParser/Parsing/ParsedValues.swift
@@ -38,9 +38,7 @@ struct ParsedValues {
   var elements: [Element] = []
   
   /// This is the *original* array of arguments that this was parsed from.
-  ///
-  /// This is used for error output generation.
-  var originalInput: [String]
+  var originalInput: OriginalInput
 }
 
 enum LenientParsedValues {
@@ -65,7 +63,13 @@ extension ParsedValues {
       elements.append(element)
     }
   }
-  
+
+  /// Adds the given input origin to any existing element.
+  mutating func add(inputOrigin: InputOrigin, for key: InputKey) {
+    guard let index = elements.firstIndex(where: { $0.key == key }) else { return }
+    elements[index].inputOrigin.formUnion(inputOrigin)
+  }
+
   func element(forKey key: InputKey) -> Element? {
     return elements.first(where: { $0.key == key })
   }

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -22,7 +22,7 @@ enum ParserError: Error {
   case missingValueForOption(InputOrigin, Name)
   case unexpectedValueForOption(InputOrigin.Element, Name, String)
   case unexpectedExtraValues([(InputOrigin, String)])
-  case duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin, originalInput: [String])
+  case duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin, originalInput: OriginalInput)
   /// We need a value for the given key, but it’s not there. Some non-optional option or argument is missing.
   case noValue(forKey: InputKey)
   case unableToParseValue(InputOrigin, Name?, String, forKey: InputKey)

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -193,8 +193,8 @@ extension ErrorMessageGenerator {
       return unexpectedValueForOptionMessage(origin: o, name: n, value: v)
     case .unexpectedExtraValues(let v):
       return unexpectedExtraValuesMessage(values: v)
-    case .duplicateExclusiveValues(previous: let previous, duplicate: let duplicate, originalInput: let arguments):
-      return duplicateExclusiveValues(previous: previous, duplicate: duplicate, arguments: arguments)
+    case .duplicateExclusiveValues(previous: let previous, duplicate: let duplicate, originalInput: let originalInput):
+      return duplicateExclusiveValues(previous: previous, duplicate: duplicate, originalInput: originalInput)
     case .noValue(forKey: let k):
       return noValueMessage(key: k)
     case .unableToParseValue(let o, let n, let v, forKey: let k):
@@ -275,7 +275,7 @@ extension ErrorMessageGenerator {
       })
     
     if let suggestion = suggestion {
-        return "Unknown option '\(name.synopsisString)'. Did you mean '\(suggestion.synopsisString)'?"
+      return "Unknown option '\(name.synopsisString)'. Did you mean '\(suggestion.synopsisString)'?"
     }
     return "Unknown option '\(name.synopsisString)'"
   }
@@ -304,11 +304,10 @@ extension ErrorMessageGenerator {
     }
   }
   
-  func duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin, arguments: [String]) -> String? {
-    func elementString(_ origin: InputOrigin, _ arguments: [String]) -> String? {
-      guard case .argumentIndex(let split) = origin.elements.first else { return nil }
-      var argument = "\'\(arguments[split.inputIndex.rawValue])\'"
-      if case let .sub(offsetIndex) = split.subIndex {
+  func duplicateExclusiveValues(previous: InputOrigin, duplicate: InputOrigin, originalInput: OriginalInput) -> String? {
+    func elementString(_ origin: InputOrigin) -> String? {
+      var argument = "\'\(originalInput[origin])\'"
+      if case .argumentIndex(let split) = origin.elements.first, case .sub(let offsetIndex) = split.subIndex {
         let stringIndex = argument.index(argument.startIndex, offsetBy: offsetIndex+2)
         argument = "\'\(argument[stringIndex])\' in \(argument)"
       }
@@ -316,8 +315,8 @@ extension ErrorMessageGenerator {
     }
 
     // Note that the RHS of these coalescing operators cannot be reached at this time.
-    let dupeString = elementString(duplicate, arguments) ?? "position \(duplicate)"
-    let origString = elementString(previous, arguments) ?? "position \(previous)"
+    let dupeString = elementString(duplicate) ?? "position \(duplicate)"
+    let origString = elementString(previous) ?? "position \(previous)"
 
     //TODO: review this message once environment values are supported.
     return "Value to be set with \(dupeString) had already been set with \(origString)"

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -57,9 +57,9 @@ public func AssertResultFailure<T, U: Error>(
   }
 }
 
-public func AssertErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
+public func AssertErrorMessage<A>(_ type: A.Type, _ arguments: [String], environment: [String: String] = [:], _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
   do {
-    _ = try A.parse(arguments)
+    _ = try A.parse(arguments, environment: environment)
     XCTFail("Parsing should have failed.", file: file, line: line)
   } catch {
     // We expect to hit this path, i.e. getting an error:
@@ -67,9 +67,9 @@ public func AssertErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ error
   }
 }
 
-public func AssertFullErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
+public func AssertFullErrorMessage<A>(_ type: A.Type, _ arguments: [String], environment: [String: String] = [:], _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
   do {
-    _ = try A.parse(arguments)
+    _ = try A.parse(arguments, environment: environment)
     XCTFail("Parsing should have failed.", file: file, line: line)
   } catch {
     // We expect to hit this path, i.e. getting an error:
@@ -77,9 +77,9 @@ public func AssertFullErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ e
   }
 }
 
-public func AssertParse<A>(_ type: A.Type, _ arguments: [String], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) where A: ParsableArguments {
+public func AssertParse<A>(_ type: A.Type, _ arguments: [String], environment: [String: String] = [:], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) where A: ParsableArguments {
   do {
-    let parsed = try type.parse(arguments)
+    let parsed = try type.parse(arguments, environment: environment)
     try closure(parsed)
   } catch {
     let message = type.message(for: error)
@@ -87,9 +87,9 @@ public func AssertParse<A>(_ type: A.Type, _ arguments: [String], file: StaticSt
   }
 }
 
-public func AssertParseCommand<A: ParsableCommand>(_ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) {
+public func AssertParseCommand<A: ParsableCommand>(_ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String], environment: [String: String] = [:], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) {
   do {
-    let command = try rootCommand.parseAsRoot(arguments)
+    let command = try rootCommand.parseAsRoot(arguments, environment: environment)
     guard let aCommand = command as? A else {
       XCTFail("Command is of unexpected type: \(command)", file: file, line: line)
       return

--- a/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
@@ -206,3 +206,66 @@ extension OptionalEndToEndTests {
     XCTAssertThrowsError(try Bar.parse(["-f", "--name", "A"]))
   }
 }
+
+// MARK: -
+
+fileprivate struct Baz: ParsableArguments {
+  enum Format: String, ExpressibleByArgument {
+    case A
+    case B
+    case C
+  }
+  @Option(name: [.environment, .long]) var name: String?
+  @Option(name: [.environment, .long]) var format: Format?
+  @Option(name: [.environment, .long]) var foo: String
+}
+
+extension OptionalEndToEndTests {
+  func testParsingWithAllValuesFromEnvironment() {
+    AssertParse(Baz.self, [], environment: ["NAME": "A", "FORMAT": "B", "FOO": "C"]) { bar in
+      XCTAssertEqual(bar.name, "A")
+      XCTAssertEqual(bar.format, .B)
+      XCTAssertEqual(bar.foo, "C")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_1() {
+    AssertParse(Baz.self, [], environment: ["NAME": "A", "FORMAT": "B", "FOO": "C"]) { bar in
+      XCTAssertEqual(bar.name, "A")
+      XCTAssertEqual(bar.format, .B)
+      XCTAssertEqual(bar.foo, "C")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_2() {
+    AssertParse(Baz.self, ["--format", "B"], environment: ["NAME": "A", "FOO": "C"]) { bar in
+      XCTAssertEqual(bar.name, "A")
+      XCTAssertEqual(bar.format, .B)
+      XCTAssertEqual(bar.foo, "C")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_3() {
+    AssertParse(Baz.self, ["--name", "A", "--foo", "C"], environment: ["FORMAT": "B"]) { bar in
+      XCTAssertEqual(bar.name, "A")
+      XCTAssertEqual(bar.format, .B)
+      XCTAssertEqual(bar.foo, "C")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_4() {
+    AssertParse(Baz.self, ["--name", "AA", "--foo", "CC", "--format", "A"], environment: ["FORMAT": "B"]) { bar in
+      XCTAssertEqual(bar.name, "AA")
+      XCTAssertEqual(bar.format, .A)
+      XCTAssertEqual(bar.foo, "CC")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_5() {
+    AssertParse(Baz.self, ["--name", "AA", "--foo", "CC", "--format", "A"], environment: ["NAME": "A", "FORMAT": "B", "FOO": "C"]) { bar in
+      XCTAssertEqual(bar.name, "AA")
+      XCTAssertEqual(bar.format, .A)
+      XCTAssertEqual(bar.foo, "CC")
+    }
+  }
+}

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -274,6 +274,24 @@ extension RepeatingEndToEndTests {
 
 // MARK: -
 
+fileprivate struct Ozz: ParsableArguments {
+  @Option(name: [.long, .environment], parsing: .upToNextOption) var names: [String]
+}
+
+extension RepeatingEndToEndTests {
+  func testParsingFromEnvironment() {
+    AssertParse(Ozz.self, [], environment: ["NAMES": "A"]) { ozz in
+      XCTAssertEqual(ozz.names, ["A"])
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments() {
+    AssertParse(Ozz.self, ["--names", "A", "B"], environment: ["NAMES": "C"]) { ozz in
+      XCTAssertEqual(ozz.names, ["A", "B"])
+    }
+  }
+}
+
 fileprivate struct Weazle: ParsableArguments {
   @Flag() var verbose: Bool
   @Argument() var names: [String]

--- a/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
@@ -115,3 +115,43 @@ extension SimpleEndToEndTests {
     XCTAssertThrowsError(try Baz.parse(["--name", "--format", "Bar", "Foo"]))
   }
 }
+
+// MARK: Environment Variables
+
+fileprivate struct Qux: ParsableArguments {
+  @Option(name: [.environment])
+  var name: String
+}
+
+fileprivate struct Qux2: ParsableArguments {
+  @Option(name: [.environment, .long])
+  var name: String
+}
+
+extension SimpleEndToEndTests {
+  func testParsingFromEnvironment_1() {
+    XCTAssertThrowsError(try Qux.parse(["--name", "Bar"], environment: [:]))
+  }
+
+  func testParsingFromEnvironment_2() {
+    AssertParse(Qux.self, [], environment: ["NAME": "Bar"]) { qux in
+      XCTAssertEqual(qux.name, "Bar")
+    }
+  }
+
+  func testParsingFromEnvironment_3() {
+    AssertParse(Qux2.self, [], environment: ["NAME": "Bar"]) { qux in
+      XCTAssertEqual(qux.name, "Bar")
+    }
+  }
+
+  func testParsingFromEnvironmentAndArguments_1() {
+    XCTAssertThrowsError(try Qux.parse(["--name", "Bar"], environment: ["NAME": "bar"]))
+  }
+
+  func testParsingFromEnvironmentAndArguments_2() {
+    AssertParse(Qux2.self, ["--name", "foo"], environment: ["NAME": "bar"]) { qux in
+      XCTAssertEqual(qux.name, "foo")
+    }
+  }
+}

--- a/Tests/ArgumentParserUnitTests/NameSpecificationTests.swift
+++ b/Tests/ArgumentParserUnitTests/NameSpecificationTests.swift
@@ -47,6 +47,11 @@ fileprivate func Assert(nameSpecification: NameSpecification, key: String, makeN
   Assert(names: names, expected: expected, file: file, line: line)
 }
 
+fileprivate func Assert(nameSpecification: NameSpecification, key: String, makeEnvironmentNames expected: [EnvironmentName], file: StaticString = #file, line: UInt = #line) {
+    let names = nameSpecification.makeEnvironmentNames(InputKey(rawValue: key))
+    Assert(names: names, expected: expected, file: file, line: line)
+}
+
 fileprivate func Assert<N>(names: [N], expected: [N], file: StaticString = #file, line: UInt = #line) where N: Equatable {
   names.forEach {
     XCTAssert(expected.contains($0), "Unexpected name '\($0)'.", file: file, line: line)
@@ -59,22 +64,46 @@ fileprivate func Assert<N>(names: [N], expected: [N], file: StaticString = #file
 extension NameSpecificationTests {
   func testMakeNames_short() {
     Assert(nameSpecification: .short, key: "foo", makeNames: [.short("f")])
+    Assert(nameSpecification: .short, key: "foo", makeEnvironmentNames: [])
   }
   
   func testMakeNames_Long() {
     Assert(nameSpecification: .long, key: "fooBarBaz", makeNames: [.long("foo-bar-baz")])
+    Assert(nameSpecification: .long, key: "fooBarBaz", makeEnvironmentNames: [])
     Assert(nameSpecification: .long, key: "fooURLForBarBaz", makeNames: [.long("foo-url-for-bar-baz")])
+    Assert(nameSpecification: .long, key: "fooURLForBarBaz", makeEnvironmentNames: [])
   }
   
   func testMakeNames_customLong() {
     Assert(nameSpecification: .customLong("bar"), key: "foo", makeNames: [.long("bar")])
+    Assert(nameSpecification: .customLong("bar"), key: "foo", makeEnvironmentNames: [])
   }
   
   func testMakeNames_customShort() {
     Assert(nameSpecification: .customShort("v"), key: "foo", makeNames: [.short("v")])
+    Assert(nameSpecification: .customShort("v"), key: "foo", makeEnvironmentNames: [])
   }
   
   func testMakeNames_customLongWithSingleDash() {
     Assert(nameSpecification: .customLong("baz", withSingleDash: true), key: "foo", makeNames: [.longWithSingleDash("baz")])
+    Assert(nameSpecification: .customLong("baz", withSingleDash: true), key: "foo", makeEnvironmentNames: [])
+  }
+
+  func testMakeNames_environment() {
+    Assert(nameSpecification: [.environment], key: "foo", makeNames: [])
+    Assert(nameSpecification: [.environment], key: "foo", makeEnvironmentNames: [EnvironmentName(rawValue: "FOO")])
+
+    Assert(nameSpecification: [.environment], key: "fooBar", makeNames: [])
+    Assert(nameSpecification: [.environment], key: "fooBar", makeEnvironmentNames: [EnvironmentName(rawValue: "FOO_BAR")])
+  }
+
+  func testMakeNames_customnEnvironment() {
+    Assert(nameSpecification: [.customEnvironment("bar")], key: "foo", makeNames: [])
+    Assert(nameSpecification: [.customEnvironment("bar")], key: "foo", makeEnvironmentNames: [EnvironmentName(rawValue: "bar")])
+  }
+
+  func testMakeNames_mixed() {
+    Assert(nameSpecification: [.long, .short, .environment], key: "foo", makeNames: [.long("foo"), .short("f")])
+    Assert(nameSpecification: [.long, .short, .environment], key: "foo", makeEnvironmentNames: [EnvironmentName(rawValue: "FOO")])
   }
 }

--- a/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
@@ -13,6 +13,13 @@ import XCTest
 @testable import ArgumentParser
 import ArgumentParserTestHelpers
 
+extension SplitArguments {
+    fileprivate init(arguments: [String], environment: [String: String] = [:]) throws {
+        let input = OriginalInput(arguments: arguments, environment: environment)
+        try self.init(originalInput: input)
+    }
+}
+
 extension SplitArguments.InputIndex: ExpressibleByIntegerLiteral {
   public init(integerLiteral value: Int) {
     self.init(rawValue: value)
@@ -46,7 +53,7 @@ final class SplitArgumentTests: XCTestCase {
   func testEmpty() throws {
     let sut = try SplitArguments(arguments: [])
     XCTAssertEqual(sut.elements.count, 0)
-    XCTAssertEqual(sut.originalInput.count, 0)
+    XCTAssertEqual(sut.originalInput.arguments.count, 0)
   }
   
   func testSingleValue() throws {
@@ -56,8 +63,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
     AssertElementEqual(sut, at: 0, .value("abc"))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["abc"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["abc"])
   }
   
   func testSingleLongOption() throws {
@@ -67,8 +74,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
     AssertElementEqual(sut, at: 0, .option(.name(.long("abc"))))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["--abc"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["--abc"])
   }
   
   func testSingleShortOption() throws {
@@ -78,8 +85,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
     AssertElementEqual(sut, at: 0, .option(.name(.short("a"))))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["-a"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["-a"])
   }
   
   func testSingleLongOptionWithValue() throws {
@@ -89,8 +96,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
     AssertElementEqual(sut, at: 0, .option(.nameWithValue(.long("abc"), "def")))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["--abc=def"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["--abc=def"])
   }
   
   func testMultipleShortOptionsCombined() throws {
@@ -110,8 +117,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 3, inputIndex: 0, subIndex: .sub(2))
     AssertElementEqual(sut, at: 3, .option(.name(.short("c"))))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["-abc"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["-abc"])
   }
   
   func testSingleLongOptionWithValueAndSingleDash() throws {
@@ -122,8 +129,8 @@ final class SplitArgumentTests: XCTestCase {
     AssertIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
     AssertElementEqual(sut, at: 0, .option(.nameWithValue(.longWithSingleDash("abc"), "def")))
     
-    XCTAssertEqual(sut.originalInput.count, 1)
-    XCTAssertEqual(sut.originalInput, ["-abc=def"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 1)
+    XCTAssertEqual(sut.originalInput.arguments, ["-abc=def"])
   }
 }
 
@@ -142,8 +149,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .value("1234"))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["abc", "x", "1234"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["abc", "x", "1234"])
   }
   
   func testMultipleLongOptions() throws {
@@ -160,8 +167,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .option(.name(.long("abc-def"))))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["--d", "--1", "--abc-def"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["--d", "--1", "--abc-def"])
   }
   
   func testMultipleShortOptions() throws {
@@ -178,8 +185,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .option(.name(.short("z"))))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["-x", "-y", "-z"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["-x", "-y", "-z"])
   }
   
   func testMultipleShortOptionsCombined_2() throws {
@@ -208,8 +215,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 6, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 6, .option(.name(.short("a"))))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["-bc", "-fv", "-a"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["-bc", "-fv", "-a"])
   }
 }
 
@@ -240,8 +247,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 6, inputIndex: 4, subIndex: .sub(1))
     AssertElementEqual(sut, at: 6, .option(.name(.short("z"))))
     
-    XCTAssertEqual(sut.originalInput.count, 5)
-    XCTAssertEqual(sut.originalInput, ["-x", "abc", "--foo", "1234", "-zz"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 5)
+    XCTAssertEqual(sut.originalInput.arguments, ["-x", "abc", "--foo", "1234", "-zz"])
   }
   
   func testMixed_2() throws {
@@ -270,8 +277,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 6, inputIndex: 4, subIndex: .complete)
     AssertElementEqual(sut, at: 6, .option(.name(.long("foo"))))
     
-    XCTAssertEqual(sut.originalInput.count, 5)
-    XCTAssertEqual(sut.originalInput, ["1234", "-zz", "abc", "-x", "--foo"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 5)
+    XCTAssertEqual(sut.originalInput.arguments, ["1234", "-zz", "abc", "-x", "--foo"])
   }
   
   func testTerminator_1() throws {
@@ -288,8 +295,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .value("--bar"))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["--foo", "--", "--bar"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["--foo", "--", "--bar"])
   }
   
   func testTerminator_2() throws {
@@ -306,8 +313,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .value("bar"))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["--foo", "--", "bar"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["--foo", "--", "bar"])
   }
   
   func testTerminator_3() throws {
@@ -324,8 +331,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 2, inputIndex: 2, subIndex: .complete)
     AssertElementEqual(sut, at: 2, .value("--bar=baz"))
     
-    XCTAssertEqual(sut.originalInput.count, 3)
-    XCTAssertEqual(sut.originalInput, ["--foo", "--", "--bar=baz"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 3)
+    XCTAssertEqual(sut.originalInput.arguments, ["--foo", "--", "--bar=baz"])
   }
   
   func testTerminatorAtTheEnd() throws {
@@ -339,8 +346,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 1, inputIndex: 1, subIndex: .complete)
     AssertElementEqual(sut, at: 1, .terminator)
     
-    XCTAssertEqual(sut.originalInput.count, 2)
-    XCTAssertEqual(sut.originalInput, ["--foo", "--"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 2)
+    XCTAssertEqual(sut.originalInput.arguments, ["--foo", "--"])
   }
   
   func testTerminatorAtTheBeginning() throws {
@@ -354,8 +361,8 @@ extension SplitArgumentTests {
     AssertIndexEqual(sut, at: 1, inputIndex: 1, subIndex: .complete)
     AssertElementEqual(sut, at: 1, .value("--foo"))
     
-    XCTAssertEqual(sut.originalInput.count, 2)
-    XCTAssertEqual(sut.originalInput, ["--", "--foo"])
+    XCTAssertEqual(sut.originalInput.arguments.count, 2)
+    XCTAssertEqual(sut.originalInput.arguments, ["--", "--foo"])
   }
 }
 


### PR DESCRIPTION
### Description

This allows reading values for `@Option` and `Flag` from environment variables.

I started work on this before this repo was open sourced, and it was requested as #4

### Detailed Design

Flags can now be specified as
```swift
@Flag(name: [.environment, .long])
```
and similarly options as
```swift
@Option(name: [.environment, .long])
```

There are two new `NameSpecification` to support this:
```swift
    /// Read the value from an environment variable. The name is using the `THE_QUICK_BROWN_FOX` style.
    case environment
    
    /// Read the value from an environment variable with the specified name/
    case customEnvironment(String)
```

As one would expect, `.environment` picks a auto-genreated name based on on the flag / option name, similar to how for command line names are generated. But for environment variables, the generated strings are using the `THE_QUICK_BROWN_FOX` style.

TODO: I’d like to prefix the executable name to the auto-generated environment variable names. Need to funnel that through.

#### Example

If we have
```swift
enum Shape: String, CaseIterable {
  case round
  case square
  case oblong
}

struct Options: ParsableArguments {
  @Flag(name: [.environment, .long])
  var shape: Shape?
}
```
we can set an environment variable `ROUND` to make `shape = .round` — similar to the command line argument `--round`.

For options if we have
```swift
struct Options: ParsableArguments {
  @Option(name: [.environment, .long]) var name: String?
}
```
we can set the environment variable `NAME` to `Daniel`, and `name = "Daniel` — similar to the command line arguments `--name Daniel`.

#### Details

There’s a new `EnvironmentName` type that’s a `RawRepresentable` wrapping a `String` to give some type-safety. Environment variables get mapped to a `[EnvironmentName: String]`.

For flags and options that are exclusive, we still allow the command line to override any environment variables.

There’s a new `OriginalInput` type that’s using in a few places where we used to have a `[String]`. This would be the array of arguments passed to the executable. Now it’s type safe and holds both this array and the environment variables that are set. This cleans up the code in a few places.

The `InputOrigin` now can both represent an index into the arguments array or an environment variable name.

### Documentation Plan

TODO:
- [ ] update Documentation
- [ ] update the guide

### Test Plan

Updated the unit tests as applicable.

### Source Impact

Purely additional. Should not require any source changes by users.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
- [ ] Added code to prefix the executable name to environment variable names
