### PR TITLE
Print custom errors thrown from a `transform` closure

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -206,6 +206,8 @@ extension CommandParser {
       return .failure(error)
     } catch let error as ParserError {
       return .failure(CommandError(commandStack: commandStack, parserError: error))
+    } catch let error as ValidationError {
+      return .failure(CommandError(commandStack: commandStack, parserError: .userValidationError(error)))
     } catch is HelpRequested {
       return .success(HelpCommand(commandStack: commandStack))
     } catch {

--- a/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ArgumentParserTestHelpers
+import ArgumentParser
+
+final class TransformEndToEndTests: XCTestCase {
+}
+
+fileprivate struct Foo: ParsableArguments {
+
+    static var usageString: String = """
+    Usage: foo --string <int_str>
+    """
+    
+    @Option(help: ArgumentHelp("Convert string to integer", valueName: "int_str"),
+            transform: { try convert($0) })
+    var string: Int
+    
+    private static func convert(_ str: String) throws -> Int {
+        guard let converted = Int(argument: str) else { throw ValidationError("Could not convert to Int") }
+        return converted
+    }
+}
+
+extension TransformEndToEndTests {
+    func testTransform() throws {
+        AssertParse(Foo.self, ["--string", "42"]) { foo in
+            XCTAssertEqual(foo.string, 42)
+        }
+    }
+    
+    func testValidation_Fail() throws {
+        AssertFullErrorMessage(Foo.self, ["--string", "Forty Two"], "Error: Internal error. Invalid state while parsing command-line arguments.\n" + Foo.usageString)
+    }
+}

--- a/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
@@ -27,7 +27,7 @@ fileprivate struct Foo: ParsableArguments {
     var string: Int
     
     private static func convert(_ str: String) throws -> Int {
-        guard let converted = Int(argument: str) else { throw ValidationError("Could not convert to Int") }
+        guard let converted = Int(argument: str) else { throw ValidationError("Could not convert to Int.") }
         return converted
     }
 }
@@ -40,6 +40,6 @@ extension TransformEndToEndTests {
     }
     
     func testValidation_Fail() throws {
-        AssertFullErrorMessage(Foo.self, ["--string", "Forty Two"], "Error: Internal error. Invalid state while parsing command-line arguments.\n" + Foo.usageString)
+        AssertFullErrorMessage(Foo.self, ["--string", "Forty Two"], "Error: Could not convert to Int.\n" + Foo.usageString)
     }
 }


### PR DESCRIPTION
> This PR is probably incomplete, I just wanted some feedback that I was heading in the right direction before I spent any more time on it.

## Rational

If an argument property supplies a `transform` closure, like so,

```swift
@Option(help: "Some string input please.", transform: { try convert($0) })
var input: String
```

...and if the function `convert(...)` throws, this error should be printed to standard error, the same way throwing from `run()` or `validate()` does.

I raised this issue on the [Swift Forums](https://forums.swift.org/t/throwing-from-a-transform-closure/35137) and it was suggested by @natecook1000 this was a bug.

## Changes

1. I added a file called TransformEndToEndTests.swift that test simple cases of using `transform` closures with `@Option` properties. As far as I could tell there were no tests for `transform` closures.
2. I made a change to `parse(arguments: ...)` to catch any `ValidationError` and wrap it in a `ParserError.userValidationError`. The `ValidationError` is then printed as expected.
3. I updated the fail test to check for the `ValidationError` message.

## Before merging

1. Add tests (and implementation?) for `@Argument`
2. Discuss what errors can be thrown from a `transform` closure. Just `ValidationError` or should it support `CleanExit`, `ExitCode`?
3. Update documentation 

### Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
