### PR TITLE
Changed Readme notes about the ArgumentParser integration via SwiftPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,17 @@ use this dependency specification instead:
 Finally, include `"ArgumentParser"` as a dependency for your executable target:
 
 ```swift
-.product(name: "ArgumentParser", package: "swift-argument-parser"),
+let package = Package(
+    // name, platforms, products, etc.
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
+        // other dependencies
+    ],
+    targets: [
+        .target(name: "<command-line-tool>", dependencies: [
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        ]),
+        // other targets
+    ]
+)
 ```


### PR DESCRIPTION
The ArgumentParser dependency should be specified using the `target` block, not `product`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
