### PR TITLE
Unique argument names validator

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -192,10 +192,6 @@ struct ParsableArgumentsUniqueNamesValidator: ParsableArgumentsValidator {
   struct Error: Swift.Error, CustomStringConvertible {
     var duplicateNames: [String: Int] = [:]
 
-    var occurred: Bool {
-      !duplicateNames.isEmpty
-    }
-
     var description: String {
       duplicateNames.map { entry in
         "Multiple (\(entry.value)) `Option` or `Flag` arguments are named \"\(entry.key)\"."
@@ -230,15 +226,9 @@ struct ParsableArgumentsUniqueNamesValidator: ParsableArgumentsValidator {
       }
     }
 
-    var error = Error()
-
     let duplicateNames = countedNames.filter { $0.value > 1 }
     if !duplicateNames.isEmpty {
-      error.duplicateNames = duplicateNames
-    }
-
-    if error.occurred {
-      throw error
+      throw Error(duplicateNames: duplicateNames)
     }
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -30,7 +30,7 @@ extension ParsableArguments {
     let validators: [ParsableArgumentsValidator.Type] = [
       PositionalArgumentsValidator.self,
       ParsableArgumentsCodingKeyValidator.self,
-      ParsableArgumentsUniqueNamesValidator.self
+      ParsableArgumentsUniqueNamesValidator.self,
     ]
     let errors: [Error] = validators.compactMap { validator in
       do {

--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -29,7 +29,8 @@ extension ParsableArguments {
   static func _validate() throws {
     let validators: [ParsableArgumentsValidator.Type] = [
       PositionalArgumentsValidator.self,
-      ParsableArgumentsCodingKeyValidator.self
+      ParsableArgumentsCodingKeyValidator.self,
+      ParsableArgumentsUniqueNamesValidator.self
     ]
     let errors: [Error] = validators.compactMap { validator in
       do {
@@ -182,6 +183,66 @@ struct ParsableArgumentsCodingKeyValidator: ParsableArgumentsValidator {
       }
     } catch {
       fatalError("Unexpected validation error: \(error)")
+    }
+  }
+}
+
+/// Ensure argument names are unique within a `ParsableArguments` or `ParsableCommand`.
+struct ParsableArgumentsUniqueNamesValidator: ParsableArgumentsValidator {
+  struct Error: Swift.Error, CustomStringConvertible {
+    var duplicateNames: [String: Int] = [:]
+
+    var occurred: Bool {
+      !duplicateNames.isEmpty
+    }
+
+    var description: String {
+      var description = duplicateNames.reduce(into: "") { description, entry in
+        description += "Multiple (\(entry.value)) `Option` or `Flag` arguments are named \"\(entry.key)\".\n"
+      }
+      if description.last == "\n" {
+        description.removeLast()
+      }
+      return description
+    }
+  }
+
+  static func validate(_ type: ParsableArguments.Type) throws {
+    let argSets: [ArgumentSet] = Mirror(reflecting: type.init())
+      .children
+      .compactMap { child in
+        guard
+          var codingKey = child.label,
+          let parsed = child.value as? ArgumentSetProvider
+          else { return nil }
+
+        // Property wrappers have underscore-prefixed names
+        codingKey = String(codingKey.first == "_" ? codingKey.dropFirst(1) : codingKey.dropFirst(0))
+
+        let key = InputKey(rawValue: codingKey)
+        return parsed.argumentSet(for: key)
+    }
+
+    let countedNames: [String: Int] = argSets.reduce(into: [:]) { countedNames, args in
+      switch args.content {
+      case .arguments(let defs):
+        for name in defs.flatMap({ $0.names }) {
+          countedNames[name.valueString, default: 0] += 1
+        }
+      default:
+        break
+      }
+    }
+
+    var error = Error()
+
+    let duplicateNames = countedNames.filter { $0.value > 1 }
+    if !duplicateNames.isEmpty {
+      error.duplicateNames = duplicateNames
+    }
+
+    if error.occurred {
+      throw error
     }
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -197,13 +197,9 @@ struct ParsableArgumentsUniqueNamesValidator: ParsableArgumentsValidator {
     }
 
     var description: String {
-      var description = duplicateNames.reduce(into: "") { description, entry in
-        description += "Multiple (\(entry.value)) `Option` or `Flag` arguments are named \"\(entry.key)\".\n"
-      }
-      if description.last == "\n" {
-        description.removeLast()
-      }
-      return description
+      duplicateNames.map { entry in
+        "Multiple (\(entry.value)) `Option` or `Flag` arguments are named \"\(entry.key)\"."
+      }.joined(separator: "\n")
     }
   }
 

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -281,8 +281,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     XCTAssertThrowsError(try ParsableArgumentsUniqueNamesValidator.validate(MultipleUniquenessViolations.self)) { error in
       if let error = error as? ParsableArgumentsUniqueNamesValidator.Error {
         XCTAssert(
-          /// The `Mirror` reflects the properties `foo` and `bar` in a random order, but `help` will always be first
-          /// because the `Error`s `violations` array is built that way.
+          /// The `Mirror` reflects the properties `foo` and `bar` in a random order each time it's built.
           error.description == """
           Multiple (2) `Option` or `Flag` arguments are named \"bar\".
           Multiple (2) `Option` or `Flag` arguments are named \"foo\".


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Abstract
Adds `ParsableArgumentsUniqueNamesValidator`, which conforms to `ParsableArgumentsValidator` and implements the validation requested in https://github.com/apple/swift-argument-parser/issues/112: ensuring that argument names aren't duplicated in a type conforming to `ParsableArguments` or `ParsableCommand`.

### Problem
Custom names can be used to give two or more options or flags the same name. For example:
```swift
import ArgumentParser

struct TwoOfTheSameName: ParsableCommand {
    @Option()
    var foo: String

    @Option(name: .customLong("foo"))
    var notActuallyFoo: String

    func run() throws {
        print("foo: \(foo)")
        print("notActuallyFoo: \(notActuallyFoo)")
    }
}

TwoOfTheSameName.main(["--foo thing"])
```
gives this output in `master`:
```
Error: Missing expected argument '--foo <foo>'
Usage: two-of-the-same-name --foo <foo> --foo <foo>
Program ended with exit code: 64
```

### Proposed solution
With the changes in this PR, the output is now
```
Fatal error: Validation failed for `TwoOfTheSameName`:
- Multiple (2) `Option` or `Flag` arguments are named "foo".
: file /Users/tthomas/Library/Developer/Xcode/DerivedData/argument-uniqueness-test-fuopasnbytbtladimilqpbwgllpu/SourcePackages/checkouts/swift-argument-parser/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift, line 196
```
(The above is actually printed twice, for reasons I haven't yet investigated, but that also happens for the validators currently in `master`.)

### Discussion
I used the existing `ParsableArguments` validation implementation, but that means the reflection code used to obtain a `ParsableArguments`'s `ArgumentSet` is now duplicated four times in the code. I'd like to try a refactor to DRY that up if that's desirable.
 
### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
