### PR TITLE
Changing the access level of `ValidationError.message`

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -20,6 +20,9 @@ import MSVCRT
 /// An error type that is presented to the user as an error with parsing their
 /// command-line input.
 public struct ValidationError: Error, CustomStringConvertible {
+  /// The error message represented by this instance, this string is presented to
+  /// the user when a `ValidationError` is thrown from either; `run()`,
+  /// `validate()` or a transform closure.
   public internal(set) var message: String
   
   /// Creates a new validation error with the given message.

--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -20,7 +20,7 @@ import MSVCRT
 /// An error type that is presented to the user as an error with parsing their
 /// command-line input.
 public struct ValidationError: Error, CustomStringConvertible {
-  var message: String
+  public internal(set) var message: String
   
   /// Creates a new validation error with the given message.
   public init(_ message: String) {


### PR DESCRIPTION
This is a very short PR that came out of some changes made in #115. Because it is an API change is was suggested this become a PR in its own right.

However, looking at the code I wanted to make sure the motivations are correct and consider some alternatives. 

### Do we need this change?
`ValidationError` conforms to `CustomStringConvertible`, `description` is `public` and it vends `message`. So client code can read the `message` value without this change.

### Alternative 1
Remove `message` value entirely and use `description`.

```swift
public struct ValidationError: Error, CustomStringConvertible {
  public internal(set) var description: String
  
  /// Creates a new validation error with the given message.
  public init(_ message: String) {
    self.description = message
  }
}
```

### Alternative 2
`message` should be `private(set)`. No library code (currently) changes the `message` string, and its internal by default.

```swift
public struct ValidationError: Error, CustomStringConvertible {
  public private(set) var message: String
  
  /// Creates a new validation error with the given message.
  public init(_ message: String) {
    self.message = message
  }
  
  public var description: String {
    message
  }
}
```

### Alternative 3

If we are making `message` `private` these is no need for it to be a `var`, so change it to a public `let`.

```swift
public struct ValidationError: Error, CustomStringConvertible {
  public let message: String
  
  /// Creates a new validation error with the given message.
  public init(_ message: String) {
    self.message = message
  }
  
  public var description: String {
    message
  }
}
```

### Checklist
- [x] I've updated the documentation if necessary
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- ~~I've added at least one test that validates that my change is working, if appropriate~~
