### PR TITLE
ArgumentParser: repair the build on Windows

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -17,6 +17,10 @@ import Darwin
 import MSVCRT
 #endif
 
+#if os(Windows)
+import let WinSDK.ERROR_BAD_ARGUMENTS
+#endif
+
 /// An error type that is presented to the user as an error with parsing their
 /// command-line input.
 public struct ValidationError: Error, CustomStringConvertible {
@@ -57,7 +61,11 @@ public struct ExitCode: Error, RawRepresentable, Hashable {
   public static let failure = ExitCode(EXIT_FAILURE)
   
   /// An exit code that indicates that the user provided invalid input.
+#if os(Windows)
+  public static let validationFailure = ExitCode(ERROR_BAD_ARGUMENTS)
+#else
   public static let validationFailure = ExitCode(EX_USAGE)
+#endif
 
   /// A Boolean value indicating whether this exit code represents the
   /// successful completion of a command.


### PR DESCRIPTION
Windows does not have a `EX_USAGE`, use `ERROR_BAD_ARGUMENTS` instead.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
