### PR TITLE
Support skipping custom validation for testing

### DIFF
--- a/Documentation/06 Manual Parsing and Testing.md
+++ b/Documentation/06 Manual Parsing and Testing.md
@@ -105,11 +105,8 @@ howdy
 hi
 ```
 
+## Parsing without validating
 
-
-
-
-
-
-
-
+If you want to skip your `ParsableArguments`types `validate()` method (for testing or otherwise) you can call
+`Math.parse(["add", "4", "5"], skipValidation: true)`. Skipping validation skips the validate method on all commands
+and subcommands.

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -52,6 +52,8 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
       }
     }
     
+    let skipValidation = (decoder as? SingleValueDecoder)?.skipCustomValidation ?? false
+    if skipValidation { return }
     do {
       try wrappedValue.validate()
     } catch {

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -83,15 +83,17 @@ extension ParsableArguments {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   /// - Returns: A new instance of this type.
   public static func parse(
-    _ arguments: [String]? = nil
+    _ arguments: [String]? = nil,
+    skipCustomValidation: Bool = false
   ) throws -> Self {
     // Parse the command and unwrap the result if necessary.
-    switch try self.asCommand.parseAsRoot(arguments) {
+    switch try self.asCommand.parseAsRoot(arguments, skipCustomValidation: skipCustomValidation) {
     case is HelpCommand:
       throw ParserError.helpRequested
     case let result as _WrappedParsableCommand<Self>:
       return result.options
     case var result as Self:
+      if skipCustomValidation { return result }
       do {
         try result.validate()
       } catch {

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -57,11 +57,12 @@ extension ParsableCommand {
   /// - Returns: A new instance of this type, one of its subcommands, or a
   ///   command type internal to the `ArgumentParser` library.
   public static func parseAsRoot(
-    _ arguments: [String]? = nil
+    _ arguments: [String]? = nil,
+    skipCustomValidation: Bool = false
   ) throws -> ParsableCommand {
     var parser = CommandParser(self)
     let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
-    return try parser.parse(arguments: arguments).get()
+    return try parser.parse(arguments: arguments, skipCustomValidation: skipCustomValidation).get()
   }
   
   /// Parses an instance of this type, or one of its subcommands, from

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -57,9 +57,9 @@ public func AssertResultFailure<T, U: Error>(
   }
 }
 
-public func AssertErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
+public func AssertErrorMessage<A>(_ type: A.Type, _ arguments: [String], skipCustomValidation: Bool = false, _ errorMessage: String, file: StaticString = #file, line: UInt = #line) where A: ParsableArguments {
   do {
-    _ = try A.parse(arguments)
+    _ = try A.parse(arguments, skipCustomValidation: skipCustomValidation)
     XCTFail("Parsing should have failed.", file: file, line: line)
   } catch {
     // We expect to hit this path, i.e. getting an error:
@@ -77,9 +77,9 @@ public func AssertFullErrorMessage<A>(_ type: A.Type, _ arguments: [String], _ e
   }
 }
 
-public func AssertParse<A>(_ type: A.Type, _ arguments: [String], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) where A: ParsableArguments {
+public func AssertParse<A>(_ type: A.Type, _ arguments: [String], skipCustomValidation: Bool = false, file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) where A: ParsableArguments {
   do {
-    let parsed = try type.parse(arguments)
+    let parsed = try type.parse(arguments, skipCustomValidation: skipCustomValidation)
     try closure(parsed)
   } catch {
     let message = type.message(for: error)
@@ -87,9 +87,9 @@ public func AssertParse<A>(_ type: A.Type, _ arguments: [String], file: StaticSt
   }
 }
 
-public func AssertParseCommand<A: ParsableCommand>(_ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String], file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) {
+public func AssertParseCommand<A: ParsableCommand>(_ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String], skipCustomValidation: Bool = false, file: StaticString = #file, line: UInt = #line, closure: (A) throws -> Void) {
   do {
-    let command = try rootCommand.parseAsRoot(arguments)
+    let command = try rootCommand.parseAsRoot(arguments, skipCustomValidation: skipCustomValidation)
     guard let aCommand = command as? A else {
       XCTFail("Command is of unexpected type: \(command)", file: file, line: line)
       return

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -232,6 +232,35 @@ extension SubcommandEndToEndTests {
                         wait(for: [cmd.didValidateExpectation], timeout: 0.1)
     }
   }
+
+  func testSkippingValidate_subcommands() {
+    // provide a value to base-flag that will throw
+    AssertErrorMessage(
+      BaseCommand.self,
+      ["--base-flag", "foo", "sub", "--sub-flag", "foo", "subsub"],
+      "baseCommandFailure"
+    )
+
+    // provide a value to sub-flag that will throw
+    AssertErrorMessage(
+      BaseCommand.self,
+      ["--base-flag", BaseCommand.baseFlagValue, "sub", "--sub-flag", "foo", "subsub"],
+      "subCommandFailure"
+    )
+
+    // provide a valid command and make sure both validates succeed
+    AssertParseCommand(BaseCommand.self,
+                       BaseCommand.SubCommand.SubSubCommand.self,
+                       ["--base-flag", BaseCommand.baseFlagValue, "sub", "--sub-flag", BaseCommand.SubCommand.subFlagValue, "subsub", "--sub-sub-flag"],
+                       skipCustomValidation: true) { cmd in
+                        XCTAssertTrue(cmd.subSubFlag)
+
+                        // make sure that the instance of SubSubCommand provided
+                        // does not have its validate method called when called with skipCustomValidation.
+                        cmd.didValidateExpectation.isInverted = true
+                        wait(for: [cmd.didValidateExpectation], timeout: 0.1)
+    }
+  }
 }
 
 // MARK: Version flags

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -122,6 +122,12 @@ extension ValidationEndToEndTests {
     // verify that error description is printed if avaiable via LocalizedError
     AssertErrorMessage(Foo.self, ["--throw", "Joe"], UserValidationError.userValidationError.errorDescription!)
   }
+
+  func testCustomValidationCanBeSkipped() throws {
+    AssertParse(Foo.self, ["tim", "Joe", "--throw"], skipCustomValidation: true) { (foo) in
+      XCTAssertEqual(foo.names, ["tim", "Joe"])
+    }
+  }
   
   func testEmptyErrorValidation() {
     AssertErrorMessage(Foo.self, ["--show-usage-only", "Joe"], "")


### PR DESCRIPTION
### Description
As described in #120, there are use cases where you want to parse a ParsableArgument/PasrsableCommand without calling your custom `validate()` methods on your command and subcommand. Typically testing, but other complex scenarios are also conceivable.

### Detailed Design
Update parse & parseAsRoot to take `skipCustomValidation: Bool = false` parameter which is passed through to the Decoders where necessary. Added 2 tests that build on the existing test scenarios.

```swift
extension ParsableCommand {
  public static func parseAsRoot(
    _ arguments: [String]? = nil,
    skipCustomValidation: Bool = false
  ) throws -> ParsableCommand { }
}

extension ParsableArguments {
  public static func parse(
    _ arguments: [String]? = nil,
    skipCustomValidation: Bool = false
  ) 
}
```

### Alternative parameter names

* `skippingCustomValidation`
* `skipValidation`

Let me know if you'd like me to push a change for this.

### Documentation Plan
Added a brief paragraph to the docs

### Test Plan
2 new tests. Tested locally on 10.15 & against swift:latest docker image.

### Source Impact
Non breaking public API addition with default argument.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

@natecook1000, is there anything obviously missing from the above?