### PR TITLE
[WIP] Add ArgumentSource as the projected value of arguments

### DIFF
--- a/Examples/repeat/main.swift
+++ b/Examples/repeat/main.swift
@@ -19,11 +19,15 @@ struct Repeat: ParsableCommand {
     var includeCounter: Bool
 
     @Argument(help: "The phrase to repeat.")
-    var phrase: String
+    var phrase: [String]
 
     func run() throws {
         let repeatCount = count ?? .max
 
+        dump($count)
+        dump($includeCounter)
+        dump($phrase)
+      
         for i in 1...repeatCount {
             if includeCounter {
                 print("\(i): \(phrase)")

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -40,14 +40,23 @@ public struct Argument<Value>:
   public var wrappedValue: Value {
     get {
       switch _parsedValue {
-      case .value(let v):
+      case .value(let v, _):
         return v
       case .definition:
         fatalError(directlyInitializedError)
       }
     }
     set {
-      _parsedValue = .value(newValue)
+      _parsedValue = .value(newValue, _parsedValue.source ?? ArgumentSource(source: []))
+    }
+  }
+  
+  public var projectedValue: ArgumentSource {
+    switch _parsedValue {
+    case .value(_, let source):
+      return source
+    case .definition:
+      fatalError(directlyInitializedError)
     }
   }
 }
@@ -55,7 +64,7 @@ public struct Argument<Value>:
 extension Argument: CustomStringConvertible {
   public var description: String {
     switch _parsedValue {
-    case .value(let v):
+    case .value(let v, _):
       return String(describing: v)
     case .definition:
       return "Argument(*definition*)"

--- a/Sources/ArgumentParser/Parsable Properties/ArgumentSource.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentSource.swift
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public struct ArgumentSource {
+  public var source: [(value: String, position: Int)]
+}
+

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -52,14 +52,23 @@ public struct Flag<Value>: Decodable, ParsedWrapper {
   public var wrappedValue: Value {
     get {
       switch _parsedValue {
-      case .value(let v):
+      case .value(let v, _):
         return v
       case .definition:
         fatalError(directlyInitializedError)
       }
     }
     set {
-      _parsedValue = .value(newValue)
+      _parsedValue = .value(newValue, _parsedValue.source ?? ArgumentSource(source: []))
+    }
+  }
+  
+  public var projectedValue: ArgumentSource {
+    switch _parsedValue {
+    case .value(_, let source):
+      return source
+    case .definition:
+      fatalError(directlyInitializedError)
     }
   }
 }
@@ -67,7 +76,7 @@ public struct Flag<Value>: Decodable, ParsedWrapper {
 extension Flag: CustomStringConvertible {
   public var description: String {
     switch _parsedValue {
-    case .value(let v):
+    case .value(let v, _):
       return String(describing: v)
     case .definition:
       return "Flag(*definition*)"

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -42,14 +42,23 @@ public struct Option<Value>: Decodable, ParsedWrapper {
   public var wrappedValue: Value {
     get {
       switch _parsedValue {
-      case .value(let v):
+      case .value(let v, _):
         return v
       case .definition:
         fatalError(directlyInitializedError)
       }
     }
     set {
-      _parsedValue = .value(newValue)
+      _parsedValue = .value(newValue, _parsedValue.source ?? ArgumentSource(source: []))
+    }
+  }
+  
+  public var projectedValue: ArgumentSource {
+    switch _parsedValue {
+    case .value(_, let source):
+      return source
+    case .definition:
+      fatalError(directlyInitializedError)
     }
   }
 }
@@ -57,7 +66,7 @@ public struct Option<Value>: Decodable, ParsedWrapper {
 extension Option: CustomStringConvertible {
   public var description: String {
     switch _parsedValue {
-    case .value(let v):
+    case .value(let v, _):
       return String(describing: v)
     case .definition:
       return "Option(*definition*)"

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -44,7 +44,7 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
     if let d = decoder as? SingleValueDecoder,
       let value = try? d.previousValue(Value.self)
     {
-      self.init(_parsedValue: .value(value))
+      self.init(_parsedValue: .value(value, ArgumentSource(source: [])))
     } else {
       try self.init(_decoder: decoder)
       if let d = decoder as? SingleValueDecoder {
@@ -63,14 +63,14 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
   public var wrappedValue: Value {
     get {
       switch _parsedValue {
-      case .value(let v):
+      case .value(let v, _):
         return v
       case .definition:
         fatalError(directlyInitializedError)
       }
     }
     set {
-      _parsedValue = .value(newValue)
+      _parsedValue = .value(newValue, _parsedValue.source ?? ArgumentSource(source: []))
     }
   }
 }
@@ -78,7 +78,7 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
 extension OptionGroup: CustomStringConvertible {
   public var description: String {
     switch _parsedValue {
-    case .value(let v):
+    case .value(let v, _):
       return String(describing: v)
     case .definition:
       return "OptionGroup(*definition*)"

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -36,11 +36,17 @@ struct HelpCommand: ParsableCommand {
   
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self._subcommands = Argument(_parsedValue: .value(try container.decode([String].self, forKey: .subcommands)))
+    self._subcommands = Argument(
+      _parsedValue: .value(
+        try container.decode([String].self, forKey: .subcommands),
+        ArgumentSource(source: [])))
   }
   
   init(commandStack: [ParsableCommand.Type]) {
     self.commandStack = commandStack
-    self._subcommands = Argument(_parsedValue: .value(commandStack.map { $0._commandName }))
+    self._subcommands = Argument(
+      _parsedValue: .value(
+        commandStack.map { $0._commandName },
+        ArgumentSource(source: [])))
   }
 }


### PR DESCRIPTION
### Description
This adds a new `ArgumentSource` type as the projected value for `@Argument`, `@Option`, and `@Flag` types. This way, you can access the original string and location in the command-line arguments that produced a value.

```swift
struct Example: ParsableCommand {
    @Argument()
    var name: String

    @Option()
    var age: Int

    func run() {
        print("Your name is \(name) and your age is \(age).")
        if $name.source.first!.position < $age.source.first!.position {
            print("You gave your name before your age.")
        } else {
            print("You gave your age before your name.")
        }
    }
}
```

```
$ example --age 43 Blake
Your name is Blake and your is 43.
You gave your age before your name.
```

### Detailed Design
TK

### Documentation Plan
TK

### Test Plan
TK

### Source Impact
This would be an additive change only.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
