### PR TITLE
Introduces `defaultToHelp` command configuration

### DIFF
--- a/Examples/math/main.swift
+++ b/Examples/math/main.swift
@@ -20,6 +20,9 @@ struct Math: ParsableCommand {
 
         // Commands can define a version for automatic '--version' support.
         version: "1.0.0",
+        
+        // Show help on no input.
+        defaultToHelp: true,
 
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -30,6 +30,10 @@ public struct CommandConfiguration {
   /// A Boolean value indicating whether this command should be shown in
   /// the extended help display.
   public var shouldDisplay: Bool
+    
+  /// A Boolean value indicating whether this command should display help
+  /// when executed without further user input.
+  public var defaultToHelp: Bool
   
   /// An array of the types that define subcommands for this command.
   public var subcommands: [ParsableCommand.Type]
@@ -51,6 +55,8 @@ public struct CommandConfiguration {
   ///   - version: The version number for this command. When you provide a
   ///     non-empty string, the arguemnt parser prints it if the user provides
   ///     a `--version` flag.
+  ///   - defaultToHelp: A Boolean value indicating whether the command should
+  ///     display help in the absence of other user input.
   ///   - shouldDisplay: A Boolean value indicating whether the command
   ///     should be shown in the extended help display.
   ///   - subcommands: An array of the types that define subcommands for the
@@ -65,6 +71,7 @@ public struct CommandConfiguration {
     discussion: String = "",
     version: String = "",
     shouldDisplay: Bool = true,
+    defaultToHelp: Bool = false,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
     helpNames: NameSpecification = [.short, .long]
@@ -74,6 +81,7 @@ public struct CommandConfiguration {
     self.discussion = discussion
     self.version = version
     self.shouldDisplay = shouldDisplay
+    self.defaultToHelp = defaultToHelp
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand
     self.helpNames = helpNames

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -191,6 +191,7 @@ extension CommandParser {
   /// - Parameter arguments: The array of arguments to parse. This should not
   ///   include the command name as the first argument.
   mutating func parse(arguments: [String]) -> Result<ParsableCommand, CommandError> {
+    
     var split: SplitArguments
     do {
       split = try SplitArguments(arguments: arguments)
@@ -201,6 +202,10 @@ extension CommandParser {
     }
     
     do {
+      if arguments.isEmpty && commandStack.contains(where: { $0.configuration.defaultToHelp }) {
+        throw HelpRequested()
+      }
+
       try descendingParse(&split)
       let result = try extractLastParsedValue(split)
       

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -38,6 +38,7 @@ final class MathExampleTests: XCTestCase {
     AssertExecuteCommand(command: "math -h", expected: helpText)
     AssertExecuteCommand(command: "math --help", expected: helpText)
     AssertExecuteCommand(command: "math help", expected: helpText)
+    AssertExecuteCommand(command: "math", expected: helpText)
   }
   
   func testMath_AddHelp() throws {


### PR DESCRIPTION
Adds configuration option that allows a command to present help when
no other input is provided by the user at the command-line call.

### Description
This change introduces a hook so users can configure the command to
respond with a help message on the absence of arguments.

### Detailed Design

```swift
// CommandConfiguration:
// ...
  /// A Boolean value indicating whether this command should display help
  /// when executed without further user input.
  public var defaultToHelp: Bool
// ...
```

### Documentation Plan
Updated code doc in CommandConfiguration.swift

### Test Plan
Test with updated math.swift. Instead of returning 0 without arguments, it should return the help message.

### Source Impact
This is purely additive and optional, defaulting to `false`, the existing behavior.

### Checklist
- [x ] I've added at least one test that validates that my change is working, if appropriate
- [x ] I've followed the code style of the rest of the project
- [x ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary 

I have not updated the documentation, but will amend this PR if the idea has a chance for moving forward.
