### PR TITLE
Add support to CMake to build swift-argument-parser during SwiftPM bootstrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,18 @@
 cmake_minimum_required(VERSION 3.16.0)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
 project(swift-argument-parser
   LANGUAGES Swift)
 
 option(BUILD_EXAMPLES "Build Example Programs" TRUE)
+option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 include(CTest)
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 find_package(Foundation QUIET)
@@ -20,5 +26,4 @@ if(BUILD_TESTING)
   add_subdirectory(Tests)
 endif()
 
-export(TARGETS ArgumentParser
-  FILE swift-argument-parser-config.cmake)
+add_subdirectory(cmake/modules)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -2,3 +2,9 @@ add_subdirectory(ArgumentParser)
 if(BUILD_TESTING)
   add_subdirectory(ArgumentParserTestHelpers)
 endif()
+
+set_property(GLOBAL APPEND PROPERTY ArgumentParser_EXPORTS ArgumentParser)
+
+ # NOTE: workaround for CMake not setting up include flags yet
+ set_target_properties(ArgumentParser PROPERTIES
+   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/cmake/modules/ArgumentParserConfig.cmake.in
+++ b/cmake/modules/ArgumentParserConfig.cmake.in
@@ -1,0 +1,3 @@
+if(NOT TARGET ArgumentParser)
+   include(@ArgumentParser_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(ArgumentParser_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/ArgumentParserExports.cmake)
+
+ configure_file(ArgumentParserConfig.cmake.in
+   ${CMAKE_CURRENT_BINARY_DIR}/ArgumentParserConfig.cmake)
+
+ get_property(ArgumentParser_EXPORTS GLOBAL PROPERTY ArgumentParser_EXPORTS)
+ export(TARGETS ${ArgumentParser_EXPORTS}
+   FILE ${ArgumentParser_EXPORTS_FILE})


### PR DESCRIPTION
This is a fairly early attempt at integrating this repo into the SwiftPM bootstrapped build, someone better at CMake than I am should probably review :)