### PR TITLE
Display help when no arguments results in error

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -214,6 +214,7 @@ extension CommandParser {
     } catch let error as CommandError {
       return .failure(error)
     } catch let error as ParserError {
+      let error = arguments.isEmpty ? ParserError.noArguments(error) : error
       return .failure(CommandError(commandStack: commandStack, parserError: error))
     } catch is HelpRequested {
       return .success(HelpCommand(commandStack: commandStack))

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -28,6 +28,7 @@ enum ParserError: Error {
   case unableToParseValue(InputOrigin, Name?, String, forKey: InputKey, originalError: Error? = nil)
   case missingSubcommand
   case userValidationError(Error)
+  case noArguments(Error)
 }
 
 /// These are errors used internally to the parsing, and will not be exposed to the help generation.

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -80,6 +80,10 @@ enum MessageInfo {
         self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
       }
     } else if let parserError = parserError {
+      let usage: String = {
+        guard case ParserError.noArguments = parserError else { return usage }
+        return "\n" + HelpGenerator(commandStack: [type.asCommand]).rendered
+      }()
       let message = ArgumentSet(commandStack.last!).helpMessage(for: parserError)
       self = .validation(message: message, usage: usage)
     } else {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -212,6 +212,15 @@ extension ErrorMessageGenerator {
       default:
         return String(describing: error)
       }
+    case .noArguments(let error):
+      switch error {
+      case let error as ParserError:
+        return ErrorMessageGenerator(arguments: self.arguments, error: error).makeErrorMessage()
+      case let error as LocalizedError:
+        return error.errorDescription
+      default:
+        return String(describing: error)
+      }
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -31,6 +31,19 @@ fileprivate struct Foo: ParsableArguments {
   static var usageString: String = """
     Usage: foo [--count <count>] [<names> ...] [--version] [--throw]
     """
+
+  static var helpString: String = """
+    USAGE: foo [--count <count>] [<names> ...] [--version] [--throw]
+
+    ARGUMENTS:
+      <names>
+
+    OPTIONS:
+      --count <count>
+      --version
+      --throw
+      -h, --help              Show help information.
+    """
   
   @Option()
   var count: Int?
@@ -106,7 +119,9 @@ extension ValidationEndToEndTests {
     AssertErrorMessage(Foo.self, [], "Must specify at least one name.")
     AssertFullErrorMessage(Foo.self, [], """
             Error: Must specify at least one name.
-            \(Foo.usageString)
+
+            \(Foo.helpString)
+            
             """)
     
     AssertErrorMessage(Foo.self, ["--count", "3", "Joe"], """

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -47,7 +47,16 @@ final class RepeatExampleTests: XCTestCase {
       command: "repeat",
       expected: """
             Error: Missing expected argument '<phrase>'
-            Usage: repeat [--count <count>] [--include-counter] <phrase>
+
+            USAGE: repeat [--count <count>] [--include-counter] <phrase>
+
+            ARGUMENTS:
+              <phrase>                The phrase to repeat.
+
+            OPTIONS:
+              --count <count>         The number of times to repeat 'phrase'.
+              --include-counter       Include a counter with each repetition.
+              -h, --help              Show help information.
             """,
       exitCode: .validationFailure)
 


### PR DESCRIPTION
This implements the feature mentioned in #134. I think it would also remove the need for #135.

When a `ParserError` is thrown, check to see if there are zero arguments. If so, the error is wrapped in the new `.noArguments` case, which allows the original error to be reported, while also triggering the full help message instead of usage.

If there's a Swiftier/more concise way of writing the addition to MessageInfo.swift, I'd love to know.

I wasn't sure whether this needs explicit mention in the documentation, and if so, which section to add it to.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
