### PR TITLE
Fix short names with equals sign

### DIFF
--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -493,7 +493,14 @@ private extension ParsedArgument {
   }
   
   init(longArgWithSingleDashRemainder remainder: Substring) throws {
-    try self.init(longArgRemainder: remainder, makeName: { Name.longWithSingleDash(String($0)) })
+    try self.init(longArgRemainder: remainder, makeName: {
+      /// If an argument has a single dash and single character,
+      /// followed by a value, treat it as a short name.
+      ///     `-c=1`      ->  `Name.short("c")`
+      /// Otherwise, treat it as a long name with single dash.
+      ///     `-count=1`  ->  `Name.longWithSingleDash("count")`
+      $0.count == 1 ? Name.short($0.first!) : Name.longWithSingleDash(String($0))
+    })
   }
   
   init(longArgRemainder remainder: Substring, makeName: (Substring) -> Name) throws {

--- a/Tests/ArgumentParserEndToEndTests/EqualsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/EqualsEndToEndTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ArgumentParserTestHelpers
+import ArgumentParser
+
+final class EqualsEndToEndTests: XCTestCase {
+}
+
+// MARK: .short name
+
+fileprivate struct Foo: ParsableArguments {
+  @Flag(name: .short) var toggle: Bool
+  @Option(name: .short) var name: String?
+  @Option(name: .short) var format: String
+}
+
+extension EqualsEndToEndTests {
+  func testEquals_withShortName() throws {
+    AssertParse(Foo.self, ["-n=Name", "-f=Format"]) { foo in
+      XCTAssertEqual(foo.toggle, false)
+      XCTAssertEqual(foo.name, "Name")
+      XCTAssertEqual(foo.format, "Format")
+    }
+  }
+
+  func testEquals_withCombinedShortName_1() throws {
+    AssertParse(Foo.self, ["-tf", "Format"]) { foo in
+      XCTAssertEqual(foo.toggle, true)
+      XCTAssertEqual(foo.name, nil)
+      XCTAssertEqual(foo.format, "Format")
+    }
+  }
+
+  func testEquals_withCombinedShortName_2() throws {
+    XCTAssertThrowsError(try Foo.parse(["-tf=Format"]))
+  }
+}
+
+// MARK: .shortAndLong name
+
+fileprivate struct Bar: ParsableArguments {
+  @Option(name: .shortAndLong) var name: String
+  @Option(name: .shortAndLong) var format: String
+}
+
+extension EqualsEndToEndTests {
+  func testEquals_withShortAndLongName() throws {
+    AssertParse(Bar.self, ["-n=Name", "-f=Format"]) { bar in
+      XCTAssertEqual(bar.name, "Name")
+      XCTAssertEqual(bar.format, "Format")
+    }
+  }
+}
+
+// MARK: .customShort name
+
+fileprivate struct Baz: ParsableArguments {
+  @Option(name: .customShort("i")) var name: String
+  @Option(name: .customShort("t")) var format: String
+}
+
+extension EqualsEndToEndTests {
+  func testEquals_withCustomShortName() throws {
+    AssertParse(Baz.self, ["-i=Name", "-t=Format"]) { baz in
+      XCTAssertEqual(baz.name, "Name")
+      XCTAssertEqual(baz.format, "Format")
+    }
+  }
+}


### PR DESCRIPTION
This fixes #132, by letting you separate a short option and its value with an equals sign.

The new tests are in EqualsEndToEndTests.swift for now, but arguably they belong in ShortNameEndToEndTests.swift. I can move them if necessary. I also omitted new tests for long argument names with equals sign, as that seems to be tested elsewhere.

I don't think there needs to be any further documentation, as this was already the documented behavior.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
