### PR TITLE
Add APIs for generating the help screen

### DIFF
--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -165,3 +165,17 @@ struct Example: ParsableCommand {
     var experimentalEnableWidgets: Bool
 }
 ```
+
+## Generating Help Text Programmatically
+
+The help screen is automatically shown to users when they call your command with the help flag. You can generate the same text from within your program by calling the `helpMessage()` method.
+
+```swift
+let help = Repeat.helpMessage()
+// `help` matches the output above
+
+let fortyColumnHelp = Repeat.helpMessage(columns: 40)
+// `fortyColumnHelp` is the same help screen, but wrapped to 40 columns
+```
+
+When generating help text for a subcommand, call `helpMessage(for:)` on the `ParsableCommand` type that represents the root of the command tree and pass the subcommand type as a parameter to ensure the correct display.

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -127,9 +127,9 @@ extension ParsableArguments {
   
   /// Returns the text of the help screen for this type.
   ///
-  /// - Parameter columns: The column width to use when wrapping long lines in the 
-  ///   help screen. If `columns` is `nil`, uses the current terminal width, or
-  ///   a default value of `80` if the terminal width is not available.
+  /// - Parameter columns: The column width to use when wrapping long lines in
+  ///   the help screen. If `columns` is `nil`, uses the current terminal width,
+  ///   or a default value of `80` if the terminal width is not available.
   /// - Returns: The full help screen for this type.
   public static func helpMessage(columns: Int? = nil) -> String {
     HelpGenerator(self).rendered(screenWidth: columns)

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -125,6 +125,16 @@ extension ParsableArguments {
     MessageInfo(error: error, type: self).fullText
   }
   
+  /// Returns the text of the help screen for this type.
+  ///
+  /// - Parameter columns: The column width to use when wrapping long lines in the 
+  ///   help screen. If `columns` is `nil`, uses the current terminal width, or
+  ///   a default value of `80` if the terminal width is not available.
+  /// - Returns: The full help screen for this type.
+  public static func helpMessage(columns: Int? = nil) -> String {
+    HelpGenerator(self).rendered(screenWidth: columns)
+  }
+
   /// Returns the exit code for the given error.
   ///
   /// The returned code is the same exit code that is used if `error` is passed

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -64,6 +64,25 @@ extension ParsableCommand {
     return try parser.parse(arguments: arguments).get()
   }
   
+  /// Returns the text of the help screen for the given subcommand of this
+  /// command.
+  ///
+  /// - Parameters:
+  ///   - subcommand: The subcommand to generate the help screen for.
+  ///     `subcommand` must be declared in the subcommand tree of this
+  ///     command.
+  ///   - columns: The column width to use when wrapping long line in the
+  ///     help screen. If `columns` is `nil`, uses the current terminal
+  ///     width, or a default value of `80` if the terminal width is not
+  ///     available.
+  public static func helpMessage(
+    for subcommand: ParsableCommand.Type,
+    columns: Int? = nil
+  ) -> String { 
+    let stack = CommandParser(self).commandStack(for: subcommand)
+    return HelpGenerator(commandStack: stack).rendered(screenWidth: columns)
+  }
+
   /// Parses an instance of this type, or one of its subcommands, from
   /// command-line arguments and calls its `run()` method, exiting cleanly
   /// or with a relevant error message.

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -27,7 +27,7 @@ struct HelpCommand: ParsableCommand {
   }
   
   func generateHelp() -> String {
-    return HelpGenerator(commandStack: commandStack).rendered
+    return HelpGenerator(commandStack: commandStack).rendered()
   }
   
   enum CodingKeys: CodingKey {

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -27,7 +27,7 @@ enum MessageInfo {
 
       switch e.parserError {
       case .helpRequested:
-        self = .help(text: HelpGenerator(commandStack: e.commandStack).rendered)
+        self = .help(text: HelpGenerator(commandStack: e.commandStack).rendered())
         return
       case .versionRequested:
         let versionString = commandStack
@@ -43,7 +43,7 @@ enum MessageInfo {
       commandStack = [type.asCommand]
       parserError = e
       if case .helpRequested = e {
-        self = .help(text: HelpGenerator(commandStack: [type.asCommand]).rendered)
+        self = .help(text: HelpGenerator(commandStack: [type.asCommand]).rendered())
         return
       }
     default:
@@ -53,7 +53,7 @@ enum MessageInfo {
       parserError = .userValidationError(error)
     }
     
-    let usage = HelpGenerator(commandStack: commandStack).usageMessage
+    let usage = HelpGenerator(commandStack: commandStack).usageMessage()
     
     // Parsing errors and user-thrown validation errors have the usage
     // string attached. Other errors just get the error message.
@@ -68,7 +68,7 @@ enum MessageInfo {
           if let command = command {
             commandStack = CommandParser(type.asCommand).commandStack(for: command)
           }
-          self = .help(text: HelpGenerator(commandStack: commandStack).rendered)
+          self = .help(text: HelpGenerator(commandStack: commandStack).rendered())
         case .message(let message):
           self = .help(text: message)
         }

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -82,7 +82,7 @@ enum MessageInfo {
     } else if let parserError = parserError {
       let usage: String = {
         guard case ParserError.noArguments = parserError else { return usage }
-        return "\n" + HelpGenerator(commandStack: [type.asCommand]).rendered
+        return "\n" + HelpGenerator(commandStack: [type.asCommand]).rendered()
       }()
       let message = ArgumentSet(commandStack.last!).helpMessage(for: parserError)
       self = .validation(message: message, usage: usage)

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -117,12 +117,25 @@ public func AssertHelp<T: ParsableArguments>(
 ) {
   do {
     _ = try T.parse(["-h"])
-    XCTFail()
+    XCTFail(file: file, line: line)
   } catch {
     let helpString = T.fullMessage(for: error)
     AssertEqualStringsIgnoringTrailingWhitespace(
       helpString, expected, file: file, line: line)
   }
+  
+  let helpString = T.helpMessage()
+  AssertEqualStringsIgnoringTrailingWhitespace(
+    helpString, expected, file: file, line: line)
+}
+
+public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
+  for _: T.Type, root _: U.Type, equals expected: String,
+  file: StaticString = #file, line: UInt = #line
+) {
+  let helpString = U.helpMessage(for: T.self)
+  AssertEqualStringsIgnoringTrailingWhitespace(
+    helpString, expected, file: file, line: line)
 }
 
 extension XCTest {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -132,7 +132,6 @@ extension HelpGenerationTests {
     }
   }
 
-
   struct D: ParsableCommand {
     @Argument(default: "--", help: "Your occupation.")
     var occupation: String
@@ -267,8 +266,8 @@ extension HelpGenerationTests {
 
     """)
     
-    AssertHelp(for: H.AnotherCommand.self, equals: """
-    USAGE: another-command [--some-option-with-very-long-name <some-option-with-very-long-name>] [--option <option>] [<argument-with-very-long-name-and-help>] [<argument-with-very-long-name>] [<argument>]
+    AssertHelp(for: H.AnotherCommand.self, root: H.self, equals: """
+    USAGE: h another-command [--some-option-with-very-long-name <some-option-with-very-long-name>] [--option <option>] [<argument-with-very-long-name-and-help>] [<argument-with-very-long-name>] [<argument>]
 
     ARGUMENTS:
       <argument-with-very-long-name-and-help>


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    Before you submit your request, please replace each paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Description
This adds two methods for generating the help screen for a command or subcommand.

### Detailed Design
The additions includes two methods, one on `ParsableArguments` and one on `ParsableCommand`. The second method has a `subcommand` parameter, and is called on the root command to generate the help text for a subcommand:

```swift
let help = RootCommand.helpMessage(for: Subcommand.self)
```

The two new methods:

```swift
extension ParsableArguments {
    /// Returns the text of the help screen for this type.
    public static func helpMessage(columns: Int? = nil) -> String
}

extension ParsableCommand {
    /// Returns the text of the help screen for the given subcommand of this
    /// command.
    public static func helpMessage(
        for subcommand: ParsableCommand.Type,
        columns: Int? = nil
    ) -> String
}
```

### Documentation Plan
Documentation is included for the new methods, and I've added a section at the end of the guide about customizing help.

### Test Plan
I've added tests of these APIs wherever we've previously been testing the help screens.

### Source Impact
This is an additive change only.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
