### PR TITLE
Set isOptional flag for options of Optional type

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -253,6 +253,7 @@ extension Option {
           values.set(v, forKey: key, inputOrigin: origin)
         }
       })
+      arg.help.options.formUnion(ArgumentDefinition.Help.Options(type: Value.self))
       arg.help.defaultValue = initial.map { "\($0)" }
       return ArgumentSet(alternatives: [arg])
       })

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -138,4 +138,15 @@ extension UsageGenerationTests {
     let help = UsageGenerator(toolName: "bar", parsable: I())
     XCTAssertEqual(help.synopsis, "bar [--color <color>]")
   }
+
+  struct J: ParsableArguments {
+    struct Foo {}
+    @Option(transform: { _ in Foo() }) var req: Foo
+    @Option(transform: { _ in Foo() }) var opt: Foo?
+  }
+
+  func testSynopsisWithTransform() {
+    let help = UsageGenerator(toolName: "bar", parsable: J())
+    XCTAssertEqual(help.synopsis, "bar --req <req> [--opt <opt>]")
+  }
 }


### PR DESCRIPTION
Documentation for `Option.init(... transform:)` says: "If the property has an `Optional` type, or you provide a non-`nil` value for the `initial` parameter, specifying this option is not required."
Initializer works exactly this way but provides wrong synopsis for `Optional` type properties.


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
