### PR TITLE
Fix invalid indentation of strings with short lines

### DIFF
--- a/Sources/ArgumentParser/Utilities/StringExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/StringExtensions.swift
@@ -19,8 +19,11 @@ extension String {
     while true {
       let nextChunk = self[currentIndex...].prefix(columns)
       if let lastLineBreak = nextChunk.lastIndex(of: "\n") {
-        result.append(self[currentIndex..<lastLineBreak])
+        result.append(contentsOf: self[currentIndex..<lastLineBreak].split(separator: "\n", omittingEmptySubsequences: false))
         currentIndex = index(after: lastLineBreak)
+      } else if nextChunk.endIndex == self.endIndex {
+        result.append(self[currentIndex...])
+        break
       } else if let lastSpace = nextChunk.lastIndex(of: " ") {
         result.append(self[currentIndex..<lastSpace])
         currentIndex = index(after: lastSpace)
@@ -28,20 +31,13 @@ extension String {
         result.append(self[currentIndex..<nextSpace])
         currentIndex = index(after: nextSpace)
       } else {
-        if let lastSegment = result.last,
-          lastSegment.count + self[currentIndex...].count < columns
-        {
-          result[result.count - 1] = self[lastSegment.startIndex...]
-          break
-        }
-        
         result.append(self[currentIndex...])
         break
       }
     }
     
     return result
-      .map { String(repeating: " ", count: wrappingIndent) + $0 }
+      .map { $0.isEmpty ? $0 : String(repeating: " ", count: wrappingIndent) + $0 }
       .joined(separator: "\n")
   }
   

--- a/Tests/ArgumentParserUnitTests/StringWrappingTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringWrappingTests.swift
@@ -30,6 +30,16 @@ Et leo duis ut diam quam.
 Integer eget aliquet nibh praesent tristique magna sit. Faucibus turpis in eu mi bibendum neque egestas congue quisque.       Risus nec feugiat in fermentum posuere urna nec tincidunt.
 """
 
+let jsonSample = """
+{
+  "level1": {
+    "level2": {
+      "level3": true
+    }
+  }
+}
+"""
+
 // MARK: -
 
 extension StringWrappingTests {
@@ -114,7 +124,7 @@ extension StringWrappingTests {
     XCTAssertEqual(longSample.wrapped(to: 60, wrappingIndent: 10), """
                       Pretium vulputate sapien nec sagittis aliquam
                       malesuada bibendum. Ut diam quam nulla porttitor.
-                      
+
                       Egestas egestas fringilla phasellus faucibus.
                       Amet dictum sit amet justo donec enim diam.
                       Consectetur adipiscing elit duis tristique.
@@ -129,5 +139,29 @@ extension StringWrappingTests {
                       feugiat in fermentum posuere urna nec tincidunt.
             """)
     
+  }
+
+  func testJSON() {
+    XCTAssertEqual(jsonSample.wrapped(to: 80), """
+            {
+              "level1": {
+                "level2": {
+                  "level3": true
+                }
+              }
+            }
+            """)
+  }
+
+  func testJSONWithIndent() {
+    XCTAssertEqual(jsonSample.wrapped(to: 80, wrappingIndent: 10), """
+                      {
+                        "level1": {
+                          "level2": {
+                            "level3": true
+                          }
+                        }
+                      }
+            """)
   }
 }


### PR DESCRIPTION
Every lines in option's discussion must be properly indented, even the short ones.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
