### PR TITLE
Remove extraneous newline for empty abstract

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -117,7 +117,10 @@ internal struct HelpGenerator {
     
     self.abstract = currentCommand.configuration.abstract
     if !currentCommand.configuration.discussion.isEmpty {
-      self.abstract += "\n\n\(currentCommand.configuration.discussion)"
+      if !self.abstract.isEmpty {
+        self.abstract += "\n"
+      }
+      self.abstract += "\n\(currentCommand.configuration.discussion)"
     }
     
     self.usage = Usage(components: [usageString])

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -298,4 +298,23 @@ extension HelpGenerationTests {
     """)
 
   }
+  
+  struct J: ParsableCommand {
+    static var configuration = CommandConfiguration(discussion: "test")
+  }
+  
+  func testOverviewButNoAbstractSpacing() {
+    let renderedHelp = HelpGenerator(J.self).rendered()
+    AssertEqualStringsIgnoringTrailingWhitespace(renderedHelp, """
+    OVERVIEW:
+    test
+
+    USAGE: j
+    
+    OPTIONS:
+      -h, --help              Show help information.
+    
+    """)
+  }
+
 }


### PR DESCRIPTION
In the event a configuration has an empty abstract and non-empty discussion,
an extra line was generated. This patch removes that line.

ISSUE: SAP-156 https://github.com/apple/swift-argument-parser/issues/156

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x ] I've added at least one test that validates that my change is working, if appropriate
- [x ] I've followed the code style of the rest of the project
- [x ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x ] I've updated the documentation if necessary
