### PR TITLE
Remove `Never` return from ParsableCommand.main()

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -84,18 +84,24 @@ extension ParsableCommand {
   }
 
   /// Parses an instance of this type, or one of its subcommands, from
-  /// command-line arguments and calls its `run()` method, exiting cleanly
-  /// or with a relevant error message.
+  /// the given arguments and calls its `run()` method, exiting with a
+  /// relevant error message if necessary.
   ///
   /// - Parameter arguments: An array of arguments to use for parsing. If
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
-  public static func main(_ arguments: [String]? = nil) -> Never {
+  public static func main(_ arguments: [String]?) {
     do {
       let command = try parseAsRoot(arguments)
       try command.run()
-      exit()
     } catch {
       exit(withError: error)
     }
+  }
+
+  /// Parses an instance of this type, or one of its subcommands, from
+  /// command-line arguments and calls its `run()` method, exiting with a
+  /// relevant error message if necessary.
+  public static func main() {
+    self.main(nil)
   }
 }


### PR DESCRIPTION
### Description
This brings the `main()` method in line with using the new `@main` attribute on the root
command type.

### Detailed Design
The changes here are to make `ParsableCommand.main()` a `Void`-returning function, to break out a separate no-argument version, and to remove the default parameter. The default-argument version doesn't satisfy the `() -> Void` requirement for `@main`.

The `main()` method now returns without exiting on successful execution of a 

### Documentation Plan
No real impact. Documentation for using `@main` with the library to follow.

### Test Plan
All existing tests continue to pass. SwiftPM will need an update to support `@main` in executable targets.

### Source Impact
Typical code should continue to behave as expected, but this is source-breaking if anyone has a strongly-typed usage of `ParsableCommand.main()`, e.g. `let mainFunction: ([String]?) -> Never = MyCommand.main`. Keeping the old version with a deprecation/unavailability annotation isn't possible, since there would be ambiguity between that and the new ones.

In addition, code that followed `MyCommand.main()` in `main.swift` is no longer dead code, and will be executed after successful execution of the command.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
