### PR TITLE
Make ParsableCommand.run() a mutating method

### DIFF
--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -52,7 +52,7 @@ struct Count: ParsableCommand {
     @Argument()
     var outputFile: String
     
-    func run() throws {
+    mutating func run() throws {
         print("""
             Counting words in '\(inputFile)' \
             and writing the result into '\(outputFile)'.
@@ -91,7 +91,7 @@ struct Count: ParsableCommand {
     @Option()
     var outputFile: String
     
-    func run() throws {
+    mutating func run() throws {
         print("""
             Counting words in '\(inputFile)' \
             and writing the result into '\(outputFile)'.
@@ -135,7 +135,7 @@ struct Count: ParsableCommand {
     @Flag()
     var verbose: Bool
     
-    func run() throws {
+    mutating func run() throws {
         if verbose {
             print("""
                 Counting words in '\(inputFile)' \
@@ -177,7 +177,7 @@ struct Count: ParsableCommand {
     @Flag(name: .shortAndLong)
     var verbose: Bool
     
-    func run() throws { ... }
+    mutating func run() throws { ... }
 }
 ```
 
@@ -211,7 +211,7 @@ struct Count: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Print status updates while counting.")
     var verbose: Bool
 
-    func run() throws { ... }
+    mutating func run() throws { ... }
 }
 ```
 
@@ -246,7 +246,7 @@ struct Count: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Print status updates while counting.")
     var verbose: Bool
 
-    func run() throws {
+    mutating func run() throws {
         if verbose {
             print("""
                 Counting words in '\(inputFile)' \

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -141,7 +141,7 @@ enum ReleaseMode: String, ExpressibleByArgument {
 struct Example: ParsableCommand {
     @Option() var mode: ReleaseMode
     
-    func run() throws {
+    mutating func run() throws {
         print(mode)
     }
 }
@@ -192,7 +192,7 @@ struct Example: ParsableCommand {
     @Flag(default: nil, inversion: .prefixedEnableDisable)
     var requiredElement: Bool
     
-    func run() throws {
+    mutating func run() throws {
         print(index, requiredElement)
     }
 }
@@ -228,7 +228,7 @@ struct Example: ParsableCommand {
     
     @Flag() var colors: [Color]
     
-    func run() throws {
+    mutating func run() throws {
         print(cacheMethod)
         print(colors)
     }
@@ -252,7 +252,7 @@ struct Example: ParsableCommand {
     @Flag(name: .shortAndLong)
     var verbose: Int
     
-    func run() throws {
+    mutating func run() throws {
         print("Verbosity level: \(verbose)")
     }
 }
@@ -279,7 +279,7 @@ struct Example: ParsableCommand {
     @Option() var name: String
     @Argument() var file: String?
     
-    func run() throws {
+    mutating func run() throws {
         print("Verbose: \(verbose), name: \(name), file: \(file ?? "none")")
     }
 }
@@ -324,7 +324,7 @@ struct Example: ParsableCommand {
     @Option() var file: [String]
     @Flag() var verbose: Bool
     
-    func run() throws {
+    mutating func run() throws {
         print("Verbose: \(verbose), files: \(file)")
     }
 }
@@ -374,7 +374,7 @@ struct Example: ParsableCommand {
     @Flag() var verbose: Bool
     @Argument() var files: [String]
     
-    func run() throws {
+    mutating func run() throws {
         print("Verbose: \(verbose), files: \(files)")
     }
 }

--- a/Documentation/03 Commands and Subcommands.md
+++ b/Documentation/03 Commands and Subcommands.md
@@ -72,7 +72,7 @@ extension Math {
         @OptionGroup()
         var options: Math.Options
         
-        func run() {
+        mutating func run() {
             let result = options.values.reduce(0, +)
             print(format(result: result, usingHex: options.hexadecimalOutput))
         }
@@ -85,7 +85,7 @@ extension Math {
         @OptionGroup()
         var options: Math.Options
         
-        func run() {
+        mutating func run() {
             let result = options.values.reduce(1, *)
             print(format(result: result, usingHex: options.hexadecimalOutput))
         }
@@ -128,7 +128,7 @@ extension Math.Statistics {
         func calculateMedian() -> Double { ... }
         func calculateMode() -> [Double] { ... }
     
-        func run() {
+        mutating func run() {
             switch kind {
             case .mean:
                 print(calculateMean())
@@ -151,7 +151,7 @@ extension Math.Statistics {
         @Argument(help: "A group of floating-point values to operate on.")
         var values: [Double]
         
-        func run() {
+        mutating func run() {
             if values.isEmpty {
                 print(0.0)
             } else {

--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -87,7 +87,7 @@ struct Repeat: ParsableCommand {
     @Argument(help: "The phrase to repeat.")
     var phrase: String
     
-    func run() throws {
+    mutating func run() throws {
         while true { print(phrase) }
     }
 }
@@ -131,7 +131,7 @@ struct Example: ParsableCommand {
     @Option(name: .shortAndLong, help: "The number of history entries to show.")
     var historyDepth: Int
     
-    func run() throws {
+    mutating func run() throws {
         printHistory(depth: historyDepth)
     }
 }

--- a/Documentation/05 Validation and Errors.md
+++ b/Documentation/05 Validation and Errors.md
@@ -32,7 +32,7 @@ struct Select: ParsableCommand {
         }
     }
     
-    func run() {
+    mutating func run() {
         print(elements.shuffled().prefix(count).joined(separator: "\n"))
     }
 }
@@ -63,7 +63,7 @@ The `ValidationError` type is a special `ArgumentParser` error — a validation 
 struct LineCount: ParsableCommand {
     @Argument() var file: String
     
-    func run() throws {
+    mutating func run() throws {
         let contents = try String(contentsOfFile: file, encoding: .utf8)
         let lines = contents.split(separator: "\n")
         print(lines.count)
@@ -91,7 +91,7 @@ struct RuntimeError: Error, CustomStringConvertible {
 struct Example: ParsableCommand {
     @Argument() var inputFile: String
     
-    func run() throws {
+    mutating func run() throws {
         if !ExampleCore.processFile(inputFile) {
             // ExampleCore.processFile(_:) prints its own errors
             // and returns `false` on failure.

--- a/Documentation/06 Manual Parsing and Testing.md
+++ b/Documentation/06 Manual Parsing and Testing.md
@@ -56,10 +56,10 @@ Let's see how this works by using the `Math` command and subcommands defined in 
 
 ```swift
 do {
-    let command = try Math.parseAsRoot()
+    var command = try Math.parseAsRoot()
 
     switch command {
-    case let command as Math.Add:
+    case var command as Math.Add:
         print("You chose to add \(command.options.values.count) values.")
         command.run()
     default:

--- a/Examples/math/main.swift
+++ b/Examples/math/main.swift
@@ -57,7 +57,7 @@ extension Math {
         @OptionGroup()
         var options: Options
         
-        func run() {
+        mutating func run() {
             let result = options.values.reduce(0, +)
             print(format(result, usingHex: options.hexadecimalOutput))
         }
@@ -70,7 +70,7 @@ extension Math {
         @OptionGroup()
         var options: Options
         
-        func run() {
+        mutating func run() {
             let result = options.values.reduce(1, *)
             print(format(result, usingHex: options.hexadecimalOutput))
         }
@@ -145,7 +145,7 @@ extension Math.Statistics {
                 .map { k, _ in k }
         }
     
-        func run() {
+        mutating func run() {
             switch kind {
             case .mean:
                 print(calculateMean())
@@ -168,7 +168,7 @@ extension Math.Statistics {
         @Argument(help: "A group of floating-point values to operate on.")
         var values: [Double]
         
-        func run() {
+        mutating func run() {
             if values.isEmpty {
                 print(0.0)
             } else {

--- a/Examples/repeat/main.swift
+++ b/Examples/repeat/main.swift
@@ -21,7 +21,7 @@ struct Repeat: ParsableCommand {
     @Argument(help: "The phrase to repeat.")
     var phrase: String
 
-    func run() throws {
+    mutating func run() throws {
         let repeatCount = count ?? .max
 
         for i in 1...repeatCount {

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ struct Repeat: ParsableCommand {
     @Argument(help: "The phrase to repeat.")
     var phrase: String
 
-    func run() throws {
+    mutating func run() throws {
         let repeatCount = count ?? .max
 
         for i in 1...repeatCount {

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -22,7 +22,7 @@
 ///     struct Example: ParsableCommand {
 ///         @Flag() var sizes: [Size]
 ///
-///         func run() {
+///         mutating func run() {
 ///             print(sizes)
 ///         }
 ///     }

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -28,7 +28,7 @@ public protocol ParsableCommand: ParsableArguments {
   /// application by calling the static `main()` method on the root type.
   /// This method has a default implementation that prints help text
   /// for this command.
-  func run() throws
+  mutating func run() throws
 }
 
 extension ParsableCommand {
@@ -41,7 +41,7 @@ extension ParsableCommand {
     CommandConfiguration()
   }
   
-  public func run() throws {
+  public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }
 }
@@ -91,7 +91,7 @@ extension ParsableCommand {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   public static func main(_ arguments: [String]? = nil) -> Never {
     do {
-      let command = try parseAsRoot(arguments)
+      var command = try parseAsRoot(arguments)
       try command.run()
       exit()
     } catch {

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -18,7 +18,7 @@ struct HelpCommand: ParsableCommand {
   
   init() {}
   
-  func run() throws {
+  mutating func run() throws {
     throw CommandError(commandStack: commandStack, parserError: .helpRequested)
   }
   

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -29,7 +29,7 @@ public protocol TestableParsableCommand: ParsableCommand, TestableParsableArgume
 }
 
 public extension TestableParsableCommand {
-  func run() throws {
+  mutating func run() throws {
     didRunExpectation.fulfill()
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -375,7 +375,7 @@ extension RepeatingEndToEndTests {
 struct PerformanceTest: ParsableCommand {
   @Option(name: .short) var bundleIdentifiers: [String]
   
-  func run() throws { print(bundleIdentifiers) }
+  mutating func run() throws { print(bundleIdentifiers) }
 }
 
 fileprivate func argumentGenerator(_ count: Int) -> [String] {

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -126,7 +126,7 @@ fileprivate struct Math: ParsableCommand {
   @Argument(help: "The first operand")
   var operands: [Int]
   
-  func run() {
+  mutating func run() {
     XCTAssertEqual(operation, .multiply)
     XCTAssertTrue(verbose)
     XCTAssertEqual(operands, [5, 11])
@@ -136,7 +136,7 @@ fileprivate struct Math: ParsableCommand {
 
 extension SubcommandEndToEndTests {
   func testParsing_SingleCommand() throws {
-    let mathCommand = try Math.parseAsRoot(["--operation", "multiply", "-v", "5", "11"])
+    var mathCommand = try Math.parseAsRoot(["--operation", "multiply", "-v", "5", "11"])
     XCTAssertFalse(mathDidRun)
     try mathCommand.run()
     XCTAssertTrue(mathDidRun)

--- a/Tests/ArgumentParserPackageManagerTests/PackageManager/GenerateXcodeProject.swift
+++ b/Tests/ArgumentParserPackageManagerTests/PackageManager/GenerateXcodeProject.swift
@@ -38,7 +38,7 @@ extension Package {
     @Option(help: "Path to xcconfig file")
     var xcconfigOverrides: String?
     
-    func run() {
+    mutating func run() {
       print("Generating Xcode Project.......")
     }
   }

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -26,7 +26,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
       case phrase
     }
     
-    func run() throws {}
+    mutating func run() throws {}
   }
   
   private struct B: ParsableCommand {
@@ -36,7 +36,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     @Argument(help: "The phrase to repeat.")
     var phrase: String
     
-    func run() throws {}
+    mutating func run() throws {}
   }
   
   private struct C: ParsableCommand {
@@ -50,7 +50,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
       case phrase
     }
     
-    func run() throws {}
+    mutating func run() throws {}
   }
   
   private struct D: ParsableArguments {

--- a/Tools/changelog-authors/main.swift
+++ b/Tools/changelog-authors/main.swift
@@ -126,7 +126,7 @@ struct ChangelogAuthors: ParsableCommand {
     return url
   }
   
-  func run() throws {
+  mutating func run() throws {
     let data = try Data(contentsOf: try comparisonURL())
     let comparison = try JSONDecoder().decode(Comparison.self, from: data)
     let authors = comparison.commits.map({ $0.author })


### PR DESCRIPTION
### Description
This changes `ParsableCommand`'s `run` requirement to be mutating. This allows for things like in-place sorting or filtering of arguments without making a mutable copy.

This change supersedes #33.

### Detailed Design
The only change here is the switch to mutating for the `run()` method.

```swift
protocol ParsableCommand: ParsableArguments {
    // other requirements

    /// ...
    mutating func run() throws
}
```

### Documentation Plan
We didn't previously mention the non-mutatingness of `run()`, so that doesn't require a change. All code samples have been updated to implement the new requirement.

### Test Plan
All existing tests pass with the change.

### Source Impact
~This **will require code changes** for every command that implements a `run()` method, since a non-mutating `run()` won't properly satisfy the new requirement. Since `ParsableCommand` provides a default implementation for `run()`, there unfortunately won't be any indication of this change at compile time.~

Apparently this _is_ in fact source-compatible with existing code. Clients can add `mutating` as they want, but existing non-mutating `run()` methods will be called correctly. 🎉

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
