### PR TITLE
Fix showing help message when “-h” is given as an input for an array (#149)

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -159,6 +159,7 @@ extension CommandParser {
       do {
         try parsedCommand.validate()
       } catch {
+        try checkForBuiltInFlags(split)
         throw CommandError(commandStack: commandStack, parserError: ParserError.userValidationError(error))
       }
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -317,4 +317,27 @@ extension HelpGenerationTests {
     """)
   }
 
+  struct K: ParsableCommand {
+    @Argument(help: "A list of paths.")
+    var paths: [String]
+    
+    func validate() throws {
+      if paths.isEmpty {
+        throw ValidationError("At least one path must be specified.")
+      }
+    }
+  }
+  
+  func testHelpWithNoValueForArray() {
+    AssertHelp(for: K.self, equals: """
+    USAGE: k [<paths> ...]
+
+    ARGUMENTS:
+      <paths>                 A list of paths.
+
+    OPTIONS:
+      -h, --help              Show help information.
+
+    """)
+  }
 }


### PR DESCRIPTION
When argument is an array and no input is given but “-h”, if you throw an Error in Validate function, it prints error and short usage instead of help message.

'command -h'

This patch checks built-in flags before throwing a validation error.

Solves #149

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
