### PR TITLE
Remove `ExpressibleByArgument` conformance from `Optional`

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -141,14 +141,14 @@ extension Argument {
     help: ArgumentHelp? = nil
   ) where Value == T? {
     self.init(_parsedValue: .init { key in
-      ArgumentSet(
+      var arg = ArgumentDefinition(
         key: key,
         kind: .positional,
         parsingStrategy: .nextAsValue,
-        parseType: T.self,
-        name: .long,
-        default: nil,
-        help: help)
+        parser: T.init(argument:),
+        default: nil)
+      arg.help.help = help
+      return ArgumentSet(arg.optional)
     })
   }
   

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -130,6 +130,49 @@ public enum ArgumentArrayParsingStrategy {
 }
 
 extension Argument {
+  /// Creates an optional property that reads its value from an argument.
+  ///
+  /// The argument is optional for the caller of the command and defaults to `nil`.
+  ///
+  /// - Parameters:
+  ///   - initial: A default value to use for this property.
+  ///   - help: Information about how to use this argument.
+  public init<T: ExpressibleByArgument>(
+    help: ArgumentHelp? = nil
+  ) where Value == T? {
+    self.init(_parsedValue: .init { key in
+      ArgumentSet(
+        key: key,
+        kind: .positional,
+        parsingStrategy: .nextAsValue,
+        parseType: T.self,
+        name: .long,
+        default: nil,
+        help: help)
+    })
+  }
+  
+  @available(*, deprecated, message: """
+    Default values don't make sense for optional properties.
+    Remove the 'default' parameter if its value is nil,
+    or make your property non-optional if it's non-nil.
+    """)
+  public init<T: ExpressibleByArgument>(
+    default initial: T?,
+    help: ArgumentHelp? = nil
+  ) where Value == T? {
+    self.init(_parsedValue: .init { key in
+      ArgumentSet(
+        key: key,
+        kind: .positional,
+        parsingStrategy: .nextAsValue,
+        parseType: T.self,
+        name: .long,
+        default: initial,
+        help: help)
+    })
+  }
+  
   /// Creates a property that reads its value from an argument, parsing with
   /// the given closure.
   ///

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -71,7 +71,7 @@ extension Argument where Value: ExpressibleByArgument {
   /// Creates a property that reads its value from an argument.
   ///
   /// - Parameters:
-  ///   - initial: A default value to use for this property. If `default` is
+  ///   - initial: A default value to use for this property. If `initial` is
   ///     `nil`, the user must supply a value for this argument.
   ///   - help: Information about how to use this argument.
   public init(

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -70,11 +70,9 @@ extension Argument: DecodableParsedWrapper where Value: Decodable {}
 extension Argument where Value: ExpressibleByArgument {
   /// Creates a property that reads its value from an argument.
   ///
-  /// If the property has an `Optional` type, the argument is optional and
-  /// defaults to `nil`.
-  ///
   /// - Parameters:
-  ///   - initial: A default value to use for this property.
+  ///   - initial: A default value to use for this property. If `default` is
+  ///     `nil`, the user must supply a value for this argument.
   ///   - help: Information about how to use this argument.
   public init(
     default initial: Value? = nil,
@@ -132,11 +130,10 @@ public enum ArgumentArrayParsingStrategy {
 extension Argument {
   /// Creates an optional property that reads its value from an argument.
   ///
-  /// The argument is optional for the caller of the command and defaults to `nil`.
+  /// The argument is optional for the caller of the command and defaults to 
+  /// `nil`.
   ///
-  /// - Parameters:
-  ///   - initial: A default value to use for this property.
-  ///   - help: Information about how to use this argument.
+  /// - Parameter help: Information about how to use this argument.
   public init<T: ExpressibleByArgument>(
     help: ArgumentHelp? = nil
   ) where Value == T? {

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -255,15 +255,15 @@ extension Option {
     help: ArgumentHelp? = nil
   ) where Value == T? {
     self.init(_parsedValue: .init { key in
-      ArgumentSet.init(
+      var arg = ArgumentDefinition(
         key: key,
         kind: .name(key: key, specification: name),
         parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy),
-        parseType: T.self,
-        name: name,
-        default: initial,
-        help: help)
-      })
+        parser: T.init(argument:),
+        default: initial)
+      arg.help.help = help
+      return ArgumentSet(arg.optional)
+    })
   }
 
   /// Creates a property that reads its value from a labeled option, parsing

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -72,14 +72,12 @@ extension Option: DecodableParsedWrapper where Value: Decodable {}
 extension Option where Value: ExpressibleByArgument {
   /// Creates a property that reads its value from a labeled option.
   ///
-  /// If the property has an `Optional` type, or you provide a non-`nil`
-  /// value for the `initial` parameter, specifying this option is not
-  /// required.
-  ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
   ///   - initial: A default value to use for this property. If `initial` is
   ///     `nil`, this option and value are required from the user.
+  ///   - parsingStrategy: The behavior to use when looking for this option's
+  ///     value.
   ///   - help: Information about how to use this option.
   public init(
     name: NameSpecification = .long,
@@ -224,7 +222,8 @@ extension Option {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property.
+  ///   - parsingStrategy: The behavior to use when looking for this option's
+  ///     value.
   ///   - help: Information about how to use this option.
   public init<T: ExpressibleByArgument>(
     name: NameSpecification = .long,
@@ -269,14 +268,12 @@ extension Option {
   /// Creates a property that reads its value from a labeled option, parsing
   /// with the given closure.
   ///
-  /// If the property has an `Optional` type, or you provide a non-`nil`
-  /// value for the `initial` parameter, specifying this option is not
-  /// required.
-  ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
   ///   - initial: A default value to use for this property. If `initial` is
   ///     `nil`, this option and value are required from the user.
+  ///   - parsingStrategy: The behavior to use when looking for this option's
+  ///     value.
   ///   - help: Information about how to use this option.
   ///   - transform: A closure that converts a string into this property's
   ///     type or throws an error.

--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -33,23 +33,6 @@ extension String: ExpressibleByArgument {
   }
 }
 
-extension Optional: ExpressibleByArgument where Wrapped: ExpressibleByArgument {
-  public init?(argument: String) {
-    if let value = Wrapped(argument: argument) {
-      self = value
-    } else {
-      return nil
-    }
-  }
-  
-  public var defaultValueDescription: String {
-    guard let value = self else {
-      return "none"
-    }
-    return "\(value)"
-  }
-}
-
 extension RawRepresentable where Self: ExpressibleByArgument, RawValue: ExpressibleByArgument {
   public init?(argument: String) {
     if let value = RawValue(argument: argument) {

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -145,6 +145,7 @@ extension ArgumentDefinition: CustomDebugStringConvertible {
 extension ArgumentDefinition {
   var optional: ArgumentDefinition {
     var result = self
+    
     result.help.options.insert(.isOptional)
     return result
   }

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -176,7 +176,7 @@ extension ArgumentSet {
 
 extension ArgumentDefinition {
   /// Create a unary / argument that parses using the given closure.
-  fileprivate init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .nextAsValue, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?) {
+  init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .nextAsValue, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?) {
     let initialValueCreator: (InputOrigin, inout ParsedValues) throws -> Void
     if let initialValue = initial {
       initialValueCreator = { origin, values in

--- a/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
@@ -39,12 +39,10 @@ fileprivate struct AlmostAllArguments: ParsableArguments {
   @Argument(default: 0) var c2: Int?
 
   @Argument(default: 0, help: "", transform: { _ in 0 }) var d: Int?
-  @Argument(default: 0) var d1: Int?
   @Argument(help: "") var d2: Int?
   @Argument(transform: { _ in 0 }) var d3: Int?
   @Argument(help: "", transform: { _ in 0 }) var d4: Int?
   @Argument(default: 0, transform: { _ in 0 }) var d5: Int?
-  @Argument(default: 0, help: "") var d6: Int?
 
   @Argument(parsing: .remaining, help: "") var e: [Int]
   @Argument() var e0: [Int]


### PR DESCRIPTION
### Description
This drops the `ExpressibleByArgument` conformance for `Optional`. This conformance doesn't quite make sense, and allowed property declarations like this:

```swift
@Option(default: 0) var count: Int?
```

The default value meant that `count` would never be `nil`, and therefore shouldn't be optional.

### Detailed Design
This change adds initializers specifically for when an `Option`'s or `Argument`'s value is optional, without a `default` parameter as well as deprecated versions that include a `default` parameter to guide clients to the correct declaration syntax.

### Documentation Plan
The new initializers are documented; related initializers have been updated. There is no change required in the guides.

### Test Plan
Existing tests exercise the functionality and verify the largely source-compatible nature of the change.

### Source Impact
While this is technically source-breaking, it should have minimal impact in regular usage. All the declaration sites for arguments and options with optional values are still supported, with deprecation warnings for declarations that combine a default value and an optional type. If a property is declared as optional but does not have a default value, there won't even be a deprecation notice.

Code that uses `Optional`'s conformance to `ExpressibleByArgument`, however, will break without warning. Users can work around this by adding an `Optional`-specific code path, or by other means.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
