### PR TITLE
Convert deprecations from pre-0.1.0 to unavailable

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -334,7 +334,7 @@ extension Flag {
   }
 }
 
-// - MARK: Deprecated CaseIterable/RawValue == String
+// - MARK: Unavailable CaseIterable/RawValue == String
 
 extension Flag where Value: CaseIterable, Value: RawRepresentable, Value: Equatable, Value.RawValue == String {
   /// Creates a property that gets its value from the presence of a flag,
@@ -346,7 +346,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value: Equata
   ///     `nil`, this flag is required.
   ///   - exclusivity: The behavior to use when multiple flags are specified.
   ///   - help: Information about how to use this flag.
-  @available(*, deprecated, message: "Add 'EnumerableFlag' conformance to your value type.")
+  @available(*, unavailable, message: "Add 'EnumerableFlag' conformance to your value type and, if needed, specify the 'name' of each case there.")
   public init(
     name: NameSpecification = .long,
     default initial: Value? = nil,
@@ -376,7 +376,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value: Equata
 extension Flag {
   /// Creates a property that gets its value from the presence of a flag,
   /// where the allowed flags are defined by a case-iterable type.
-  @available(*, deprecated, message: "Add 'EnumerableFlag' conformance to your value type.")
+  @available(*, unavailable, message: "Add 'EnumerableFlag' conformance to your value type and, if needed, specify the 'name' of each case there.")
   public init<Element>(
     name: NameSpecification = .long,
     exclusivity: FlagExclusivity = .exclusive,
@@ -409,7 +409,7 @@ extension Flag {
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
   ///   - help: Information about how to use this flag.
-  @available(*, deprecated, message: "Add 'EnumerableFlag' conformance to your value type.")
+  @available(*, unavailable, message: "Add 'EnumerableFlag' conformance to your value type and, if needed, specify the 'name' of each case there.")
   public init<Element>(
     name: NameSpecification = .long,
     help: ArgumentHelp? = nil

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -309,7 +309,7 @@ fileprivate struct RepeatOK: ParsableArguments {
   @Flag(exclusivity: .chooseLast)
   var shape: Shape
 
-  @Flag(name: .shortAndLong, default: .small, exclusivity: .exclusive)
+  @Flag(default: .small, exclusivity: .exclusive)
   var size: Size
 }
 

--- a/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
@@ -202,39 +202,3 @@ extension SourceCompatEndToEndTests {
   }
 }
 
-// MARK: - Deprecated APIs
-
-fileprivate struct DeprecatedFlags: ParsableArguments {
-  enum One: String, CaseIterable {
-    case one
-  }
-  enum Two: String, CaseIterable {
-    case two
-  }
-  enum Three: String, CaseIterable {
-    case three
-    case four
-  }
-
-  @Flag() var single: One
-  @Flag() var optional: Two?
-  @Flag() var array: [Three]
-  @Flag(name: .long) var size: Size?
-}
-
-extension SourceCompatEndToEndTests {
-  func testParsingDeprecatedFlags() throws {
-    AssertParse(DeprecatedFlags.self, ["--one"]) { options in
-      XCTAssertEqual(options.single, .one)
-      XCTAssertNil(options.optional)
-      XCTAssertTrue(options.array.isEmpty)
-    }
-
-    AssertParse(DeprecatedFlags.self, ["--one", "--two", "--three", "--four", "--three"]) { options in
-      XCTAssertEqual(options.single, .one)
-      XCTAssertEqual(options.optional, .two)
-      XCTAssertEqual(options.array, [.three, .four, .three])
-    }
-  }
-}
-

--- a/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
+++ b/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
@@ -135,15 +135,31 @@ extension ErrorMessageTests {
   }
 }
 
-private enum OutputBehaviour: String, CaseIterable { case stats, count, list }
 private struct Options: ParsableArguments {
-  @Flag(name: .shortAndLong, default: .list, help: "Program output")
+  enum OutputBehaviour: String, EnumerableFlag {
+    case stats, count, list
+    
+    static func name(for value: OutputBehaviour) -> NameSpecification {
+      .shortAndLong
+    }
+  }
+
+  @Flag(default: .list, help: "Program output")
   var behaviour: OutputBehaviour
 
   @Flag(inversion: .prefixedNo, exclusivity: .exclusive) var bool: Bool
 }
+
 private struct OptOptions: ParsableArguments {
-  @Flag(name: .short, help: "Program output")
+  enum OutputBehaviour: String, EnumerableFlag {
+    case stats, count, list
+    
+    static func name(for value: OutputBehaviour) -> NameSpecification {
+      .short
+    }
+  }
+
+  @Flag(help: "Program output")
   var behaviour: OutputBehaviour?
 }
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -115,7 +115,7 @@ extension HelpGenerationTests {
             """)
   }
 
-  enum OptionFlags: String, CaseIterable { case optional, required }
+  enum OptionFlags: String, EnumerableFlag { case optional, required }
   enum Degree {
     case bachelor, master, doctor
     static func degreeTransform(_ string: String) throws -> Degree {
@@ -179,15 +179,32 @@ extension HelpGenerationTests {
             """)
   }
 
-  enum OutputBehaviour: String, CaseIterable { case stats, count, list }
   struct E: ParsableCommand {
-    @Flag(name: .shortAndLong, help: "Change the program output")
+    enum OutputBehaviour: String, EnumerableFlag {
+      case stats, count, list
+      
+      static func name(for value: OutputBehaviour) -> NameSpecification {
+        .shortAndLong
+      }
+    }
+    
+    @Flag(help: "Change the program output")
     var behaviour: OutputBehaviour
   }
+  
   struct F: ParsableCommand {
-    @Flag(name: .short, default: .list, help: "Change the program output")
+    enum OutputBehaviour: String, EnumerableFlag {
+      case stats, count, list
+      
+      static func name(for value: OutputBehaviour) -> NameSpecification {
+        .short
+      }
+    }
+
+    @Flag(default: .list, help: "Change the program output")
     var behaviour: OutputBehaviour
   }
+  
   struct G: ParsableCommand {
     @Flag(inversion: .prefixedNo, help: "Whether to flag")
     var flag: Bool

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -323,22 +323,35 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     }
   }
 
-  // MARK: CaseIterable enum flag has first letter duplication
-  fileprivate enum ExampleEnum: String, EnumerableFlag {
-    case first
-    case second
-    case other
-    case forth
-    case fith
-  }
+  // MARK: EnumerableFlag has first letter duplication
 
   fileprivate struct DuplicatedFirstLettersShortNames: ParsableCommand {
-    @Flag(name: .short, default: .first)
+    enum ExampleEnum: String, EnumerableFlag {
+      case first
+      case second
+      case other
+      case forth
+      case fith
+      
+      static func name(for value: ExampleEnum) -> NameSpecification {
+        .short
+      }
+    }
+
+    @Flag(default: .first)
     var enumFlag: ExampleEnum
   }
 
   fileprivate struct DuplicatedFirstLettersLongNames: ParsableCommand {
-    @Flag(name: .long, default: .first)
+    enum ExampleEnum: String, EnumerableFlag {
+      case first
+      case second
+      case other
+      case forth
+      case fith
+    }
+
+    @Flag(default: .first)
     var enumFlag2: ExampleEnum
   }
 


### PR DESCRIPTION
This change converts the old `@Flag` initializers for `CaseIterable`/`String` enums from deprecated to unavailable, in preparation for the 0.1.0 release.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
