### PR TITLE
Use the first long name in usage

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -41,13 +41,7 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
   var elements: Array<Element>
   
   public init<S>(_ sequence: S) where S : Sequence, Element == S.Element {
-    let array = Array(sequence)
-    self.elements = Array()
-    for element in array {
-      if !self.elements.contains(element) {
-        self.elements.append(element)
-      }
-    }
+    self.elements = sequence.uniquified()
   }
   
   public init(arrayLiteral elements: Element...) {

--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -41,7 +41,13 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
   var elements: Array<Element>
   
   public init<S>(_ sequence: S) where S : Sequence, Element == S.Element {
-    self.elements = Array(sequence)
+    let array = Array(sequence)
+    self.elements = Array()
+    for element in array {
+      if !self.elements.contains(element) {
+        self.elements.append(element)
+      }
+    }
   }
   
   public init(arrayLiteral elements: Element...) {

--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -38,10 +38,10 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     /// Short labels can be combined into groups.
     case customShort(Character)
   }
-  var elements: Set<Element>
+  var elements: Array<Element>
   
   public init<S>(_ sequence: S) where S : Sequence, Element == S.Element {
-    self.elements = Set(sequence)
+    self.elements = Array(sequence)
   }
   
   public init(arrayLiteral elements: Element...) {

--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -53,6 +53,10 @@ extension Name {
       return n
     }
   }
+  
+  var isShort: Bool {
+    return self == .short(self.valueString.first!)
+  }
 }
 
 // short argument names based on the synopsisString

--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -55,7 +55,12 @@ extension Name {
   }
   
   var isShort: Bool {
-    return self == .short(self.valueString.first!)
+    switch self {
+    case .short:
+      return true
+    default:
+      return false
+    }
   }
 }
 

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -63,7 +63,7 @@ extension ArgumentDefinition {
     
     switch kind {
     case .named:
-      let joinedSynopsisString = sortedNames
+      let joinedSynopsisString = partitionedNames
         .map { $0.synopsisString }
         .joined(separator: ", ")
       
@@ -113,8 +113,8 @@ extension ArgumentDefinition {
     return unadornedSynopsis
   }
   
-  var sortedNames: [Name] {
-    return names.filter{ $0 == .short($0.valueString.first!) } + names.filter{ $0 != .short($0.valueString.first!) }
+  var partitionedNames: [Name] {
+    return names.filter{ $0.isShort } + names.filter{ !$0.isShort }
   }
   
   var preferredNameForSynopsis: Name? {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -118,7 +118,7 @@ extension ArgumentDefinition {
   }
   
   var preferredNameForSynopsis: Name? {
-    names.first{ $0 != .short($0.valueString.first!) } ?? names.first
+    names.first{ !$0.isShort } ?? names.first
   }
   
   var synopsisValueName: String? {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -114,11 +114,11 @@ extension ArgumentDefinition {
   }
   
   var sortedNames: [Name] {
-    return names.filter{ $0 != .long($0.valueString) } + names.filter{ $0 == .long($0.valueString) }
+    return names.filter{ $0 == .short($0.valueString.first!) } + names.filter{ $0 != .short($0.valueString.first!) }
   }
   
   var preferredNameForSynopsis: Name? {
-    names.first{ $0 == .long($0.valueString) } ?? names.first
+    names.first{ $0 != .short($0.valueString.first!) } ?? names.first
   }
   
   var synopsisValueName: String? {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -114,29 +114,11 @@ extension ArgumentDefinition {
   }
   
   var sortedNames: [Name] {
-    return names
-      .sorted { (lhs, rhs) -> Bool in
-        switch (lhs, rhs) {
-        case let (.long(l), .long(r)):
-          return l < r
-        case (_, .long):
-          return true
-        case (.long, _):
-          return false
-        case let (.short(l), .short(r)):
-          return l < r
-        case (_, .short):
-          return true
-        case (.short, _):
-          return false
-        case let (.longWithSingleDash(l), .longWithSingleDash(r)):
-          return l < r
-        }
-    }
+    return names.filter{ $0 != .long($0.valueString) } + names.filter{ $0 == .long($0.valueString) }
   }
   
   var preferredNameForSynopsis: Name? {
-    sortedNames.last
+    names.first{ $0 == .long($0.valueString) } ?? names.first
   }
   
   var synopsisValueName: String? {

--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Sequence where Element: Equatable {
+  func uniquified() -> [Element] {
+    var sequence = Array<Element>()
+    for element in self {
+      if !sequence.contains(element) {
+        sequence.append(element)
+      }
+    }
+    return sequence
+  }
+}

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -361,7 +361,7 @@ extension HelpGenerationTests {
   
   struct L: ParsableArguments {
     @Option(
-      name: [.short, .customLong("remote"),  .customLong("when"), .long, .customLong("there"), .customShort("x"), .customShort("y")],
+      name: [.short, .customLong("remote"), .customLong("remote"), .short, .customLong("when"), .long, .customLong("other", withSingleDash: true), .customLong("there"), .customShort("x"), .customShort("y")],
       help: "Help Message")
     var time: String?
   }
@@ -371,7 +371,7 @@ extension HelpGenerationTests {
     USAGE: l [--remote <remote>]
 
     OPTIONS:
-      -t, -x, -y, --remote, --when, --time, --there <remote>
+      -t, -x, -y, --remote, --when, --time, -other, --there <remote>
                               Help Message
       -h, --help              Show help information.
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -358,4 +358,23 @@ extension HelpGenerationTests {
 
     """)
   }
+  
+  struct L: ParsableArguments {
+    @Option(
+      name: [.short, .customLong("remote"),  .customLong("when"), .long, .customLong("there"), .customShort("x"), .customShort("y")],
+      help: "Help Message")
+    var time: String?
+  }
+  
+  func testHelpWithMultipleCustomNames() {
+    AssertHelp(for: L.self, equals: """
+    USAGE: l [--remote <remote>]
+
+    OPTIONS:
+      -t, -x, -y, --remote, --when, --time, --there <remote>
+                              Help Message
+      -h, --help              Show help information.
+
+    """)
+  }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -161,4 +161,16 @@ extension UsageGenerationTests {
     let help = UsageGenerator(toolName: "bar", parsable: K())
     XCTAssertEqual(help.synopsis, "bar [--remote <remote>]")
   }
+  
+  struct L: ParsableArguments {
+    @Option(
+      name: [.short, .short, .customLong("remote", withSingleDash: true), .short, .customLong("remote", withSingleDash: true)],
+      help: "Help Message")
+    var time: String?
+  }
+  
+  func testSynopsisWithSingleDashLongNameFirst() {
+    let help = UsageGenerator(toolName: "bar", parsable: L())
+    XCTAssertEqual(help.synopsis, "bar [-remote <remote>]")
+  }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -149,4 +149,16 @@ extension UsageGenerationTests {
     let help = UsageGenerator(toolName: "bar", parsable: J())
     XCTAssertEqual(help.synopsis, "bar --req <req> [--opt <opt>]")
   }
+  
+  struct K: ParsableArguments {
+    @Option(
+      name: [.short, .customLong("remote"),  .customLong("when"), .customLong("there")],
+      help: "Help Message")
+    var time: String?
+  }
+  
+  func testSynopsisWithMultipleCustomNames() {
+    let help = UsageGenerator(toolName: "bar", parsable: K())
+    XCTAssertEqual(help.synopsis, "bar [--remote <remote>]")
+  }
 }


### PR DESCRIPTION
SortedNames for ArgumentDefinition has been changed.
NameSpecification now uses Array type for elements.

* Usage will choose the first long name, if available, or otherwise the first short name
* Help screen will show short names, then long names, in the order of their declaration.

Solves (#167)

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
