### PR TITLE
Help message for default subcommands

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -213,11 +213,16 @@ internal struct HelpGenerator {
       optionElements.append(.init(label: helpLabels, abstract: "Show help information."))
     }
 
+    let configuration = commandStack.last!.configuration
     let subcommandElements: [Section.Element] =
-      commandStack.last!.configuration.subcommands.compactMap { command in
+      configuration.subcommands.compactMap { command in
         guard command.configuration.shouldDisplay else { return nil }
+        var label = command._commandName
+        if command == configuration.defaultSubcommand {
+            label += " (default)"
+        }
         return Section.Element(
-          label: command._commandName,
+          label: label,
           abstract: command.configuration.abstract)
     }
     

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -30,7 +30,7 @@ final class MathExampleTests: XCTestCase {
           -h, --help              Show help information.
 
         SUBCOMMANDS:
-          add                     Print the sum of the values.
+          add (default)           Print the sum of the values.
           multiply                Print the product of the values.
           stats                   Calculate descriptive statistics.
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -377,4 +377,24 @@ extension HelpGenerationTests {
 
     """)
   }
+
+  struct M: ParsableCommand {
+  }
+  struct N: ParsableCommand {
+    static var configuration = CommandConfiguration(subcommands: [M.self], defaultSubcommand: M.self)
+  }
+
+  func testHelpWithDefaultCommand() {
+    AssertHelp(for: N.self, equals: """
+    USAGE: n <subcommand>
+
+    OPTIONS:
+      -h, --help              Show help information.
+
+    SUBCOMMANDS:
+      m (default)
+
+      See 'n help <subcommand>' for detailed help.
+    """)
+  }
 }


### PR DESCRIPTION
It would be useful to see default subcommand in help messages.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
