### PR TITLE
Add support for `Void?` flags

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -144,6 +144,17 @@ extension Flag where Value == Optional<Bool> {
   }
 }
 
+extension Flag where Value == Optional<Void> {
+  public init(
+    name: NameSpecification = .long,
+    help: ArgumentHelp? = nil
+  ) {
+     self.init(_parsedValue: .init { key in
+      .flag(key: key, name: name, help: help, value: ())
+    })
+  }
+}
+
 extension Flag where Value == Bool {
   /// Creates a Boolean property that reads its value from the presence of a
   /// flag.

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -104,6 +104,14 @@ extension ArgumentSet {
     return ArgumentSet(arg)
   }
 
+  static func flag(key: InputKey, name: NameSpecification, help: ArgumentHelp?, value: Void) -> ArgumentSet {
+    let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key)
+    let arg = ArgumentDefinition(kind: .name(key: key, specification: name), help: help, update: .nullary({ (origin, name, values) in
+      values.set(value, forKey: key, inputOrigin: origin)
+    }))
+    return ArgumentSet(arg)
+  }
+
   static func updateFlag<Value: Equatable>(key: InputKey, value: Value, origin: InputOrigin, values: inout ParsedValues, hasUpdated: Bool, exclusivity: FlagExclusivity) throws -> Bool {
     switch (hasUpdated, exclusivity) {
     case (true, .exclusive):

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -330,3 +330,23 @@ extension FlagsEndToEndTests {
     }
   }
 }
+
+
+fileprivate struct VoidFlag: ParsableArguments {
+  @Flag()
+  var test: Void?
+}
+
+extension FlagsEndToEndTests {
+  func testParsingVoid_DefaultNil() throws {
+    AssertParse(VoidFlag.self, []) { options in
+      XCTAssert(options.test == nil)
+    }
+  }
+
+  func testParsingVoid_OverrideDefault() throws {
+    AssertParse(VoidFlag.self, ["--test"]) { options in
+      XCTAssert(options.test != nil)
+    }
+  }
+}


### PR DESCRIPTION
This is intended to replace the `Bool` flag without an inversion, as it more closely matches the underlying usage model of a flag being provided vs. not provided on the command line.

This is mostly a proof-of-concept proposal as a discussion point, relating to [the discussion about no-inversion `Flag`s in #170](https://github.com/apple/swift-argument-parser/pull/170#discussion_r441395593). As a summary, this proposal is intended to address the behavior of flags without inversions:
```swift
struct SomeArguments: ParsableCommand {
    @Flag() var someFlag: Bool
    func run() throws {
        if someFlag {
            ...
        }
    }
}
```

As discussed in the comment linked above, in my opinion, a `Bool` doesn't represent the high-level usage model as well as an `Optional` type, especially with the usage of `Bool`s in flags that have inversions and can be set by the user to have both `true` and `false` as a value, not only `true`. This PR proposes to replace the above usage with:
```swift
struct SomeArguments: ParsableCommand {
    @Flag() var someFlag: Void?
    func run() throws {
        if someFlag != nil {
            ...
        }
    }
}
```

This gains us the following benefits:
- Sidesteps the potential confusion over a non-optional value having an implicit default value currently on `master`
- Sidesteps the need to force users to provide an explicit `false` for every flag as currently on #170, while doing so in a Swift-like manner (since optionals already default to `nil`, users will be familiar with this usage pattern)
- As mentioned, better represents the high-level usage of the command-line arguments, which is both a little cleaner and will probably help stave off future issues down the road (at least in my own experience, aligning the usage and the underlying model helps to prevent weird corner-cases as things are extended)
- Simplifies code that deals with flags with inversions, as the inversion can now be inferred from the type and defaulted to `.prefixedNo` for all `Bool`s

However, this does come at a cost:
- Using `Void?` may seem strange to users that aren't "cracking the hood" of this framework, so to speak, and will likely cause some confusion that needs to be sorted out in documentation
    - This cost could be reduced by using a better-named `typealias` or single-case `enum` as described in the initial discussion linked above, but I don't know of a great name for that either (`Unary`?)
- Adds some minor complexity to existing code (the addition of `!= nil` above)

I personally feel like those benefits are worth it, but I don't think there's an exceptionally strong case for it either like there was for the default property initialization syntax in #170. Mostly, I was just curious as to what it would take to implement this and provide a concrete implementation to start off dicussion.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
