### PR TITLE
Allow required array arguments, options, and flags

### DIFF
--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -285,6 +285,46 @@ Verbosity level: 1
 Verbosity level: 4
 ```
 
+
+## Specifying default values
+
+You can specify default values for almost all supported argument, option, and flag types using normal property initialization syntax:
+
+```swift
+enum CustomFlag: String, EnumerableFlag {
+    case foo, bar, baz
+}
+
+struct Example: ParsableCommand {
+    @Flag
+    var booleanFlag = false
+
+    @Flag
+    var arrayFlag: [CustomFlag] = [.foo, .baz]
+
+    @Option
+    var singleOption = 0
+
+    @Option
+    var arrayOption = ["bar", "qux"]
+
+    @Argument
+    var singleArgument = "quux"
+
+    @Argument
+    var arrayArgument = ["quux", "quuz"]
+}
+```
+
+This includes all of the variants of the argument types above (including `@Option(transform: ...)`, etc.), with a few notable exceptions:
+- `Optional`-typed values (which default to `nil` and for which a default would not make sense, as the value could never be `nil`)
+- `Int` flags (which are used for counting the number of times a flag is specified and therefore default to `0`)
+
+If a default is not specified, the user must provide a value for that argument/option/flag or will receive an error that the value is missing.
+
+You must also always specify a default of `false` for a non-optional `Bool` flag, as in the example above. This makes the behavior consistent with both normal Swift properties (which either must be explicitly initialized or optional to initialize a `struct`/`class` containing them) and the other property types.
+
+
 ## Specifying a parsing strategy
 
 When parsing a list of command-line inputs, `ArgumentParser` distinguishes between dash-prefixed keys and un-prefixed values. When looking for the value for a key, only an un-prefixed value will be selected by default.

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -664,6 +664,16 @@ fileprivate struct RequiredArray_Option_Transform: ParsableArguments {
   var array: [String]
 }
 
+fileprivate struct RequiredArray_Argument_NoTransform: ParsableArguments {
+  @Argument()
+  var array: [String]
+}
+
+fileprivate struct RequiredArray_Argument_Transform: ParsableArguments {
+  @Argument(transform: exclaim)
+  var array: [String]
+}
+
 extension DefaultsEndToEndTests {
   /// Tests that not providing an argument for a required array option produces an error.
   func testParsing_RequiredArray_Option_NoTransform_NoInput() {
@@ -699,6 +709,45 @@ extension DefaultsEndToEndTests {
   /// Tests that providing multiple arguments for a required array option with a transform parses those values correctly.
   func testParsing_RequiredArray_Option_Transform_MultipleInput() {
     AssertParse(RequiredArray_Option_Transform.self, ["--array", "2", "3"]) { arguments in
+      XCTAssertEqual(arguments.array, ["2!", "3!"])
+    }
+  }
+
+
+  /// Tests that not providing an argument for a required array argument produces an error.
+  func testParsing_RequiredArray_Argument_NoTransform_NoInput() {
+    XCTAssertThrowsError(try RequiredArray_Argument_NoTransform.parse([]))
+  }
+
+  /// Tests that providing a single argument for a required array argument parses that value correctly.
+  func testParsing_RequiredArray_Argument_NoTransform_SingleInput() {
+    AssertParse(RequiredArray_Argument_NoTransform.self, ["1"]) { arguments in
+      XCTAssertEqual(arguments.array, ["1"])
+    }
+  }
+
+  /// Tests that providing multiple arguments for a required array argument parses those values correctly.
+  func testParsing_RequiredArray_Argument_NoTransform_MultipleInput() {
+    AssertParse(RequiredArray_Argument_NoTransform.self, ["2", "3"]) { arguments in
+      XCTAssertEqual(arguments.array, ["2", "3"])
+    }
+  }
+
+  /// Tests that not providing an argument for a required array argument with a transform produces an error.
+  func testParsing_RequiredArray_Argument_Transform_NoInput() {
+    XCTAssertThrowsError(try RequiredArray_Argument_Transform.parse([]))
+  }
+
+  /// Tests that providing a single argument for a required array argument with a transform parses that value correctly.
+  func testParsing_RequiredArray_Argument_Transform_SingleInput() {
+    AssertParse(RequiredArray_Argument_Transform.self, ["1"]) { arguments in
+      XCTAssertEqual(arguments.array, ["1!"])
+    }
+  }
+
+  /// Tests that providing multiple arguments for a required array argument with a transform parses those values correctly.
+  func testParsing_RequiredArray_Argument_Transform_MultipleInput() {
+    AssertParse(RequiredArray_Argument_Transform.self, ["2", "3"]) { arguments in
       XCTAssertEqual(arguments.array, ["2!", "3!"])
     }
   }

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -652,3 +652,54 @@ extension DefaultsEndToEndTests {
     }
   }
 }
+
+
+fileprivate struct RequiredArray_Option_NoTransform: ParsableArguments {
+  @Option(parsing: .remaining)
+  var array: [String]
+}
+
+fileprivate struct RequiredArray_Option_Transform: ParsableArguments {
+  @Option(parsing: .remaining, transform: exclaim)
+  var array: [String]
+}
+
+extension DefaultsEndToEndTests {
+  /// Tests that not providing an argument for a required array option produces an error.
+  func testParsing_RequiredArray_Option_NoTransform_NoInput() {
+    XCTAssertThrowsError(try RequiredArray_Option_NoTransform.parse([]))
+  }
+
+  /// Tests that providing a single argument for a required array option parses that value correctly.
+  func testParsing_RequiredArray_Option_NoTransform_SingleInput() {
+    AssertParse(RequiredArray_Option_NoTransform.self, ["--array", "1"]) { arguments in
+      XCTAssertEqual(arguments.array, ["1"])
+    }
+  }
+
+  /// Tests that providing multiple arguments for a required array option parses those values correctly.
+  func testParsing_RequiredArray_Option_NoTransform_MultipleInput() {
+    AssertParse(RequiredArray_Option_NoTransform.self, ["--array", "2", "3"]) { arguments in
+      XCTAssertEqual(arguments.array, ["2", "3"])
+    }
+  }
+
+  /// Tests that not providing an argument for a required array option with a transform produces an error.
+  func testParsing_RequiredArray_Option_Transform_NoInput() {
+    XCTAssertThrowsError(try RequiredArray_Option_Transform.parse([]))
+  }
+
+  /// Tests that providing a single argument for a required array option with a transform parses that value correctly.
+  func testParsing_RequiredArray_Option_Transform_SingleInput() {
+    AssertParse(RequiredArray_Option_Transform.self, ["--array", "1"]) { arguments in
+      XCTAssertEqual(arguments.array, ["1!"])
+    }
+  }
+
+  /// Tests that providing multiple arguments for a required array option with a transform parses those values correctly.
+  func testParsing_RequiredArray_Option_Transform_MultipleInput() {
+    AssertParse(RequiredArray_Option_Transform.self, ["--array", "2", "3"]) { arguments in
+      XCTAssertEqual(arguments.array, ["2!", "3!"])
+    }
+  }
+}

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -674,6 +674,11 @@ fileprivate struct RequiredArray_Argument_Transform: ParsableArguments {
   var array: [String]
 }
 
+fileprivate struct RequiredArray_Flag: ParsableArguments {
+  @Flag
+  var array: [HasData]
+}
+
 extension DefaultsEndToEndTests {
   /// Tests that not providing an argument for a required array option produces an error.
   func testParsing_RequiredArray_Option_NoTransform_NoInput() {
@@ -749,6 +754,26 @@ extension DefaultsEndToEndTests {
   func testParsing_RequiredArray_Argument_Transform_MultipleInput() {
     AssertParse(RequiredArray_Argument_Transform.self, ["2", "3"]) { arguments in
       XCTAssertEqual(arguments.array, ["2!", "3!"])
+    }
+  }
+
+
+  /// Tests that not providing an argument for a required array flag produces an error.
+  func testParsing_RequiredArray_Flag_NoInput() {
+    XCTAssertThrowsError(try RequiredArray_Flag.parse([]))
+  }
+
+  /// Tests that providing a single argument for a required array flag parses that value correctly.
+  func testParsing_RequiredArray_Flag_SingleInput() {
+    AssertParse(RequiredArray_Flag.self, ["--data"]) { arguments in
+      XCTAssertEqual(arguments.array, [.data])
+    }
+  }
+
+  /// Tests that providing multiple arguments for a required array flag parses those values correctly.
+  func testParsing_RequiredArray_Flag_MultipleInput() {
+    AssertParse(RequiredArray_Flag.self, ["--data", "--no-data"]) { arguments in
+      XCTAssertEqual(arguments.array, [.data, .noData])
     }
   }
 }


### PR DESCRIPTION
Un-deprecates (but changes the semantics of) the initializers for an array value type without a default, forcing the user to specify at least one value from the command line.

The motivation behind this is to allow users of this framework to force a user to provide at least one argument, without having to provide custom error handling. An example of a command that uses this argument setup is `cp`, which has a variant for one or more `source_file` arguments:
`cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory`

This unfortunately does un-do the deprecations done In #193 and also is a source-breaking change in a similar vein as the one in #170 (changing the semantics of the case where no default is provided) and so will need to wait for the next minor release as per the documentation. I'm happy to sit on this and occasionally re-integrate `master` into it until you're ready for a new release, but figured I'd at least get it in for review.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
