### PR TITLE
Add a precondition to prevent the parsing of a command that has itself as its subcommand

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -44,6 +44,13 @@ extension ParsableCommand {
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }
+    
+  private static func checkConfigurationPrecondition() {
+    precondition(
+      !self.configuration.subcommands.contains { $0 == self },
+      "The CommandConfiguration provided is invalid: you can't use a command as its own subcommand."
+    )
+  }
 }
 
 // MARK: - API
@@ -59,6 +66,7 @@ extension ParsableCommand {
   public static func parseAsRoot(
     _ arguments: [String]? = nil
   ) throws -> ParsableCommand {
+    checkConfigurationPrecondition()
     var parser = CommandParser(self)
     let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
     return try parser.parse(arguments: arguments).get()
@@ -79,6 +87,7 @@ extension ParsableCommand {
     for subcommand: ParsableCommand.Type,
     columns: Int? = nil
   ) -> String { 
+    checkConfigurationPrecondition()
     let stack = CommandParser(self).commandStack(for: subcommand)
     return HelpGenerator(commandStack: stack).rendered(screenWidth: columns)
   }

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -44,13 +44,6 @@ extension ParsableCommand {
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }
-    
-  private static func checkConfigurationPrecondition() {
-    precondition(
-      !self.configuration.subcommands.contains { $0 == self },
-      "The CommandConfiguration provided is invalid: you can't use a command as its own subcommand."
-    )
-  }
 }
 
 // MARK: - API
@@ -66,7 +59,6 @@ extension ParsableCommand {
   public static func parseAsRoot(
     _ arguments: [String]? = nil
   ) throws -> ParsableCommand {
-    checkConfigurationPrecondition()
     var parser = CommandParser(self)
     let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
     return try parser.parse(arguments: arguments).get()
@@ -87,7 +79,6 @@ extension ParsableCommand {
     for subcommand: ParsableCommand.Type,
     columns: Int? = nil
   ) -> String { 
-    checkConfigurationPrecondition()
     let stack = CommandParser(self).commandStack(for: subcommand)
     return HelpGenerator(commandStack: stack).rendered(screenWidth: columns)
   }

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -31,7 +31,13 @@ struct CommandParser {
   }
   
   init(_ rootCommand: ParsableCommand.Type) {
-    self.commandTree = Tree(root: rootCommand)
+    do {
+      self.commandTree = try Tree(root: rootCommand)
+    } catch Tree<ParsableCommand.Type>.InitializationError.recursiveSubcommand(let command) {
+      fatalError("The ParsableCommand \"\(command)\" can't have itself as its own subcommand.")
+    } catch {
+      fatalError("Unexpected error: \(error).")
+    }
     self.currentNode = commandTree
     
     // A command tree that has a depth greater than zero gets a `help`

--- a/Sources/ArgumentParser/Utilities/Tree.swift
+++ b/Sources/ArgumentParser/Utilities/Tree.swift
@@ -88,10 +88,17 @@ extension Tree where Element == ParsableCommand.Type {
     children.first(where: { $0.element._commandName == name })
   }
   
-  convenience init(root command: ParsableCommand.Type) {
+  convenience init(root command: ParsableCommand.Type) throws {
     self.init(command)
     for subcommand in command.configuration.subcommands {
-      addChild(Tree(root: subcommand))
+      if subcommand == command {
+        throw InitializationError.recursiveSubcommand(subcommand)
+      }
+      try addChild(Tree(root: subcommand))
     }
+  }
+    
+  enum InitializationError: Error {
+    case recursiveSubcommand(ParsableCommand.Type)
   }
 }

--- a/Tests/ArgumentParserUnitTests/TreeTests.swift
+++ b/Tests/ArgumentParserUnitTests/TreeTests.swift
@@ -53,3 +53,20 @@ extension TreeTests {
     XCTAssertTrue(tree.path(toFirstWhere: { $0 < 0 }).isEmpty)
   }
 }
+
+extension TreeTests {
+  struct A: ParsableCommand {
+    static let configuration = CommandConfiguration(subcommands: [A.self])
+  }
+  struct Root: ParsableCommand {
+    static let configuration = CommandConfiguration(subcommands: [Sub.self])
+  }
+  struct Sub: ParsableCommand {
+    static var configuration = CommandConfiguration(subcommands: [Sub.self])
+  }
+    
+  func testInitializationWithRecursiveSubcommand() {
+    XCTAssertThrowsError(try Tree(root: A.asCommand))
+    XCTAssertThrowsError(try Tree(root: Root.asCommand))
+  }
+}

--- a/Tests/ArgumentParserUnitTests/TreeTests.swift
+++ b/Tests/ArgumentParserUnitTests/TreeTests.swift
@@ -62,7 +62,7 @@ extension TreeTests {
     static let configuration = CommandConfiguration(subcommands: [Sub.self])
   }
   struct Sub: ParsableCommand {
-    static var configuration = CommandConfiguration(subcommands: [Sub.self])
+    static let configuration = CommandConfiguration(subcommands: [Sub.self])
   }
     
   func testInitializationWithRecursiveSubcommand() {


### PR DESCRIPTION
This avoids the infinite recursion that causes a crash and shows the user a meaningful error message.

Fixes: https://github.com/apple/swift-argument-parser/issues/192

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
