### PR TITLE
Change `CommandError` and `MessageInfo` to `public`

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct CommandError: Error {
-  var commandStack: [ParsableCommand.Type]
+public struct CommandError: Error {
+  public var commandStack: [ParsableCommand.Type]
   var parserError: ParserError
 }
 

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -11,12 +11,12 @@
 
 @_implementationOnly import Foundation
 
-enum MessageInfo {
+public enum MessageInfo {
   case help(text: String)
   case validation(message: String, usage: String)
   case other(message: String, exitCode: Int32)
   
-  init(error: Error, type: ParsableArguments.Type) {
+  public init(error: Error, type: ParsableArguments.Type) {
     var commandStack: [ParsableCommand.Type]
     var parserError: ParserError? = nil
     
@@ -93,7 +93,7 @@ enum MessageInfo {
     }
   }
   
-  var message: String {
+  public var message: String {
     switch self {
     case .help(text: let text):
       return text
@@ -104,7 +104,7 @@ enum MessageInfo {
     }
   }
   
-  var fullText: String {
+  public var fullText: String {
     switch self {
     case .help(text: let text):
       return text
@@ -123,7 +123,7 @@ enum MessageInfo {
     }
   }
 
-  var exitCode: ExitCode {
+  public var exitCode: ExitCode {
     switch self {
     case .help: return ExitCode.success
     case .validation: return ExitCode.validationFailure


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Change `CommandError` and `MessageInfo` to `public`. 

### TL:DR;
The motivation behind it was the desire to react to such error with a beautiful message.

### Motivation
In our tool, we use SwiftNIO and ArgumentParser for handling slack commands. At one point a command can fail. For example when a user provides not expect a flag. This will produce `CommandError`. NIO's `mapIfError` will bring it to `Error` type. Hence at this moment, we can only print such error.

```
CommandError(commandStack: [SlackCommands.PR], parserError: ArgumentParser.ParserError.unknownOption(ArgumentParser.InputOrigin.Element.argumentIndex(0), ArgumentParser.Name.long("some-wrong-argument")))
```

Not very user friendly :(
But if `CommandError` and `MessageInfo` would be public. We could detect if the mapped error is a `CommandError` and use `MessageInfo` to print a much nicer message. Such as

```
Error: Missing expected argument '<project-name>'
Usage: Stats project <project-name> [--repository <repository>]
  See 'Stats project --help' for more information.
```


This is how we would use it
```
func handleWebHook(payload: SlackHookPayload) throws -> Future<String> {
    return commandDispatcher.dispatch(payload: payload).mapIfError { error -> String in
        guard let commandError = error as? ArgumentParser.CommandError, let commandType = commandError.commandStack.first.self else {
            return "Command failed with a message: \(error)"
        }
        return MessageInfo(error: commandError, type: commandType).fullText
    }
}
```


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate // Not applicable
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary // Not applicable
