### PR TITLE
Optimize Sequence.uniquified()

### DIFF
--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -11,7 +11,7 @@
 
 extension Sequence where Element: Hashable {
   func uniquified() -> [Iterator.Element] {
-    var seen: [Iterator.Element: Bool] = [:]
-    return self.filter { seen.updateValue(true, forKey: $0) == nil }
+    var seen = Set<Element>()
+    return self.filter { seen.insert($0).0 }
   }
 }

--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Sequence where Iterator.Element: Hashable {
+extension Sequence where Element: Hashable {
   func uniquified() -> [Iterator.Element] {
     var seen: [Iterator.Element: Bool] = [:]
     return self.filter { seen.updateValue(true, forKey: $0) == nil }

--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Sequence where Element: Hashable {
-  func uniquified() -> [Iterator.Element] {
+  func uniquified() -> [Element] {
     var seen = Set<Element>()
     return self.filter { seen.insert($0).0 }
   }

--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -9,14 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Sequence where Element: Equatable {
-  func uniquified() -> [Element] {
-    var sequence = Array<Element>()
-    for element in self {
-      if !sequence.contains(element) {
-        sequence.append(element)
-      }
-    }
-    return sequence
+extension Sequence where Iterator.Element: Hashable {
+  func uniquified() -> [Iterator.Element] {
+    var seen: [Iterator.Element: Bool] = [:]
+    return self.filter { seen.updateValue(true, forKey: $0) == nil }
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Proposes a slight optimization of `uniquified ` added in #179.  Using `contains` on the temporary `sequence` variable leads to quadratic performance because `.contains` runs in O(n) time.  

By instead creating a temporary variable that is a dictionary, we can filter on `self` and use the dictionary's [`.updateValue`](https://developer.apple.com/documentation/swift/dictionary/3127179-updatevalue) member, passing in each element. This keeps performance near O(n) - the tradeoff being that this requires elements to conform to `Hashable` (vs just `Equatable`).

Not sure if another test is needed as all tests continue to pass, but happy to add one if this is smiled upon.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
