### PR TITLE
Allow property wrappers to be used without parentheses

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -35,6 +35,20 @@ public struct Argument<Value>:
   public init(from decoder: Decoder) throws {
     try self.init(_decoder: decoder)
   }
+
+  /// This initializer works around a quirk of property wrappers, where the
+  /// compiler will not see no-argument initializers in extensions. Explicitly
+  /// marking this initializer unavailable means that when `Value` conforms to
+  /// `ExpressibleByArgument`, that overload will be selected instead.
+  ///
+  /// ```swift
+  /// @Argument() var foo: String // Syntax without this initializer
+  /// @Argument var foo: String   // Syntax with this initializer
+  /// ```
+  @available(*, unavailable, message: "A default value must be provided unless the value type conforms to ExpressibleByArgument.")
+  public init() {
+    fatalError("unavailable")
+  }
   
   /// The value presented by this property wrapper.
   public var wrappedValue: Value {
@@ -113,8 +127,7 @@ extension Argument where Value: ExpressibleByArgument {
   ///
   /// This method is called to initialize an `Argument` with a default value such as:
   /// ```swift
-  /// @Argument()
-  /// var foo: String = "bar"
+  /// @Argument var foo: String = "bar"
   /// ```
   ///
   /// - Parameters:
@@ -134,8 +147,7 @@ extension Argument where Value: ExpressibleByArgument {
   ///
   /// This method is called to initialize an `Argument` without a default value such as:
   /// ```swift
-  /// @Argument()
-  /// var foo: String
+  /// @Argument var foo: String
   /// ```
   ///
   /// - Parameters:

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -47,7 +47,22 @@ public struct Flag<Value>: Decodable, ParsedWrapper {
   public init(from decoder: Decoder) throws {
     try self.init(_decoder: decoder)
   }
-  
+
+  /// This initializer works around a quirk of property wrappers, where the
+  /// compiler will not see no-argument initializers in extensions. Explicitly
+  /// marking this initializer unavailable means that when `Value` is a type
+  /// supported by `Flag` like `Bool` or `EnumerableFlag`, the appropriate
+  /// overload will be selected instead.
+  ///
+  /// ```swift
+  /// @Flag() var flag: Bool  // Syntax without this initializer
+  /// @Flag var flag: Bool    // Syntax with this initializer
+  /// ```
+  @available(*, unavailable, message: "A default value must be provided unless the value type is supported by Flag.")
+  public init() {
+    fatalError("unavailable")
+  }
+
   /// The value presented by this property wrapper.
   public var wrappedValue: Value {
     get {
@@ -222,8 +237,7 @@ extension Flag where Value == Bool {
   /// ```diff
   /// -@Flag(default: true)
   /// -var foo: Bool
-  /// +@Flag()
-  /// +var foo: Bool = true
+  /// +@Flag var foo: Bool = true
   /// ```
   ///
   /// Use this initializer to create a Boolean flag with an on/off pair. With
@@ -245,7 +259,7 @@ extension Flag where Value == Bool {
   ///         case useDevelopmentServer
   ///     }
   ///
-  ///     @Flag() var serverChoice: ServerChoice
+  ///     @Flag var serverChoice: ServerChoice
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
@@ -401,10 +415,9 @@ extension Flag where Value: EnumerableFlag {
   ///
   /// Existing usage of the `default` parameter should be replaced such as follows:
   /// ```diff
-  /// -@Argument(default: .baz)
+  /// -@Flag(default: .baz)
   /// -var foo: Bar
-  /// +@Argument()
-  /// +var foo: Bar = baz
+  /// +@Flag var foo: Bar = baz
   /// ```
   ///
   /// - Parameters:
@@ -438,7 +451,7 @@ extension Flag where Value: EnumerableFlag {
   ///   case useDevelopmentServer
   /// }
   ///
-  /// @Flag() var serverChoice: ServerChoice = .useProductionServer
+  /// @Flag var serverChoice: ServerChoice = .useProductionServer
   /// ```
   ///
   /// - Parameters:
@@ -469,7 +482,7 @@ extension Flag where Value: EnumerableFlag {
   ///   case useDevelopmentServer
   /// }
   ///
-  /// @Flag() var serverChoice: ServerChoice
+  /// @Flag var serverChoice: ServerChoice
   /// ```
   ///
   /// - Parameters:

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -37,7 +37,21 @@ public struct Option<Value>: Decodable, ParsedWrapper {
   public init(from decoder: Decoder) throws {
     try self.init(_decoder: decoder)
   }
-  
+
+  /// This initializer works around a quirk of property wrappers, where the
+  /// compiler will not see no-argument initializers in extensions. Explicitly
+  /// marking this initializer unavailable means that when `Value` conforms to
+  /// `ExpressibleByArgument`, that overload will be selected instead.
+  ///
+  /// ```swift
+  /// @Option() var foo: String // Syntax without this initializer
+  /// @Option var foo: String   // Syntax with this initializer
+  /// ```
+  @available(*, unavailable, message: "A default value must be provided unless the value type conforms to ExpressibleByArgument.")
+  public init() {
+    fatalError("unavailable")
+  }
+
   /// The value presented by this property wrapper.
   public var wrappedValue: Value {
     get {
@@ -100,8 +114,7 @@ extension Option where Value: ExpressibleByArgument {
   /// ```diff
   /// -@Option(default: "bar")
   /// -var foo: String
-  /// +@Option()
-  /// +var foo: String = "bar"
+  /// +@Option var foo: String = "bar"
   /// ```
   ///
   /// - Parameters:
@@ -130,8 +143,7 @@ extension Option where Value: ExpressibleByArgument {
   ///
   /// This method is called to initialize an `Option` with a default value such as:
   /// ```swift
-  /// @Option()
-  /// var foo: String = "bar"
+  /// @Option var foo: String = "bar"
   /// ```
   ///
   /// - Parameters:
@@ -157,8 +169,7 @@ extension Option where Value: ExpressibleByArgument {
   ///
   /// This method is called to initialize an `Option` without a default value such as:
   /// ```swift
-  /// @Option()
-  /// var foo: String
+  /// @Option var foo: String
   /// ```
   ///
   /// - Parameters:

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -18,16 +18,12 @@
 ///         @Flag(name: .shortAndLong)
 ///         var verbose: Bool
 ///
-///         @Argument()
-///         var values: [Int]
+///         @Argument var values: [Int]
 ///     }
 ///
 ///     struct Options: ParsableArguments {
-///         @Option()
-///         var name: String
-///
-///         @OptionGroup()
-///         var globals: GlobalOptions
+///         @Option var name: String
+///         @OptionGroup var globals: GlobalOptions
 ///     }
 ///
 /// The flag and positional arguments declared as part of `GlobalOptions` are
@@ -58,7 +54,14 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
       throw ParserError.userValidationError(error)
     }
   }
-  
+
+  /// Creates a property that represents another parsable type.
+  public init() {
+    self.init(_parsedValue: .init { _ in
+      ArgumentSet(Value.self)
+    })
+  }
+
   /// The value presented by this property wrapper.
   public var wrappedValue: Value {
     get {
@@ -83,14 +86,5 @@ extension OptionGroup: CustomStringConvertible {
     case .definition:
       return "OptionGroup(*definition*)"
     }
-  }
-}
-
-extension OptionGroup {
-  /// Creates a property that represents another parsable type.
-  public init() {
-    self.init(_parsedValue: .init { _ in
-      ArgumentSet(Value.self)
-      })
   }
 }

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -167,6 +167,17 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     var options: Options
   }
 
+  private struct L: ParsableArguments {
+    struct Options: ParsableArguments {
+      @Argument var items: [Int] = []
+    }
+
+    @Argument var foo: String
+    @Option var bar: String
+    @OptionGroup var options: Options
+    @Flag var flag: Bool
+  }
+
   func testPositionalArgumentsValidation() throws {
     XCTAssertNil(PositionalArgumentsValidator.validate(A.self))
     XCTAssertNil(PositionalArgumentsValidator.validate(F.self))


### PR DESCRIPTION
Fixes #206, where unless the property wrapper types were used with empty parentheses, `ParsableArguments`-conforming types would not have a no-argument initializer synthesized and thus would unexpectedbly fail to
conform to `ParsableArguments`.

This is caused by [a limitation of the compiler's property wrapper support](https://bugs.swift.org/browse/SR-13295) where it fails to see initializers in extensions as candidates for property wrapper requirements.

By declaring a no-argument intializer in each type, but then marking it as unavailable, the no-parenthesis syntax now works, but selects the existing initializers in extensions anyway.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
