### PR TITLE
Make arrays with default values use their elements' defaultValueDescription

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -366,7 +366,7 @@ extension Argument {
         initial: { origin, values in
           values.set(wrappedValue, forKey: key, inputOrigin: origin)
         })
-      arg.help.defaultValue = !wrappedValue.isEmpty ? "\(wrappedValue)" : nil
+      arg.help.defaultValue = !wrappedValue.isEmpty ? wrappedValue.defaultValueDescription : nil
       return ArgumentSet(alternatives: [arg])
     })
   }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -498,7 +498,7 @@ extension Option {
       var arg = ArgumentDefinition(kind: kind, help: help, parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy), update: .appendToArray(forType: Element.self, key: key), initial: { origin, values in
         values.set(wrappedValue, forKey: key, inputOrigin: origin)
       })
-      arg.help.defaultValue = !wrappedValue.isEmpty ? "\(wrappedValue)" : nil
+      arg.help.defaultValue = !wrappedValue.isEmpty ? wrappedValue.defaultValueDescription : nil
       return ArgumentSet(alternatives: [arg])
       })
   }

--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -66,3 +66,9 @@ extension Float: ExpressibleByArgument {}
 extension Double: ExpressibleByArgument {}
 
 extension Bool: ExpressibleByArgument {}
+
+extension Array where Element: ExpressibleByArgument {
+  var defaultValueDescription: String {
+    return "[\(map { $0.defaultValueDescription }.joined(separator: ", "))]"
+  }
+}

--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -69,6 +69,6 @@ extension Bool: ExpressibleByArgument {}
 
 extension Array where Element: ExpressibleByArgument {
   var defaultValueDescription: String {
-    return "[\(map { $0.defaultValueDescription }.joined(separator: ", "))]"
+    return map { $0.defaultValueDescription }.joined(separator: ", ")
   }
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -427,10 +427,10 @@ extension HelpGenerationTests {
     USAGE: p [-o <o> ...] [<remainder> ...]
 
     ARGUMENTS:
-      <remainder>             Help Message (default: [large])
+      <remainder>             Help Message (default: large)
 
     OPTIONS:
-      -o <o>                  Help Message (default: [small, medium])
+      -o <o>                  Help Message (default: small, medium)
       -h, --help              Show help information.
 
     """)

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -174,7 +174,7 @@ extension HelpGenerationTests {
                                       Your middle name. (default: Winston)
               --age <age>             Your age. (default: 20)
               --logging <logging>     Whether logging is enabled. (default: false)
-              --lucky <numbers>       Your lucky numbers. (default: [7, 14])
+              --lucky <numbers>       Your lucky numbers. (default: 7, 14)
               --optional/--required   Vegan diet. (default: optional)
               --degree <degree>       Your degree. (default: bachelor)
               --directory <directory> Directory. (default: current directory)

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -401,4 +401,38 @@ extension HelpGenerationTests {
       See 'n help <subcommand>' for detailed help.
     """)
   }
+
+  enum O: String, ExpressibleByArgument {
+    case small
+    case medium
+    case large
+
+    init?(argument: String) {
+      guard let result = Self(rawValue: argument) else {
+        return nil
+      }
+      self = result
+    }
+  }
+  struct P: ParsableArguments {
+    @Option(name: [.short], help: "Help Message")
+    var o: [O] = [.small, .medium]
+
+    @Argument(help: "Help Message")
+    var remainder: [O] = [.large]
+  }
+
+  func testHelpWithDefaultValueForArray() {
+    AssertHelp(for: P.self, equals: """
+    USAGE: p [-o <o> ...] [<remainder> ...]
+
+    ARGUMENTS:
+      <remainder>             Help Message (default: [large])
+
+    OPTIONS:
+      -o <o>                  Help Message (default: [small, medium])
+      -h, --help              Show help information.
+
+    """)
+  }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Makes default values for `@Argument`s and `@Option`s whose values are arrays of `ExpressibleByArgument` use their elements' `defaultValueDescription` in the help text.

Fixes #208.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
