### PR TITLE
Update documentation and examples to use natural property wrapper syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ package updates, you can specify your package dependency using
   
   ```swift
   // old
-  @Flag() var verbose: Bool
+  @Flag var verbose: Bool
   // new
-  @Flag() var verbose = false
+  @Flag var verbose = false
   ```
   
   **_Important:_** There is a semantic change for flags with inversions that do
@@ -198,7 +198,7 @@ The 0.0.5 release includes contributions from [kennyyork], [natecook1000],
   properly constrained.
 - The parser no longer treats passing the same exclusive flag more than once as
   an error.
-- `ParsableArguments` types that are declared as `@OptionGroup()` properties on
+- `ParsableArguments` types that are declared as `@OptionGroup` properties on
   commands can now also be declared on subcommands. Previosuly, the parent 
   command's declaration would prevent subcommands from seeing the user-supplied 
   arguments.

--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -46,11 +46,8 @@ We'll define the initial version of the command as a type that conforms to the `
 import ArgumentParser
 
 struct Count: ParsableCommand {
-    @Argument()
-    var inputFile: String
-
-    @Argument()
-    var outputFile: String
+    @Argument var inputFile: String
+    @Argument var outputFile: String
     
     mutating func run() throws {
         print("""
@@ -85,11 +82,8 @@ We do this by using the `@Option` property wrapper instead of `@Argument`:
 
 ```swift
 struct Count: ParsableCommand {
-    @Option()
-    var inputFile: String
-
-    @Option()
-    var outputFile: String
+    @Option var inputFile: String
+    @Option var outputFile: String
     
     mutating func run() throws {
         print("""
@@ -126,14 +120,9 @@ Let's change our `Count` type to look like this:
 
 ```swift
 struct Count: ParsableCommand {
-    @Option()
-    var inputFile: String
-
-    @Option()
-    var outputFile: String
-
-    @Flag()
-    var verbose = false
+    @Option var inputFile: String
+    @Option var outputFile: String
+    @Flag var verbose = false
     
     mutating func run() throws {
         if verbose {

--- a/Documentation/02 Arguments, Options, and Flags.md
+++ b/Documentation/02 Arguments, Options, and Flags.md
@@ -26,15 +26,11 @@ The three preceding examples could be calls of this `Example` command:
 
 ```swift
 struct Example: ParsableCommand {
-    @Argument() var files: [String] = []
-
-    @Option() var count: Int?
-
-    @Option() var index = 0
-
-    @Flag() var verbose = false
-
-    @Flag() var stripWhitespace = false
+    @Argument var files: [String] = []
+    @Option var count: Int?
+    @Option var index = 0
+    @Flag var verbose = false
+    @Flag var stripWhitespace = false
 }
 ```
 
@@ -49,11 +45,8 @@ Users must provide values for all properties with no implicit or specified defau
 
 ```swift
 struct Example: ParsableCommand {
-    @Option()
-    var userName: String
-
-    @Argument()
-    var value: Int
+    @Option var userName: String
+    @Argument var value: Int
 }
 ```
 
@@ -74,9 +67,8 @@ When providing a default value for an array property, any user-supplied values r
 
 ```swift
 struct Lucky: ParsableCommand {
-  @Argument()
-  var numbers = [7, 14, 21]
-  
+  @Argument var numbers = [7, 14, 21]
+
   mutating func run() throws {
     print("""
     Your lucky numbers are:
@@ -154,7 +146,7 @@ struct Path: ExpressibleByArgument {
 }
 
 struct Example: ParsableCommand {
-    @Argument() var inputFile: Path
+    @Argument var inputFile: Path
 }
 ```
 
@@ -166,7 +158,7 @@ enum ReleaseMode: String, ExpressibleByArgument {
 }
 
 struct Example: ParsableCommand {
-    @Option() var mode: ReleaseMode
+    @Option var mode: ReleaseMode
 
     mutating func run() throws {
         print(mode)
@@ -251,9 +243,8 @@ enum Color: String, EnumerableFlag {
 }
 
 struct Example: ParsableCommand {
-    @Flag() var cacheMethod: CacheMethod
-
-    @Flag() var colors: [Color] = []
+    @Flag var cacheMethod: CacheMethod
+    @Flag var colors: [Color] = []
 
     mutating func run() throws {
         print(cacheMethod)
@@ -302,9 +293,9 @@ For example, this command defines a `--verbose` flag, a `--name` option, and an 
 
 ```swift
 struct Example: ParsableCommand {
-    @Flag() var verbose = false
-    @Option() var name: String
-    @Argument() var file: String?
+    @Flag var verbose = false
+    @Option var name: String
+    @Argument var file: String?
 
     mutating func run() throws {
         print("Verbose: \(verbose), name: \(name), file: \(file ?? "none")")
@@ -349,8 +340,8 @@ The default strategy for parsing options as arrays is to read each value from a 
 
 ```swift
 struct Example: ParsableCommand {
-    @Option() var file: [String] = []
-    @Flag() var verbose = false
+    @Option var file: [String] = []
+    @Flag var verbose = false
 
     mutating func run() throws {
         print("Verbose: \(verbose), files: \(file)")
@@ -400,8 +391,8 @@ The default strategy for parsing arrays of positional arguments is to ignore  al
 
 ```swift
 struct Example: ParsableCommand {
-    @Flag() var verbose = false
-    @Argument() var files: [String] = []
+    @Flag var verbose = false
+    @Argument var files: [String] = []
 
     mutating func run() throws {
         print("Verbose: \(verbose), files: \(files)")

--- a/Documentation/03 Commands and Subcommands.md
+++ b/Documentation/03 Commands and Subcommands.md
@@ -63,7 +63,7 @@ struct Options: ParsableArguments {
 }
 ```
 
-It's time to define our first two subcommands: `Add` and `Multiply`. Both of these subcommands include the arguments defined in the `Options` type by denoting that property with the `@OptionGroup()` property wrapper. `@OptionGroup` doesn't define any new arguments for a command; instead, it splats in the arguments defined by another `ParsableArguments` type.
+It's time to define our first two subcommands: `Add` and `Multiply`. Both of these subcommands include the arguments defined in the `Options` type by denoting that property with the `@OptionGroup` property wrapper. `@OptionGroup` doesn't define any new arguments for a command; instead, it splats in the arguments defined by another `ParsableArguments` type.
 
 ```swift
 extension Math {
@@ -71,8 +71,7 @@ extension Math {
         static var configuration
             = CommandConfiguration(abstract: "Print the sum of the values.")
 
-        @OptionGroup()
-        var options: Math.Options
+        @OptionGroup var options: Math.Options
 
         mutating func run() {
             let result = options.values.reduce(0, +)
@@ -84,8 +83,7 @@ extension Math {
         static var configuration
             = CommandConfiguration(abstract: "Print the product of the values.")
 
-        @OptionGroup()
-        var options: Math.Options
+        @OptionGroup var options: Math.Options
 
         mutating func run() {
             let result = options.values.reduce(1, *)

--- a/Documentation/05 Validation and Errors.md
+++ b/Documentation/05 Validation and Errors.md
@@ -12,11 +12,8 @@ Here's a command that prints out one or more random elements from the list you p
 
 ```swift
 struct Select: ParsableCommand {
-    @Option
-    var count: Int = 1
-
-    @Argument()
-    var elements: [String] = []
+    @Option var count: Int = 1
+    @Argument var elements: [String] = []
 
     mutating func validate() throws {
         guard count >= 1 else {
@@ -64,7 +61,7 @@ The `ValidationError` type is a special `ArgumentParser` error — a validation 
 
 ```swift
 struct LineCount: ParsableCommand {
-    @Argument() var file: String
+    @Argument var file: String
 
     mutating func run() throws {
         let contents = try String(contentsOfFile: file, encoding: .utf8)
@@ -92,7 +89,7 @@ struct RuntimeError: Error, CustomStringConvertible {
 }
 
 struct Example: ParsableCommand {
-    @Argument() var inputFile: String
+    @Argument var inputFile: String
 
     mutating func run() throws {
         if !ExampleCore.processFile(inputFile) {

--- a/Documentation/06 Manual Parsing and Testing.md
+++ b/Documentation/06 Manual Parsing and Testing.md
@@ -12,11 +12,8 @@ Let's implement the `Select` command discussed in [Validation and Errors](05%20V
 
 ```swift
 struct SelectOptions: ParsableArguments {
-    @Option()
-    var count: Int = 1
-
-    @Argument()
-    var elements: [String] = []
+    @Option var count: Int = 1
+    @Argument var elements: [String] = []
 }
 ```
 

--- a/Examples/math/main.swift
+++ b/Examples/math/main.swift
@@ -54,8 +54,7 @@ extension Math {
 
         // The `@OptionGroup` attribute includes the flags, options, and
         // arguments defined by another `ParsableArguments` type.
-        @OptionGroup()
-        var options: Options
+        @OptionGroup var options: Options
 
         mutating func run() {
             let result = options.values.reduce(0, +)
@@ -67,8 +66,7 @@ extension Math {
         static var configuration =
             CommandConfiguration(abstract: "Print the product of the values.")
 
-        @OptionGroup()
-        var options: Options
+        @OptionGroup var options: Options
 
         mutating func run() {
             let result = options.values.reduce(1, *)

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -104,8 +104,7 @@ extension Argument where Value: ExpressibleByArgument {
   /// ```diff
   /// -@Argument(default: "bar")
   /// -var foo: String
-  /// +@Argument()
-  /// +var foo: String = "bar"
+  /// +@Argument var foo: String = "bar"
   /// ```
   ///
   /// - Parameters:
@@ -171,7 +170,7 @@ public enum ArgumentArrayParsingStrategy {
   /// For example, for a parsable type defined as following:
   ///
   ///     struct Options: ParsableArguments {
-  ///         @Flag() var verbose: Bool
+  ///         @Flag var verbose: Bool
   ///         @Argument(parsing: .remaining) var words: [String]
   ///     }
   ///
@@ -188,7 +187,7 @@ public enum ArgumentArrayParsingStrategy {
   /// For example, for a parsable type defined as following:
   ///
   ///     struct Options: ParsableArguments {
-  ///         @Flag() var verbose: Bool
+  ///         @Flag var verbose: Bool
   ///         @Argument(parsing: .unconditionalRemaining) var words: [String]
   ///     }
   ///

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -294,11 +294,8 @@ public enum ArrayParsingStrategy {
   /// through the terminator `--`. That is the more common approach. For example:
   /// ```swift
   /// struct Options: ParsableArguments {
-  ///     @Option()
-  ///     var name: String
-  ///
-  ///     @Argument()
-  ///     var remainder: [String]
+  ///     @Option var name: String
+  ///     @Argument var remainder: [String]
   /// }
   /// ```
   /// would parse the input `--name Foo -- Bar --baz` such that the `remainder`

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -20,7 +20,7 @@
 ///     }
 ///
 ///     struct Example: ParsableCommand {
-///         @Flag() var sizes: [Size]
+///         @Flag var sizes: [Size]
 ///
 ///         mutating func run() {
 ///             print(sizes)

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -52,8 +52,7 @@ struct _WrappedParsableCommand<P: ParsableArguments>: ParsableCommand {
     }
   }
   
-  @OptionGroup()
-  var options: P
+  @OptionGroup var options: P
 }
 
 struct StandardError: TextOutputStream {

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -12,7 +12,7 @@
 struct HelpCommand: ParsableCommand {
   static var configuration = CommandConfiguration(commandName: "help")
   
-  @Argument() var subcommands: [String] = []
+  @Argument var subcommands: [String] = []
   
   private(set) var commandStack: [ParsableCommand.Type] = []
   


### PR DESCRIPTION
Since https://github.com/apple/swift-argument-parser/pull/207, property wrapper usage with no arguments can now use the more natural syntax without the `()`. Updates documentation and example code accordingly.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
