### PR TITLE
Improve support for multi-word completion strings in ZSH

### DIFF
--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -22,7 +22,7 @@ struct ZshCompletionsGenerator {
 
     \(generateCompletionFunction([type]))
     _custom_completion() {
-        local completions=($($*))
+        local completions=("${(@f)$($*)}")
         _describe '' completions
     }
 

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -495,7 +495,7 @@ _math_help() {
 
 
 _custom_completion() {
-    local completions=($($*))
+    local completions=("${(@f)$($*)}")
     _describe '' completions
 }
 

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -226,7 +226,7 @@ _escaped() {
 
 
 _custom_completion() {
-    local completions=($($*))
+    local completions=("${(@f)$($*)}")
     _describe '' completions
 }
 

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -134,7 +134,7 @@ _base() {
 
 
 _custom_completion() {
-    local completions=($($*))
+    local completions=("${(@f)$($*)}")
     _describe '' completions
 }
 


### PR DESCRIPTION
This changes the existing string substitution expression that's used to take the results of a custom completion callback and turn it into an array of strings so that each string is not split on whitespace it might contain.

I will not pretend to fully understand why this new "expand string into array" expression works when the other didn't, but it does. The new expression is based on this SO answer: https://unix.stackexchange.com/a/29748. I know just enough shell stuff to be dangerous, so it's very likely there's a better way than what I've found, and I'd be happy to get some feedback on this!

The motivation for this change was for the install command of [xcodes](https://github.com/RobotsAndPencils/xcodes) (PR with swift-argument-parser support [here](https://github.com/RobotsAndPencils/xcodes/pull/94)) to support Xcode version completion strings with multiple words, like "12.0 Beta". The previous version of this expression would split this string into two, so that "12.0" and "Beta" were independent options in the ZSH completion UI, which didn't make sense for this use case.

For example, if `xcodes ---completion install -- version` printed:

```
11.6
12.0 Beta
12.0 Beta 2
12.0 Beta 3
```

the previous implementation would result in ZSH's completion UI looking like this (braces to indicate terminal highlighting):

```
$ xcodes install <tab>
[11.6]
12.0
2
3
Beta
```

and this new implementation will result in ZSH's completion UI looking like this:

```
$ xcodes install <tab>
[11.6]
12.0 Beta
12.0 Beta 2
12.0 Beta 3
```

Similar results can be seen in the example math executable, if you add a multi-word string to the result of the customArg argument.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
