### PR TITLE
Update doc with Zsh completion filename format

### DIFF
--- a/Documentation/07 Completion Scripts.md
+++ b/Documentation/07 Completion Scripts.md
@@ -28,6 +28,12 @@ The correct method of installing a completion script depends on your shell and y
 
 If you have [`oh-my-zsh`](https://ohmyz.sh) installed, you already have a directory of automatically loading completion scripts — `.oh-my-zsh/completions`. Copy your new completion script to that directory.
 
+```
+$ example --generate-completion-script zsh > ~/.oh-my-zsh/completions/_example
+```
+
+> Your completion script must have the following filename format: `_example`.
+
 Without `oh-my-zsh`, you'll need to add a path for completion scripts to your function path, and turn on completion script autoloading. First, add these lines to `~/.zshrc`:
 
 ```


### PR DESCRIPTION
Users do not familiarize with the shell-completions scripts in Zsh could be frustrated following [this guide](https://github.com/apple/swift-argument-parser/blob/280700d361c1b3af6e2345f5e24f67fa9450bec6/Documentation/07%20Completion%20Scripts.md#installing-zsh-completions). `oh-my-zsh` uses a specific filename format `_example` - I think it is useful to add this information to documentation together with an example.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary