### PR TITLE
fix: Improve zsh completion script generator

### DIFF
--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -327,7 +327,7 @@ complete -F _math math
 private let zshCompletionScriptText = """
 #compdef math
 local context state state_descr line
-_math_commandname="math"
+_math_commandname=$words[1]
 typeset -A opt_args
 
 _math() {
@@ -466,14 +466,14 @@ _math_stats_quantiles() {
         ':one-of-four:(alphabet alligator branch braggart)'
         ':custom-arg:{_custom_completion $_math_commandname ---completion stats quantiles -- customArg $words}'
         ':values:'
-        '--test-success-exit-code[]'
-        '--test-failure-exit-code[]'
-        '--test-validation-exit-code[]'
-        '--test-custom-exit-code[]:test-custom-exit-code:'
-        '--file[]:file:_files -g '"'"'*.txt *.md'"'"''
-        '--directory[]:directory:_files -/'
-        '--shell[]:shell:{_describe '' $(head -100 /usr/share/dict/words | tail -50)}'
-        '--custom[]:custom:{_custom_completion $_math_commandname ---completion stats quantiles -- --custom $words}'
+        '--test-success-exit-code'
+        '--test-failure-exit-code'
+        '--test-validation-exit-code'
+        '--test-custom-exit-code:test-custom-exit-code:'
+        '--file:file:_files -g '"'"'*.txt *.md'"'"''
+        '--directory:directory:_files -/'
+        '--shell:shell:{local -a list; list=(${(f)"$(head -100 /usr/share/dict/words | tail -50)"}); _describe '''' list}'
+        '--custom:custom:{_custom_completion $_math_commandname ---completion stats quantiles -- --custom $words}'
         '(-h --help)'{-h,--help}'[Print help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -112,7 +112,7 @@ extension CompletionScriptTests {
 private let zshBaseCompletions = """
 #compdef base
 local context state state_descr line
-_base_commandname="base"
+_base_commandname=$words[1]
 typeset -A opt_args
 
 _base() {
@@ -120,11 +120,11 @@ _base() {
     local -a args
     args+=(
         '--name[The user'"'"'s name.]:name:'
-        '--kind[]:kind:(one two custom-three)'
-        '--other-kind[]:other-kind:(1 2 3)'
-        '--path1[]:path1:_files'
-        '--path2[]:path2:_files'
-        '--path3[]:path3:(a b c)'
+        '--kind:kind:(one two custom-three)'
+        '--other-kind:other-kind:(1 2 3)'
+        '--path1:path1:_files'
+        '--path2:path2:_files'
+        '--path3:path3:(a b c)'
         '(-h --help)'{-h,--help}'[Print help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0


### PR DESCRIPTION
This PR includes some improvements to the zsh completion script generator:

* `shellCommand` stores output in a local array that is passed to `_describe` to handle spaces and other punctuation in the shell command output

* elide the help abstract if it is empty, as it confuses the zsh completion system

* set the `_<commandName>_commandname` to `$words[1]`, which is the full name of the command used to invoke the completion. This ensures invocations like `./build/debug/math ...` as passed on to the `_custom_completion` command.

The existing tests have been updated.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
