### PR TITLE
Add an experimental customization point for the error label

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -110,5 +110,3 @@ public struct CommandConfiguration {
     self.helpNames = helpNames
   }
 }
-
-

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -120,15 +120,15 @@ enum MessageInfo {
     }
   }
   
-  var fullText: String {
+  func fullText(for args: ParsableArguments.Type) -> String {
     switch self {
     case .help(text: let text):
       return text
     case .validation(message: let message, usage: let usage):
-      let errorMessage = message.isEmpty ? "" : "Error: \(message)\n"
+      let errorMessage = message.isEmpty ? "" : "\(args._errorLabel): \(message)\n"
       return errorMessage + usage
     case .other(let message, _):
-      return message.isEmpty ? "" : "Error: \(message)"
+      return message.isEmpty ? "" : "\(args._errorLabel): \(message)"
     }
   }
   


### PR DESCRIPTION
This supports SwiftPM, which uses "error:" instead of "Error:" to make its error messages match the compiler.
