### PR TITLE
Allows single- and double-dashed args with the same name

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArgumentsValidation.swift
@@ -237,7 +237,7 @@ struct ParsableArgumentsUniqueNamesValidator: ParsableArgumentsValidator {
       switch args.content {
       case .arguments(let defs):
         for name in defs.flatMap({ $0.names }) {
-          countedNames[name.valueString, default: 0] += 1
+          countedNames[name.synopsisString, default: 0] += 1
         }
       default:
         break

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -230,7 +230,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     if let error = ParsableArgumentsUniqueNamesValidator.validate(TwoOfTheSameName.self)
       as? ParsableArgumentsUniqueNamesValidator.Error
     {
-      XCTAssertEqual(error.description, "Multiple (2) `Option` or `Flag` arguments are named \"foo\".")
+      XCTAssertEqual(error.description, "Multiple (2) `Option` or `Flag` arguments are named \"--foo\".")
     } else {
       XCTFail(unexpectedErrorMessage)
     }
@@ -250,7 +250,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     @Flag(name: .customLong("bar"))
     var notBar: Bool = false
 
-    @Option()
+    @Option(name: [.long, .customLong("help", withSingleDash: true)])
     var help: String
   }
 
@@ -261,12 +261,12 @@ final class ParsableArgumentsValidationTests: XCTestCase {
       XCTAssert(
         /// The `Mirror` reflects the properties `foo` and `bar` in a random order each time it's built.
         error.description == """
-        Multiple (2) `Option` or `Flag` arguments are named \"bar\".
-        Multiple (2) `Option` or `Flag` arguments are named \"foo\".
+        Multiple (2) `Option` or `Flag` arguments are named \"--bar\".
+        Multiple (2) `Option` or `Flag` arguments are named \"--foo\".
         """
         || error.description == """
-        Multiple (2) `Option` or `Flag` arguments are named \"foo\".
-        Multiple (2) `Option` or `Flag` arguments are named \"bar\".
+        Multiple (2) `Option` or `Flag` arguments are named \"--foo\".
+        Multiple (2) `Option` or `Flag` arguments are named \"--bar\".
         """
       )
     } else {
@@ -293,7 +293,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     if let error = ParsableArgumentsUniqueNamesValidator.validate(MultipleNamesPerArgument.self)
       as? ParsableArgumentsUniqueNamesValidator.Error
     {
-      XCTAssertEqual(error.description, "Multiple (2) `Option` or `Flag` arguments are named \"v\".")
+      XCTAssertEqual(error.description, "Multiple (2) `Option` or `Flag` arguments are named \"-v\".")
     } else {
       XCTFail(unexpectedErrorMessage)
     }
@@ -324,7 +324,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     if let error = ParsableArgumentsUniqueNamesValidator.validate(FourDuplicateNames.self)
       as? ParsableArgumentsUniqueNamesValidator.Error
     {
-      XCTAssertEqual(error.description, "Multiple (4) `Option` or `Flag` arguments are named \"foo\".")
+      XCTAssertEqual(error.description, "Multiple (4) `Option` or `Flag` arguments are named \"--foo\".")
     } else {
       XCTFail(unexpectedErrorMessage)
     }
@@ -366,7 +366,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     if let error = ParsableArgumentsUniqueNamesValidator.validate(DuplicatedFirstLettersShortNames.self)
       as? ParsableArgumentsUniqueNamesValidator.Error
     {
-      XCTAssertEqual(error.description, "Multiple (3) `Option` or `Flag` arguments are named \"f\".")
+      XCTAssertEqual(error.description, "Multiple (3) `Option` or `Flag` arguments are named \"-f\".")
     } else {
       XCTFail(unexpectedErrorMessage)
     }


### PR DESCRIPTION
Fixes #231. Note that this changes the error text slightly, to include the single/double-dash prefix.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
