### PR TITLE
Fix CMake build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-find_package(dispatch QUIET)
-find_package(Foundation QUIET)
-find_package(XCTest QUIET)
+find_package(dispatch CONFIG)
+find_package(Foundation CONFIG)
+find_package(XCTest CONFIG)
 
 add_subdirectory(Sources)
 if(BUILD_EXAMPLES)

--- a/Sources/ArgumentParserTestHelpers/CMakeLists.txt
+++ b/Sources/ArgumentParserTestHelpers/CMakeLists.txt
@@ -5,4 +5,5 @@ set_target_properties(ArgumentParserTestHelpers PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(ArgumentParserTestHelpers PUBLIC
   ArgumentParser
-  XCTest)
+  XCTest
+  Foundation)


### PR DESCRIPTION
- TestHelpers has a implicit dependency on Foundation through
  ArgumentParser, so it needs to link against Foundation
- The find package calls should be REQUIRED and CONFIG so they can take
  advantage of CMake configs

### Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
