### PR TITLE
Store mutations made by validate()

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -157,6 +157,9 @@ extension CommandParser {
       // after decoding a command, make sure to validate it
       do {
         try parsedCommand.validate()
+        var lastArgument = decodedArguments.removeLast()
+        lastArgument.value = parsedCommand
+        decodedArguments.append(lastArgument)
       } catch {
         try checkForBuiltInFlags(split)
         throw CommandError(commandStack: commandStack, parserError: ParserError.userValidationError(error))

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -146,3 +146,28 @@ extension ValidationEndToEndTests {
     AssertFullErrorMessage(Foo.self, ["--fail-silently", "Joe"], "")
   }
 }
+
+fileprivate struct FooCommand: ParsableCommand {
+  @Flag(help: .hidden)
+  var foo = false
+  @Flag(help: .hidden)
+  var bar = false
+
+  mutating func validate() throws {
+    if foo {
+      // --foo implies --bar
+      bar = true
+    }
+  }
+
+  func run() throws {
+    XCTAssertEqual(foo, bar)
+  }
+}
+
+extension ValidationEndToEndTests {
+  func testMutationsPreserved() throws {
+    var foo = try FooCommand.parseAsRoot(["--foo"])
+    try foo.run()
+  }
+}


### PR DESCRIPTION
Since #104, mutations made to a command struct by its `validate()` function are lost when using `parseAsRoot(_:)`. This is because validations are run on a mutable copy of the parsed command, and that copy is never stored.

My teammates and I use `validate()` as a place to enforce invariants. For example:

```swift
struct Foo: ParsableCommand {
    @Flag()
    var verbose = false

    @Flag()
    var dryRun = false

    mutating func validate() {
        if dryRun {
            verbose = true    // --dry-run implies --verbose
        }
    }

    func run() {
        if verbose { ... }
    }
}
```

While this isn't _technically_ a validation step, it's been useful to separate post-processing of the arguments like this from the business logic of `run()`.

I couldn't find anything indicating that #104 intended to change this behavior, so I'm assuming it was a regression. Here's a fix!

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
