### PR TITLE
Add support for joined short options

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -78,7 +78,7 @@ extension Name {
     switch self {
     case .long(let longName):
       return "-l \(longName)"
-    case .short(let shortName):
+    case .short(let shortName, _):
       return "-s \(shortName)"
     case .longWithSingleDash(let dashedName):
       return "-o \(dashedName)"
@@ -89,7 +89,7 @@ extension Name {
     switch self {
     case .long(let longName):
       return "--\(longName)"
-    case .short(let shortName):
+    case .short(let shortName, _):
       return "-\(shortName)"
     case .longWithSingleDash(let dashedName):
       return "-\(dashedName)"

--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -25,6 +25,11 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     /// To create a single-dash argument, pass `true` as `withSingleDash`. Note
     /// that combining single-dash options and options with short,
     /// single-character names can lead to ambiguities for the user.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the option or flag.
+    ///   - withSingleDash: A Boolean value indicating whether to use a single
+    ///     dash as the prefix. If `false`, the name has a double-dash prefix.
     case customLong(_ name: String, withSingleDash: Bool = false)
     
     /// Use the first character of the property's name as a short option label.
@@ -35,8 +40,16 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     
     /// Use the given character as a short option label.
     ///
-    /// Short labels can be combined into groups.
-    case customShort(Character, allowingJoined: Bool = false)
+    /// When passing `true` as `allowingJoined` in an `@Option` declaration,
+    /// the user can join a value with the option name. For example, if an
+    /// option is declared as `-D`, allowing joined values, a user could pass
+    /// `-Ddebug` to specify `debug` as the value for that option.
+    ///
+    /// - Parameters:
+    ///   - char: The name of the option or flag.
+    ///   - allowingJoined: A Boolean value indicating whether this short name
+    ///     allows a joined value.
+    case customShort(_ char: Character, allowingJoined: Bool = false)
   }
   var elements: [Element]
   
@@ -62,6 +75,11 @@ extension NameSpecification {
   /// To create a single-dash argument, pass `true` as `withSingleDash`. Note
   /// that combining single-dash options and options with short,
   /// single-character names can lead to ambiguities for the user.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the option or flag.
+  ///   - withSingleDash: A Boolean value indicating whether to use a single
+  ///     dash as the prefix. If `false`, the name has a double-dash prefix.
   public static func customLong(_ name: String, withSingleDash: Bool = false) -> NameSpecification {
     [.customLong(name, withSingleDash: withSingleDash)]
   }
@@ -74,7 +92,15 @@ extension NameSpecification {
   
   /// Use the given character as a short option label.
   ///
-  /// Short labels can be combined into groups.
+  /// When passing `true` as `allowingJoined` in an `@Option` declaration,
+  /// the user can join a value with the option name. For example, if an
+  /// option is declared as `-D`, allowing joined values, a user could pass
+  /// `-Ddebug` to specify `debug` as the value for that option.
+  ///
+  /// - Parameters:
+  ///   - char: The name of the option or flag.
+  ///   - allowingJoined: A Boolean value indicating whether this short name
+  ///     allows a joined value.
   public static func customShort(_ char: Character, allowingJoined: Bool = false) -> NameSpecification {
     [.customShort(char, allowingJoined: allowingJoined)]
   }

--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -36,7 +36,7 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     /// Use the given character as a short option label.
     ///
     /// Short labels can be combined into groups.
-    case customShort(Character)
+    case customShort(Character, allowingJoined: Bool = false)
   }
   var elements: [Element]
   
@@ -75,8 +75,8 @@ extension NameSpecification {
   /// Use the given character as a short option label.
   ///
   /// Short labels can be combined into groups.
-  public static func customShort(_ char: Character) -> NameSpecification {
-    [.customShort(char)]
+  public static func customShort(_ char: Character, allowingJoined: Bool = false) -> NameSpecification {
+    [.customShort(char, allowingJoined: allowingJoined)]
   }
   
   /// Combine the `.short` and `.long` specifications to allow both long
@@ -100,8 +100,8 @@ extension NameSpecification.Element {
       return withSingleDash
         ? .longWithSingleDash(name)
         : .long(name)
-    case .customShort(let name):
-      return .short(name)
+    case .customShort(let name, let allowingJoined):
+      return .short(name, allowingJoined: allowingJoined)
     }
   }
 }

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -194,6 +194,10 @@ extension ArgumentDefinition {
       return false
     }
   }
+  
+  var allowsJoinedValue: Bool {
+    names.contains(where: { $0.allowsJoined })
+  }
 }
 
 extension ArgumentDefinition.Kind {

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -224,6 +224,12 @@ extension ArgumentSet {
         if let value = parsed.value {
           // This was `--foo=bar` style:
           try update(origin, parsed.name, value, &result)
+        } else if argument.allowsJoinedValue,
+            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+          // Found a joined argument
+          let origins = origin.inserting(origin2)
+          try update(origins, parsed.name, String(value), &result)
+          usedOrigins.formUnion(origins)
         } else if let (origin2, value) = inputArguments.popNextValue(after: originElement) {
           // Use `popNext(after:)` to handle cases where short option
           // labels are combined
@@ -240,6 +246,12 @@ extension ArgumentSet {
           // This was `--foo=bar` style:
           try update(origin, parsed.name, value, &result)
           usedOrigins.formUnion(origin)
+        } else if argument.allowsJoinedValue,
+            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+          // Found a joined argument
+          let origins = origin.inserting(origin2)
+          try update(origins, parsed.name, String(value), &result)
+          usedOrigins.formUnion(origins)
         } else {
           guard let (origin2, value) = inputArguments.popNextElementAsValue(after: originElement) else {
             throw ParserError.missingValueForOption(origin, parsed.name)
@@ -258,6 +270,13 @@ extension ArgumentSet {
           // This was `--foo=bar` style:
           try update(origin, parsed.name, value, &result)
           usedOrigins.formUnion(origin)
+        } else if argument.allowsJoinedValue,
+            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+          // Found a joined argument
+          let origins = origin.inserting(origin2)
+          try update(origins, parsed.name, String(value), &result)
+          usedOrigins.formUnion(origins)
+          inputArguments.removeAll(in: usedOrigins)
         }
         
         // ...and then consume the rest of the arguments
@@ -276,6 +295,13 @@ extension ArgumentSet {
           // This was `--foo=bar` style:
           try update(origin, parsed.name, value, &result)
           usedOrigins.formUnion(origin)
+        } else if argument.allowsJoinedValue,
+            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+          // Found a joined argument
+          let origins = origin.inserting(origin2)
+          try update(origins, parsed.name, String(value), &result)
+          usedOrigins.formUnion(origins)
+          inputArguments.removeAll(in: usedOrigins)
         }
         
         // ...and then consume the arguments until hitting an option

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -18,6 +18,23 @@
 struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
   enum Element: Comparable, Hashable {
     case argumentIndex(SplitArguments.Index)
+    
+    var baseIndex: Int? {
+      switch self {
+      case .argumentIndex(let i):
+        return i.inputIndex.rawValue
+      }
+    }
+    
+    var subIndex: Int? {
+      switch self {
+      case .argumentIndex(let i):
+        switch i.subIndex {
+        case .complete: return nil
+        case .sub(let n): return n
+        }
+      }
+    }
   }
   
   private var _elements: Set<Element> = []

--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -15,7 +15,7 @@ enum Name: Hashable {
   /// A single character name prefixed with `-` (1 dash) or equivalent.
   ///
   /// Usually supports mixing multiple short names with a single dash, i.e. `-ab` is equivalent to `-a -b`.
-  case short(Character)
+  case short(Character, allowingJoined: Bool = false)
   /// A name (usually multi-character) prefixed with `-` (1 dash).
   case longWithSingleDash(String)
   
@@ -36,7 +36,7 @@ extension Name {
     switch self {
     case .long(let n):
       return "--\(n)"
-    case .short(let n):
+    case .short(let n, _):
       return "-\(n)"
     case .longWithSingleDash(let n):
       return "-\(n)"
@@ -47,7 +47,7 @@ extension Name {
     switch self {
     case .long(let n):
       return n
-    case .short(let n):
+    case .short(let n, _):
       return String(n)
     case .longWithSingleDash(let n):
       return n
@@ -60,6 +60,24 @@ extension Name {
       return true
     default:
       return false
+    }
+  }
+  
+  var allowsJoined: Bool {
+    switch self {
+    case .short(_, let allowingJoined):
+      return allowingJoined
+    default:
+      return false
+    }
+  }
+  
+  /// The instance to match against user input -- this always has
+  /// `allowingJoined` as `false`, since that's the way input is parsed.
+  var nameToMatch: Name {
+    switch self {
+    case .long, .longWithSingleDash: return self
+    case .short(let c, _): return .short(c)
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
+++ b/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(EndToEndTests
   DefaultsEndToEndTests.swift
   EnumEndToEndTests.swift
   FlagsEndToEndTests.swift
+  JoinedEndToEndTests.swift
   LongNameWithShortDashEndToEndTests.swift
   NestedCommandEndToEndTests.swift
   OptionalEndToEndTests.swift

--- a/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
@@ -158,7 +158,10 @@ extension JoinedEndToEndTests {
   }
   
   func testArrayUpToNextParsing_Fails() throws {
-    // TODO
+    XCTAssertThrowsError(try Baz.parse(["-D", "--other"]))
+    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "--other"]))
+    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "--other"]))
+    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "debug", "--other"]))
   }
 }
 
@@ -179,12 +182,12 @@ extension JoinedEndToEndTests {
       XCTAssertEqual(qux.debug, ["debug1", "debug2"])
     }
     
-    AssertParse(Qux.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { qux in
-      XCTAssertEqual(qux.debug, ["debug1", "debug2", "-Ddebug3", "debug4"])
+    AssertParse(Qux.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4", "--other"]) { qux in
+      XCTAssertEqual(qux.debug, ["debug1", "debug2", "-Ddebug3", "debug4", "--other"])
     }
   }
   
   func testArrayRemainingParsing_Fails() throws {
-    // TODO
+    XCTAssertThrowsError(try Baz.parse(["--other", "-Ddebug", "debug"]))
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ArgumentParserTestHelpers
+import ArgumentParser
+
+final class JoinedEndToEndTests: XCTestCase {
+}
+
+// MARK: -
+
+fileprivate struct Foo: ParsableArguments {
+  @Option(name: .customShort("f"))
+  var file = ""
+  
+  @Option(name: .customShort("d", allowingJoined: true))
+  var debug = ""
+  
+  @Flag(name: .customLong("fdi", withSingleDash: true))
+  var fdi = false
+}
+
+extension JoinedEndToEndTests {
+  func testSingleValueParsing() throws {
+    AssertParse(Foo.self, []) { foo in
+      XCTAssertEqual(foo.file, "")
+      XCTAssertEqual(foo.debug, "")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-f", "file", "-d=Debug"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-f", "file", "-d", "Debug"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-f", "file", "-dDebug"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-dDebug", "-f", "file"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-dDebug"]) { foo in
+      XCTAssertEqual(foo.file, "")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-fd", "file", "Debug"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, false)
+    }
+
+    AssertParse(Foo.self, ["-fd", "file", "Debug", "-fdi"]) { foo in
+      XCTAssertEqual(foo.file, "file")
+      XCTAssertEqual(foo.debug, "Debug")
+      XCTAssertEqual(foo.fdi, true)
+    }
+
+    AssertParse(Foo.self, ["-fdi"]) { foo in
+      XCTAssertEqual(foo.file, "")
+      XCTAssertEqual(foo.debug, "")
+      XCTAssertEqual(foo.fdi, true)
+    }
+  }
+  
+  func testSingleValueParsing_Fails() throws {
+    XCTAssertThrowsError(try Foo.parse(["-f", "-d"]))
+    XCTAssertThrowsError(try Foo.parse(["-f", "file", "-d"]))
+    XCTAssertThrowsError(try Foo.parse(["-fd", "file"]))
+    XCTAssertThrowsError(try Foo.parse(["-fdDebug", "file"]))
+    XCTAssertThrowsError(try Foo.parse(["-fFile"]))
+  }
+}
+
+// MARK: -
+
+fileprivate struct Bar: ParsableArguments {
+  @Option(name: .customShort("D", allowingJoined: true))
+  var debug: [String] = []
+}
+
+extension JoinedEndToEndTests {
+  func testArrayValueParsing() throws {
+    AssertParse(Bar.self, []) { bar in
+      XCTAssertEqual(bar.debug, [])
+    }
+
+    AssertParse(Bar.self, ["-Ddebug1"]) { bar in
+      XCTAssertEqual(bar.debug, ["debug1"])
+    }
+
+    AssertParse(Bar.self, ["-Ddebug1", "-Ddebug2", "-Ddebug3"]) { bar in
+      XCTAssertEqual(bar.debug, ["debug1", "debug2", "debug3"])
+    }
+
+    AssertParse(Bar.self, ["-D", "debug1", "-Ddebug2", "-D", "debug3"]) { bar in
+      XCTAssertEqual(bar.debug, ["debug1", "debug2", "debug3"])
+    }
+  }
+  
+  func testArrayValueParsing_Fails() throws {
+    XCTAssertThrowsError(try Bar.parse(["-D"]))
+    XCTAssertThrowsError(try Bar.parse(["-Ddebug1", "debug2"]))
+  }
+}
+
+// MARK: -
+
+fileprivate struct Baz: ParsableArguments {
+  @Option(name: .customShort("D", allowingJoined: true), parsing: .upToNextOption)
+  var debug: [String] = []
+  
+  @Flag var verbose = false
+}
+
+extension JoinedEndToEndTests {
+  func testArrayUpToNextParsing() throws {
+    AssertParse(Baz.self, []) { baz in
+      XCTAssertEqual(baz.debug, [])
+    }
+    
+    AssertParse(Baz.self, ["-Ddebug1", "debug2"]) { baz in
+      XCTAssertEqual(baz.debug, ["debug1", "debug2"])
+      XCTAssertEqual(baz.verbose, false)
+    }
+    
+    AssertParse(Baz.self, ["-Ddebug1", "debug2", "--verbose"]) { baz in
+      XCTAssertEqual(baz.debug, ["debug1", "debug2"])
+      XCTAssertEqual(baz.verbose, true)
+    }
+    
+    AssertParse(Baz.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { baz in
+      XCTAssertEqual(baz.debug, ["debug3", "debug4"])
+    }
+  }
+  
+  func testArrayUpToNextParsing_Fails() throws {
+    // TODO
+  }
+}
+
+// MARK: -
+
+fileprivate struct Qux: ParsableArguments {
+  @Option(name: .customShort("D", allowingJoined: true), parsing: .remaining)
+  var debug: [String] = []
+}
+
+extension JoinedEndToEndTests {
+  func testArrayRemainingParsing() throws {
+    AssertParse(Qux.self, []) { qux in
+      XCTAssertEqual(qux.debug, [])
+    }
+    
+    AssertParse(Qux.self, ["-Ddebug1", "debug2"]) { qux in
+      XCTAssertEqual(qux.debug, ["debug1", "debug2"])
+    }
+    
+    AssertParse(Qux.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { qux in
+      XCTAssertEqual(qux.debug, ["debug1", "debug2", "-Ddebug3", "debug4"])
+    }
+  }
+  
+  func testArrayRemainingParsing_Fails() throws {
+    // TODO
+  }
+}


### PR DESCRIPTION
### Description
This supports joined arguments, like '-Ddebug' or '-v4'. Joined arguments need to be explicitly declared as `.customShort("D", allowingJoined: true)`.

### Detailed Design
You can now specify a Boolean `allowingJoined` value when declaring a custom short name specification, like this:

```swift
@main
struct Example: ParsableCommand {
    @Option(name: .customShort("D", allowingJoined: true))
    var debugValue: String

    func run() {
        print(debugValue)
    }
}
```

Existing calls still work as expected:

```
$ example -D debug
debug
$ example -D=debug
debug
```

And now you can use joined syntax:

```
$ example -Ddebug
debug
```

### Documentation Plan
Expanded the documentation for `.customShort(_:allowingJoined:)` on both `NameSpecification` and `NameSpecification.Element`.

### Test Plan
Unit tests covering the breadth of usage.

### Source Impact
This is an additive change only, users must opt into the new functionality.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
