### PR TITLE
add support to call custom subcommand provided by user

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,19 @@ var package = Package(
             name: "ArgumentParser",
             targets: ["ArgumentParser"]),
     ],
-    dependencies: [],
+    dependencies: [
+      .package(
+        url: "https://github.com/apple/swift-tools-support-core",
+        from: "0.1.10")
+    ],
     targets: [
         .target(
             name: "ArgumentParser",
-            dependencies: []),
+            dependencies: [
+                .product(
+                    name: "SwiftToolsSupport",
+                    package: "swift-tools-support-core")
+            ]),
         .target(
             name: "ArgumentParserTestHelpers",
             dependencies: ["ArgumentParser"]),

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -47,6 +47,13 @@ public struct CommandConfiguration {
   /// Flag names to be used for help.
   public var helpNames: NameSpecification
   
+  public enum AllowingExternalCommands {
+    case none, all
+    case list([String])
+  }
+  /// Allow that call `main-sub` when user enters `main sub`
+  public var allowingExternalCommands: AllowingExternalCommands
+
   /// Creates the configuration for a command.
   ///
   /// - Parameters:
@@ -66,6 +73,7 @@ public struct CommandConfiguration {
   ///     is given.
   ///   - helpNames: The flag names to use for requesting help, simulating
   ///     a Boolean property named `help`.
+  ///   - allowingExternalCommands: Allow that call `main-sub` when user enters `main sub`
   public init(
     commandName: String? = nil,
     abstract: String = "",
@@ -74,6 +82,7 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
+    allowingExternalCommands: AllowingExternalCommands = .none,
     helpNames: NameSpecification = [.short, .long]
   ) {
     self.commandName = commandName
@@ -83,6 +92,7 @@ public struct CommandConfiguration {
     self.shouldDisplay = shouldDisplay
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand
+    self.allowingExternalCommands = allowingExternalCommands
     self.helpNames = helpNames
   }
 
@@ -97,6 +107,7 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
+    allowingExternalCommands: AllowingExternalCommands = .none,
     helpNames: NameSpecification = [.short, .long]
   ) {
     self.commandName = commandName
@@ -107,6 +118,7 @@ public struct CommandConfiguration {
     self.shouldDisplay = shouldDisplay
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand
+    self.allowingExternalCommands = allowingExternalCommands
     self.helpNames = helpNames
   }
 }

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -236,7 +236,7 @@ extension CommandParser {
     }
   }
   
-  func createCustomCommand(extraValues: __shared [(InputOrigin, String)]) -> Result<UserCustomCommand, CommandError> {
+  func createCustomCommand(extraValues: __shared [(InputOrigin, String)]) -> Result<CustomCommand, CommandError> {
     let parserError = ParserError.unexpectedExtraValues(extraValues)
     // remove default subcommand
     var stack = commandStack
@@ -257,7 +257,7 @@ extension CommandParser {
     }
     let commandName = stack.map { $0._commandName }.joined(separator: "-") + "-" + name
     let arguments = extraValues.dropFirst().map(\.1)
-    let customCommand = UserCustomCommand(commandName: commandName, arguments: arguments, parserError: parserError)
+    let customCommand = CustomCommand(commandName: commandName, arguments: arguments, parserError: parserError)
     return .success(customCommand)
   }
 }

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -236,12 +236,13 @@ extension CommandParser {
     }
   }
   
+  /// Create CustomCommand from unexpected extra values and `commandStack`.
+  /// It should called when parse failed.
+  ///
+  /// - Parameter extraValues: The array of unexpected extra arguments.
   func createCustomCommand(extraValues: __shared [(InputOrigin, String)]) -> Result<CustomCommand, CommandError> {
     var error: CommandError {
-      CommandError(
-        commandStack: commandStack,
-        parserError: .unexpectedExtraValues(extraValues)
-      )
+      CommandError(commandStack: commandStack, parserError: .unexpectedExtraValues(extraValues))
     }
     // remove default subcommand
     var stack = commandStack

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -18,6 +18,8 @@ enum ParserError: Error {
   case completionScriptCustomResponse(String)
   case unsupportedShell(String? = nil)
   
+  case failedExecuteExternalCommand
+  
   case notImplemented
   case invalidState
   case unknownOption(InputOrigin.Element, Name)

--- a/Sources/ArgumentParser/Usage/CustomCommand.swift
+++ b/Sources/ArgumentParser/Usage/CustomCommand.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+struct UserCustomCommand: ParsableCommand {
+  var commandName: String
+  var arguments: [String]
+  var parserError: ParserError
+  
+  func run() throws {
+    print(commandName, "is called")
+  }
+}
+
+extension UserCustomCommand {
+  /// UserCustomCommand does not confirm Decodable
+  /// - Throws: ValidationError
+  init(from decoder: Decoder) throws {
+    throw ValidationError("UserCustomCommand does not confirm Decodable")
+  }
+}
+
+extension UserCustomCommand {
+  init() {
+    commandName = ""
+    arguments = []
+    parserError = .invalidState
+  }
+}

--- a/Sources/ArgumentParser/Usage/CustomCommand.swift
+++ b/Sources/ArgumentParser/Usage/CustomCommand.swift
@@ -12,31 +12,34 @@
 import TSCBasic
 
 struct CustomCommand: ParsableCommand {
-  var commandName: String
+  var commandPath: AbsolutePath
   var arguments: [String]
-  var parserError: ParserError
   
   func run() throws {
-    guard let path = Process.findExecutable(commandName),
-          localFileSystem.exists(path) else {
-      throw parserError
-    }
-    try exec(path: path.pathString, args: arguments)
+    try exec(path: commandPath.pathString, args: arguments)
   }
 }
 
 extension CustomCommand {
   /// CustomCommand does not confirm Decodable
-  /// - Throws: ValidationError
-  init(from decoder: Decoder) throws {
-    throw ValidationError("UserCustomCommand does not confirm Decodable")
+  init(from decoder: Decoder) {
+    fatalError("CustomCommand does not confirm Decodable")
   }
 }
 
 extension CustomCommand {
   init() {
-    commandName = ""
-    arguments = []
-    parserError = .invalidState
+    fatalError("CustomCommand can't initialize")
+  }
+}
+
+extension CustomCommand {
+  init?(commandName: String, arguments: [String]) {
+    guard let path = Process.findExecutable(commandName),
+          localFileSystem.exists(path) else {
+      return nil
+    }
+    self.commandPath = path
+    self.arguments = arguments
   }
 }

--- a/Sources/ArgumentParser/Usage/CustomCommand.swift
+++ b/Sources/ArgumentParser/Usage/CustomCommand.swift
@@ -23,13 +23,8 @@ struct CustomCommand: ParsableCommand {
 
 extension CustomCommand {
   /// **NOT SUPPORTED**
-  init(from decoder: Decoder) {
-    fatalError("CustomCommand does not confirm Decodable")
-  }
-  
-  /// **NOT SUPPORTED**
   init() {
-    fatalError("CustomCommand can't initialize")
+    fatalError("CustomCommand.init is not supported")
   }
 }
 

--- a/Sources/ArgumentParser/Usage/CustomCommand.swift
+++ b/Sources/ArgumentParser/Usage/CustomCommand.swift
@@ -9,25 +9,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct UserCustomCommand: ParsableCommand {
+import TSCBasic
+
+struct CustomCommand: ParsableCommand {
   var commandName: String
   var arguments: [String]
   var parserError: ParserError
   
   func run() throws {
-    print(commandName, "is called")
+    guard let path = Process.findExecutable(commandName),
+          localFileSystem.exists(path) else {
+      throw parserError
+    }
+    try exec(path: path.pathString, args: arguments)
   }
 }
 
-extension UserCustomCommand {
-  /// UserCustomCommand does not confirm Decodable
+extension CustomCommand {
+  /// CustomCommand does not confirm Decodable
   /// - Throws: ValidationError
   init(from decoder: Decoder) throws {
     throw ValidationError("UserCustomCommand does not confirm Decodable")
   }
 }
 
-extension UserCustomCommand {
+extension CustomCommand {
   init() {
     commandName = ""
     arguments = []

--- a/Sources/ArgumentParser/Usage/CustomCommand.swift
+++ b/Sources/ArgumentParser/Usage/CustomCommand.swift
@@ -11,6 +11,7 @@
 
 import TSCBasic
 
+/// CustomCommand is for calling other executables.
 struct CustomCommand: ParsableCommand {
   var commandPath: AbsolutePath
   var arguments: [String]
@@ -21,19 +22,22 @@ struct CustomCommand: ParsableCommand {
 }
 
 extension CustomCommand {
-  /// CustomCommand does not confirm Decodable
+  /// **NOT SUPPORTED**
   init(from decoder: Decoder) {
     fatalError("CustomCommand does not confirm Decodable")
   }
-}
-
-extension CustomCommand {
+  
+  /// **NOT SUPPORTED**
   init() {
     fatalError("CustomCommand can't initialize")
   }
 }
 
 extension CustomCommand {
+  /// Find executable command's path and if it not exist, return nil.
+  /// - Parameters:
+  ///   - commandName: command name to call
+  ///   - arguments: arguments to provide to the command
   init?(commandName: String, arguments: [String]) {
     guard let path = Process.findExecutable(commandName),
           localFileSystem.exists(path) else {

--- a/Sources/ArgumentParser/Usage/ExternalCommand.swift
+++ b/Sources/ArgumentParser/Usage/ExternalCommand.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 
 /// CustomCommand is for calling other executables.
-struct CustomCommand: ParsableCommand {
+struct ExternalCommand: ParsableCommand {
   var commandPath: AbsolutePath
   var arguments: [String]
   
@@ -21,14 +21,14 @@ struct CustomCommand: ParsableCommand {
   }
 }
 
-extension CustomCommand {
+extension ExternalCommand {
   /// **NOT SUPPORTED**
   init() {
-    fatalError("CustomCommand.init is not supported")
+    fatalError("unavailable")
   }
 }
 
-extension CustomCommand {
+extension ExternalCommand {
   /// Find executable command's path and if it not exist, return nil.
   /// - Parameters:
   ///   - commandName: command name to call

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -166,6 +166,9 @@ extension ErrorMessageGenerator {
     case .unsupportedShell:
       return unsupportedAutodetectedShell
       
+    case .failedExecuteExternalCommand:
+      return notImplementedMessage
+      
     case .notImplemented:
       return notImplementedMessage
     case .invalidState:


### PR DESCRIPTION
### Description
Some major commands, like swift and cargo, have a feature which calls `swift-sub` when entering `swift sub`. This PR adds support to this.

### Detailed Design
This PR doesn't add new APIs. 
A simple case is here (main is built with swift-argument-parser):

```
$ ls
main main-sub
$ ./main
main is called
$ ./main-sub
sub is called
$ ./main sub
sub is called
```

If `main` needs arguments, custom subcommands behave like swift-argument-parser's subcommand. I'm questioning this behavior, but I've decided to adapt it to the current behavior. 

```
$ ls
main main-custom
$ ./main -h
USAGE: main <text> <subcommand>

ARGUMENTS:
  <text>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  sub

  See 'main help <subcommand>' for detailed help.
$
$ ./main sub
main command is called; text: sub
$ ./main file sub
sub command is called
$ ./main sub file 
Error: Unexpected argument 'file'
Usage: main <text> <subcommand>
  See 'main --help' for more information.
$
$ ./main-custom
custom command is called
$ ./main custom
main command is called; text: custom
$ ./main file custom
custom command is called
$ ./main custom file
Error: Unexpected argument 'file'
Usage: main <text> <subcommand>
  See 'main --help' for more information.
```

### Documentation Plan
I don't know whether I should add documentation or not.

### Test Plan
`swift test` tests in `/private/temp` so I have no idea to test this feature. 

### Source Impact
Nothing

### Alternative Design
- Add a flag to `CommandConfiguration` whether allows sub command provided by users.

### Note
`execv` is always failed when I execute text executable file. It is no problem with a binary file.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
