### PR TITLE
Make it clear that Foundation has to be imported

### DIFF
--- a/Documentation/01 Getting Started.md
+++ b/Documentation/01 Getting Started.md
@@ -223,6 +223,9 @@ OPTIONS:
 As promised, here's the complete `count` command, for your experimentation:
 
 ```swift
+import ArgumentParser
+import Foundation
+
 struct Count: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Word counter.")
     


### PR DESCRIPTION
It's not from the get-go clear for beginners that Foundation has to be imported as well. Otherwise, you would end up with a bunch of compilation errors.

### Checklist
- [-] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
