### PR TITLE
Add custom helpNames support for Subcommand

### DIFF
--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -153,6 +153,34 @@ OPTIONS:
   -?, --help              Show help information.
 ```
 
+If you don't provide alternative help names for Subcommand then it will inherit help names from it's immediate parent.
+
+```swift
+struct Parent: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        subcommands: [Child.self],
+        helpNames: [.long, .customShort("?")])
+
+    struct Child: ParsableCommand {
+        @Option(name: .shortAndLong, help: "The host the server will run on.")
+        var host: String
+    }
+}
+```
+
+When running the command, `-h` matches the short name of the `host` property, and `-?` displays the help screen.
+
+```
+% parent child -h 192.0.0.0
+...
+% parent child -?
+USAGE: parent child --host <host>
+
+OPTIONS:
+  -h, --host <host>       The host the server will run on.
+  -?, --help              Show help information.
+```
+
 ## Hiding Arguments and Commands
 
 You may want to suppress features under development or experimental flags from the generated help screen. You can hide an argument or a subcommand by passing `shouldDisplay: false` to the property wrapper or `CommandConfiguration` initializers, respectively.

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -64,8 +64,9 @@ public struct CommandConfiguration {
   ///     command.
   ///   - defaultSubcommand: The default command type to run if no subcommand
   ///     is given.
-  ///   - helpNames: The flag names to use for requesting help, simulating
-  ///     a Boolean property named `help`.
+  ///   - helpNames: The flag names to use for requesting help. If `helpNames`
+  ///     is `nil`, the flag names are derived by simulating a Boolean property
+  ///     named `help`.
   public init(
     commandName: String? = nil,
     abstract: String = "",

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -45,7 +45,7 @@ public struct CommandConfiguration {
   public var defaultSubcommand: ParsableCommand.Type?
   
   /// Flag names to be used for help.
-  public var helpNames: NameSpecification
+  public var helpNames: NameSpecification?
   
   /// Creates the configuration for a command.
   ///
@@ -74,7 +74,7 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
-    helpNames: NameSpecification = [.short, .long]
+    helpNames: NameSpecification? = nil
   ) {
     self.commandName = commandName
     self.abstract = abstract
@@ -97,7 +97,7 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
-    helpNames: NameSpecification = [.short, .long]
+    helpNames: NameSpecification? = nil
   ) {
     self.commandName = commandName
     self._superCommandName = _superCommandName

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -75,7 +75,7 @@ extension CommandParser {
   /// built in help flags.
   func checkForBuiltInFlags(_ split: SplitArguments) throws {
     // Look for help flags
-    guard !split.contains(anyOf: self.commandTree.element.getHelpNames()) else {
+    guard !split.contains(anyOf: self.commandStack.getHelpNames()) else {
       throw HelpRequested()
     }
 

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -196,7 +196,7 @@ struct CustomHelp: ParsableCommand {
 
 extension HelpTests {
   func testCustomHelpNames() {
-    let names = CustomHelp.getHelpNames()
+    let names = [CustomHelp.self].getHelpNames()
     XCTAssertEqual(names, [.short("?"), .long("show-help")])
   }
 }
@@ -211,7 +211,7 @@ struct NoHelp: ParsableCommand {
 
 extension HelpTests {
   func testNoHelpNames() {
-    let names = NoHelp.getHelpNames()
+    let names = [NoHelp.self].getHelpNames()
     XCTAssertEqual(names, [])
 
     XCTAssertEqual(
@@ -223,5 +223,46 @@ extension HelpTests {
               --count <count>         How many florps?
 
             """)
+  }
+}
+
+struct SubCommandCustomHelp: ParsableCommand {
+  static var configuration = CommandConfiguration (
+    helpNames: [.customShort("p"), .customLong("parrent-help")]
+  )
+
+  struct InheritHelp: ParsableCommand {
+
+  }
+
+  struct ModifiedHelp: ParsableCommand {
+    static var configuration = CommandConfiguration (
+      helpNames: [.customShort("s"), .customLong("subcommand-help")]
+    )
+
+    struct InheritImmediateParentdHelp: ParsableCommand {
+
+    }
+  }
+}
+
+extension HelpTests {
+  func testSubCommandInheritHelpNames() {
+    let names = [SubCommandCustomHelp.self, SubCommandCustomHelp.InheritHelp.self].getHelpNames()
+    XCTAssertEqual(names, [.short("p"), .long("parrent-help")])
+  }
+
+  func testSubCommandCustomHelpNames() {
+    let names = [SubCommandCustomHelp.self, SubCommandCustomHelp.ModifiedHelp.self].getHelpNames()
+    XCTAssertEqual(names, [.short("s"), .long("subcommand-help")])
+  }
+
+  func testInheritImmediateParentHelpNames() {
+    let names = [
+      SubCommandCustomHelp.self,
+      SubCommandCustomHelp.ModifiedHelp.self,
+      SubCommandCustomHelp.ModifiedHelp.InheritImmediateParentdHelp.self
+    ].getHelpNames()
+    XCTAssertEqual(names, [.short("s"), .long("subcommand-help")])
   }
 }


### PR DESCRIPTION
Modifying help flag names now works for subcommand. If not specified `helpNames` is inherited from parent. This PR is compatible with the current system.

Fix #215

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
