### PR TITLE
Fix small typo in `CommandConfiguration` documentation

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -56,7 +56,7 @@ public struct CommandConfiguration {
   ///   - abstract: A one-line description of the command.
   ///   - discussion: A longer description of the command.
   ///   - version: The version number for this command. When you provide a
-  ///     non-empty string, the arguemnt parser prints it if the user provides
+  ///     non-empty string, the argument parser prints it if the user provides
   ///     a `--version` flag.
   ///   - shouldDisplay: A Boolean value indicating whether the command
   ///     should be shown in the extended help display.


### PR DESCRIPTION
# Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
