### PR TITLE
Provide more descriptive error message for non-argument variable parsing failure.

### DIFF
--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -339,7 +339,7 @@ extension ErrorMessageGenerator {
     }
     switch possibilities.count {
     case 0:
-      return "Missing expected argument"
+      return "No value set for non-argument var \(key). Replace with a static variable, or let constant."
     case 1:
       return "Missing expected argument '\(possibilities.first!)'"
     default:


### PR DESCRIPTION
Relates to issue https://forums.swift.org/t/how-to-exclude-members-from-parsing/34325/9

The existing message was completely unhelpful, and even erroneous in the sense that the issue is not related to an argument at all, but to a non-argument. The new message is a stop-gap until the actual problem causing the error is resolved, but it at least gives the user actionable information and makes it clear where the issue lies.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
