### PR TITLE
Render version in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ package updates, you can specify your package dependency using
 
 ## [Unreleased]
 
-*No changes yet.*
+- The version string is now included in the help output if specified.
 
 ---
 

--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -74,7 +74,7 @@ OPTIONS:
 
 ## Customizing Help for Commands
 
-In addition to configuring the command name and subcommands, as described in [Command and Subcommands](03%20Commands%20and%20Subcommands.md), you can also configure a command's help text by providing an abstract and discussion.
+In addition to configuring the command name and subcommands, as described in [Command and Subcommands](03%20Commands%20and%20Subcommands.md), you can also configure a command's help text by providing an abstract, discussion or version number.
 
 ```swift
 struct Repeat: ParsableCommand {
@@ -82,7 +82,9 @@ struct Repeat: ParsableCommand {
         abstract: "Repeats your input phrase.",
         discussion: """
             Prints to stdout forever, or until you halt the program.
-            """)
+            """,
+        version: "1.2.3"
+    )
 
     @Argument(help: "The phrase to repeat.")
     var phrase: String
@@ -102,6 +104,8 @@ OVERVIEW: Repeats your input phrase.
 Prints to stdout forever, or until you halt the program.
 
 USAGE: repeat <phrase>
+
+VERSION: 1.2.3
 
 ARGUMENTS:
   <phrase>                The phrase to repeat.

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -258,6 +258,10 @@ internal struct HelpGenerator {
     let renderedAbstract = abstract.isEmpty
       ? ""
       : "OVERVIEW: \(abstract)".wrapped(to: screenWidth) + "\n\n"
+
+    let renderedVersion = (commandStack.first?.configuration.version).map { version in
+        version.isEmpty ? "" : "VERSION: \(version)".wrapped(to: screenWidth) + "\n\n"
+    } ?? ""
     
     var helpSubcommandMessage: String = ""
     if includesSubcommands {
@@ -277,6 +281,7 @@ internal struct HelpGenerator {
     \(renderedAbstract)\
     USAGE: \(usage.rendered(screenWidth: screenWidth))
     
+    \(renderedVersion)\
     \(renderedSections)\(helpSubcommandMessage)
     """
   }

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -25,6 +25,8 @@ final class MathExampleTests: XCTestCase {
 
         USAGE: math <subcommand>
 
+        VERSION: 1.0.0
+
         OPTIONS:
           --version               Show the version.
           -h, --help              Show help information.
@@ -48,6 +50,8 @@ final class MathExampleTests: XCTestCase {
 
         USAGE: math add [--hex-output] [<values> ...]
 
+        VERSION: 1.0.0
+
         ARGUMENTS:
           <values>                A group of integers to operate on.
 
@@ -68,6 +72,8 @@ final class MathExampleTests: XCTestCase {
 
         USAGE: math stats average [--kind <kind>] [<values> ...]
 
+        VERSION: 1.0.0
+
         ARGUMENTS:
           <values>                A group of floating-point values to operate on.
 
@@ -87,6 +93,8 @@ final class MathExampleTests: XCTestCase {
         OVERVIEW: Print the quantiles of the values (TBD).
 
         USAGE: math stats quantiles [<values> ...]
+
+        VERSION: 1.0.0
 
         ARGUMENTS:
           <values>                A group of floating-point values to operate on.

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -313,6 +313,8 @@ extension HelpGenerationTests {
     AssertHelp(for: I.self, equals: """
     USAGE: i
 
+    VERSION: 1.0.0
+
     OPTIONS:
       --version               Show the version.
       -h, --help              Show help information.


### PR DESCRIPTION
I believe this is generally useful information to have, if it's been specified.

This was requested by a SwiftLint user who's been generous enough to try out a version of the tool that's integrated this library: https://github.com/realm/SwiftLint/issues/1088#issuecomment-745738042

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary