### PR TITLE
Remove deprecated property wrapper initializers

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -95,35 +95,6 @@ extension Argument where Value: ExpressibleByArgument {
       })
   }
 
-  /// Creates a property that reads its value from an argument.
-  ///
-  /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:help:)` for properties with a default value
-  /// - `init(help:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Argument(default: "bar")
-  /// -var foo: String
-  /// +@Argument var foo: String = "bar"
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, the user must supply a value for this argument.
-  ///   - help: Information about how to use this argument.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: String = \"bar\"`)")
-  public init(
-    default initial: Value?,
-    help: ArgumentHelp? = nil
-  ) {
-    self.init(
-      initial: initial,
-      help: help,
-      completion: nil
-    )
-  }
-
   /// Creates a property with a default value provided by standard Swift default value syntax.
   ///
   /// This method is called to initialize an `Argument` with a default value such as:
@@ -234,28 +205,6 @@ extension Argument {
     })
   }
   
-  @available(*, deprecated, message: """
-    Default values don't make sense for optional properties.
-    Remove the 'default' parameter if its value is nil,
-    or make your property non-optional if it's non-nil.
-    """)
-  public init<T: ExpressibleByArgument>(
-    default initial: T?,
-    help: ArgumentHelp? = nil
-  ) where Value == T? {
-    self.init(_parsedValue: .init { key in
-      ArgumentSet(
-        key: key,
-        kind: .positional,
-        parsingStrategy: .nextAsValue,
-        parseType: T.self,
-        name: .long,
-        default: initial,
-        help: help,
-        completion: T.defaultCompletionKind)
-    })
-  }
-
   /// Creates a property with an optional default value, intended to be called by other constructors to centralize logic.
   ///
   /// This private `init` allows us to expose multiple other similar constructors to allow for standard default property initialization while reducing code duplication.
@@ -282,40 +231,6 @@ extension Argument {
       })
       return ArgumentSet(arg)
     })
-  }
-
-  /// Creates a property that reads its value from an argument, parsing with
-  /// the given closure.
-  ///
-  /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:help:transform:)` for properties with a default value
-  /// - `init(help:transform:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Argument(default: "bar", transform: baz)
-  /// -var foo: String
-  /// +@Argument(transform: baz)
-  /// +var foo: String = "bar"
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - initial: A default value to use for this property.
-  ///   - help: Information about how to use this argument.
-  ///   - transform: A closure that converts a string into this property's
-  ///     type or throws an error.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: String = \"bar\"`)")
-  public init(
-    default initial: Value?,
-    help: ArgumentHelp? = nil,
-    transform: @escaping (String) throws -> Value
-  ) {
-    self.init(
-      initial: initial,
-      help: help,
-      completion: nil,
-      transform: transform
-    )
   }
 
   /// Creates a property with a default value provided by standard Swift default value syntax, parsing with the given closure.

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -173,26 +173,6 @@ extension Flag where Value == Bool {
     })
   }
 
-  /// Creates a Boolean property that reads its value from the presence of a
-  /// flag.
-  ///
-  /// This property defaults to a value of `false`.
-  ///
-  /// - Parameters:
-  ///   - name: A specification for what names are allowed for this flag.
-  ///   - help: Information about how to use this flag.
-  @available(*, deprecated, message: "Provide an explicit default value of `false` for this flag (`@Flag var foo: Bool = false`)")
-  public init(
-    name: NameSpecification = .long,
-    help: ArgumentHelp? = nil
-  ) {
-    self.init(
-      name: name,
-      initial: false,
-      help: help
-    )
-  }
-
   /// Creates a Boolean property with default value provided by standard Swift default value syntax that reads its value from the presence of a flag.
   ///
   /// - Parameters:
@@ -224,68 +204,6 @@ extension Flag where Value == Bool {
     self.init(_parsedValue: .init { key in
       .flag(key: key, name: name, default: initial, inversion: inversion, exclusivity: exclusivity, help: help)
       })
-  }
-
-  /// Creates a Boolean property that reads its value from the presence of
-  /// one or more inverted flags.
-  ///
-  /// /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:name:inversion:exclusivity:help:)` for properties with a default value
-  /// - `init(name:inversion:exclusivity:help:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Flag(default: true)
-  /// -var foo: Bool
-  /// +@Flag var foo: Bool = true
-  /// ```
-  ///
-  /// Use this initializer to create a Boolean flag with an on/off pair. With
-  /// the following declaration, for example, the user can specify either
-  /// `--use-https` or `--no-use-https` to set the `useHTTPS` flag to `true`
-  /// or `false`, respectively.
-  ///
-  ///     @Flag(inversion: .prefixedNo)
-  ///     var useHTTPS: Bool
-  ///
-  /// To customize the names of the two states further, define a
-  /// `CaseIterable` enumeration with a case for each state, and use that
-  /// as the type for your flag. In this case, the user can specify either
-  /// `--use-production-server` or `--use-development-server` to set the
-  /// flag's value.
-  ///
-  ///     enum ServerChoice {
-  ///         case useProductionServer
-  ///         case useDevelopmentServer
-  ///     }
-  ///
-  ///     @Flag var serverChoice: ServerChoice
-  ///
-  /// - Parameters:
-  ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, one of the flags declared by this `@Flag` attribute is required
-  ///     from the user.
-  ///   - inversion: The method for converting this flag's name into an on/off
-  ///     pair.
-  ///   - exclusivity: The behavior to use when an on/off pair of flags is
-  ///     specified.
-  ///   - help: Information about how to use this flag.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: Bool = false`)")
-  public init(
-    name: NameSpecification = .long,
-    default initial: Bool?,
-    inversion: FlagInversion,
-    exclusivity: FlagExclusivity = .chooseLast,
-    help: ArgumentHelp? = nil
-  ) {
-    self.init(
-      name: name,
-      initial: initial,
-      inversion: inversion,
-      exclusivity: exclusivity,
-      help: help
-    )
   }
 
   /// Creates a Boolean property with default value provided by standard Swift default value syntax that reads its value from the presence of one or more inverted flags.
@@ -402,39 +320,6 @@ extension Flag where Value: EnumerableFlag {
       }
       return ArgumentSet(args)
       })
-  }
-
-  /// Creates a property that gets its value from the presence of a flag,
-  /// where the allowed flags are defined by an `EnumerableFlag` type.
-  ///
-  /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:exclusivity:help:)` for properties with a default value
-  /// - `init(exclusivity:help:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Flag(default: .baz)
-  /// -var foo: Bar
-  /// +@Flag var foo: Bar = baz
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, one of the flags declared by this `@Flag` attribute is required
-  ///     from the user.
-  ///   - exclusivity: The behavior to use when multiple flags are specified.
-  ///   - help: Information about how to use this flag.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: Bar = .baz`)")
-  public init(
-    default initial: Value?,
-    exclusivity: FlagExclusivity = .exclusive,
-    help: ArgumentHelp? = nil
-  ) {
-    self.init(
-      initial: initial,
-      exclusivity: exclusivity,
-      help: help
-    )
   }
 
   /// Creates a property with a default value provided by standard Swift default value syntax that gets its value from the presence of a flag.

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -106,41 +106,6 @@ extension Option where Value: ExpressibleByArgument {
     )
   }
 
-  /// Creates a property that reads its value from a labeled option.
-  ///
-  /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:name:parsing:help:)` for properties with a default value
-  /// - `init(name:parsing:help:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Option(default: "bar")
-  /// -var foo: String
-  /// +@Option var foo: String = "bar"
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, this option and value are required from the user.
-  ///   - parsingStrategy: The behavior to use when looking for this option's
-  ///     value.
-  ///   - help: Information about how to use this option.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: String = \"bar\"`)")
-  public init(
-    name: NameSpecification = .long,
-    default initial: Value?,
-    parsing parsingStrategy: SingleValueParsingStrategy = .next,
-    help: ArgumentHelp? = nil
-  ) {
-    self.init(
-      name: name,
-      initial: initial,
-      parsingStrategy: parsingStrategy,
-      help: help,
-      completion: nil)
-  }
-
   /// Creates a property with a default value provided by standard Swift default value syntax.
   ///
   /// This method is called to initialize an `Option` with a default value such as:
@@ -338,30 +303,6 @@ extension Option {
     })
   }
 
-  @available(*, deprecated, message: """
-    Default values don't make sense for optional properties.
-    Remove the 'default' parameter if its value is nil,
-    or make your property non-optional if it's non-nil.
-    """)
-  public init<T: ExpressibleByArgument>(
-    name: NameSpecification = .long,
-    default initial: T?,
-    parsing parsingStrategy: SingleValueParsingStrategy = .next,
-    help: ArgumentHelp? = nil
-  ) where Value == T? {
-    self.init(_parsedValue: .init { key in
-      var arg = ArgumentDefinition(
-        key: key,
-        kind: .name(key: key, specification: name),
-        parsingStrategy: ArgumentDefinition.ParsingStrategy(parsingStrategy),
-        parser: T.init(argument:),
-        default: initial,
-        completion: T.defaultCompletionKind)
-      arg.help.help = help
-      return ArgumentSet(arg.optional)
-    })
-  }
-
   /// Creates a property with an optional default value, intended to be called by other constructors to centralize logic.
   ///
   /// This private `init` allows us to expose multiple other similar constructors to allow for standard default property initialization while reducing code duplication.
@@ -393,48 +334,6 @@ extension Option {
       arg.help.defaultValue = initial.map { "\($0)" }
       return ArgumentSet(arg)
       })
-  }
-
-  /// Creates a property that reads its value from a labeled option, parsing
-  /// with the given closure.
-  ///
-  /// This method is deprecated, with usage split into two other methods below:
-  /// - `init(wrappedValue:name:parsing:help:transform:)` for properties with a default value
-  /// - `init(name:parsing:help:transform:)` for properties with no default value
-  ///
-  /// Existing usage of the `default` parameter should be replaced such as follows:
-  /// ```diff
-  /// -@Option(default: "bar", transform: baz)
-  /// -var foo: String
-  /// +@Option(transform: baz)
-  /// +var foo: String = "bar"
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - name: A specification for what names are allowed for this flag.
-  ///   - initial: A default value to use for this property. If `initial` is
-  ///     `nil`, this option and value are required from the user.
-  ///   - parsingStrategy: The behavior to use when looking for this option's
-  ///     value.
-  ///   - help: Information about how to use this option.
-  ///   - transform: A closure that converts a string into this property's
-  ///     type or throws an error.
-  @available(*, deprecated, message: "Use regular property initialization for default values (`var foo: String = \"bar\"`)")
-  public init(
-    name: NameSpecification = .long,
-    default initial: Value?,
-    parsing parsingStrategy: SingleValueParsingStrategy = .next,
-    help: ArgumentHelp? = nil,
-    transform: @escaping (String) throws -> Value
-  ) {
-     self.init(
-      name: name,
-      initial: initial,
-      parsingStrategy: parsingStrategy,
-      help: help,
-      completion: nil,
-      transform: transform
-    )
   }
 
   /// Creates a property with a default value provided by standard Swift default value syntax, parsing with the given closure.

--- a/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
@@ -20,35 +20,25 @@ final class SourceCompatEndToEndTests: XCTestCase {}
 // MARK: - Property Wrapper Initializers
 
 fileprivate struct AlmostAllArguments: ParsableArguments {
-  @Argument(default: 0, help: "") var a: Int
   @Argument(help: "") var a_newDefaultSyntax: Int = 0
   @Argument() var a0: Int
   @Argument(help: "") var a1: Int
-  @Argument(default: 0) var a2: Int
   @Argument var a2_newDefaultSyntax: Int = 0
 
-  @Argument(default: 0, help: "", transform: { _ in 0 }) var b: Int
   @Argument(help: "", transform: { _ in 0 }) var b_newDefaultSyntax: Int = 0
-  @Argument(default: 0) var b1: Int
   @Argument var b1_newDefaultSyntax: Int = 0
   @Argument(help: "") var b2: Int
   @Argument(transform: { _ in 0 }) var b3: Int
   @Argument(help: "", transform: { _ in 0 }) var b4: Int
-  @Argument(default: 0, transform: { _ in 0 }) var b5: Int
   @Argument(transform: { _ in 0 }) var b5_newDefaultSyntax: Int = 0
-  @Argument(default: 0, help: "") var b6: Int
   @Argument(help: "") var b6_newDefaultSyntax: Int = 0
 
-  @Argument(default: 0, help: "") var c: Int?
   @Argument() var c0: Int?
   @Argument(help: "") var c1: Int?
-  @Argument(default: 0) var c2: Int?
 
-  @Argument(default: 0, help: "", transform: { _ in 0 }) var d: Int?
   @Argument(help: "") var d2: Int?
   @Argument(transform: { _ in 0 }) var d3: Int?
   @Argument(help: "", transform: { _ in 0 }) var d4: Int?
-  @Argument(default: 0, transform: { _ in 0 }) var d5: Int?
 
   @Argument(parsing: .remaining, help: "") var e: [Int] = [1, 2]
   @Argument(parsing: .remaining, help: "") var e1: [Int]
@@ -69,77 +59,49 @@ fileprivate struct AlmostAllArguments: ParsableArguments {
 }
 
 fileprivate struct AllOptions: ParsableArguments {
-  @Option(name: .long, default: 0, parsing: .next, help: "") var a: Int
   @Option(name: .long, parsing: .next, help: "") var a_newDefaultSyntax: Int = 0
-  @Option(default: 0, parsing: .next, help: "") var a1: Int
   @Option(parsing: .next, help: "") var a1_newDefaultSyntax: Int = 0
   @Option(name: .long, parsing: .next, help: "") var a2: Int
-  @Option(name: .long, default: 0, help: "") var a3: Int
   @Option(name: .long, help: "") var a3_newDefaultSyntax: Int = 0
   @Option(parsing: .next, help: "") var a4: Int
-  @Option(default: 0, help: "") var a5: Int
   @Option(help: "") var a5_newDefaultSyntax: Int = 0
-  @Option(default: 0, parsing: .next) var a6: Int
   @Option(parsing: .next) var a6_newDefaultSyntax: Int = 0
   @Option(name: .long, help: "") var a7: Int
   @Option(name: .long, parsing: .next) var a8: Int
-  @Option(name: .long, default: 0) var a9: Int
   @Option(name: .long) var a9_newDefaultSyntax: Int = 0
   @Option(name: .long) var a10: Int
-  @Option(default: 0) var a11: Int
   @Option var a11_newDefaultSyntax: Int = 0
   @Option(parsing: .next) var a12: Int
   @Option(help: "") var a13: Int
 
-  @Option(name: .long, default: 0, parsing: .next, help: "") var b: Int?
-  @Option(default: 0, parsing: .next, help: "") var b1: Int?
   @Option(name: .long, parsing: .next, help: "") var b2: Int?
-  @Option(name: .long, default: 0, help: "") var b3: Int?
   @Option(parsing: .next, help: "") var b4: Int?
-  @Option(default: 0, help: "") var b5: Int?
-  @Option(default: 0, parsing: .next) var b6: Int?
   @Option(name: .long, help: "") var b7: Int?
   @Option(name: .long, parsing: .next) var b8: Int?
-  @Option(name: .long, default: 0) var b9: Int?
   @Option(name: .long) var b10: Int?
-  @Option(default: 0) var b11: Int?
   @Option(parsing: .next) var b12: Int?
   @Option(help: "") var b13: Int?
 
-  @Option(name: .long, default: 0, parsing: .next, help: "", transform: { _ in 0 }) var c: Int
   @Option(name: .long, parsing: .next, help: "", transform: { _ in 0 }) var c_newDefaultSyntax: Int = 0
-  @Option(default: 0, parsing: .next, help: "", transform: { _ in 0 }) var c1: Int
   @Option(parsing: .next, help: "", transform: { _ in 0 }) var c1_newDefaultSyntax: Int = 0
   @Option(name: .long, parsing: .next, help: "", transform: { _ in 0 }) var c2: Int
-  @Option(name: .long, default: 0, help: "", transform: { _ in 0 }) var c3: Int
   @Option(name: .long, help: "", transform: { _ in 0 }) var c3_newDefaultSyntax: Int = 0
   @Option(parsing: .next, help: "", transform: { _ in 0 }) var c4: Int
-  @Option(default: 0, help: "", transform: { _ in 0 }) var c5: Int
   @Option(help: "", transform: { _ in 0 }) var c5_newDefaultSyntax: Int = 0
-  @Option(default: 0, parsing: .next, transform: { _ in 0 }) var c6: Int
   @Option(parsing: .next, transform: { _ in 0 }) var c6_newDefaultSyntax: Int = 0
   @Option(name: .long, help: "", transform: { _ in 0 }) var c7: Int
   @Option(name: .long, parsing: .next, transform: { _ in 0 }) var c8: Int
-  @Option(name: .long, default: 0, transform: { _ in 0 }) var c9: Int
   @Option(name: .long, transform: { _ in 0 }) var c9_newDefaultSyntax: Int = 0
   @Option(name: .long, transform: { _ in 0 }) var c10: Int
-  @Option(default: 0, transform: { _ in 0 }) var c11: Int
   @Option(transform: { _ in 0 }) var c11_newDefaultSyntax: Int = 0
   @Option(parsing: .next, transform: { _ in 0 }) var c12: Int
   @Option(help: "", transform: { _ in 0 }) var c13: Int
 
-  @Option(name: .long, default: 0, parsing: .next, help: "", transform: { _ in 0 }) var d: Int?
-  @Option(default: 0, parsing: .next, help: "", transform: { _ in 0 }) var d1: Int?
   @Option(name: .long, parsing: .next, help: "", transform: { _ in 0 }) var d2: Int?
-  @Option(name: .long, default: 0, help: "", transform: { _ in 0 }) var d3: Int?
   @Option(parsing: .next, help: "", transform: { _ in 0 }) var d4: Int?
-  @Option(default: 0, help: "", transform: { _ in 0 }) var d5: Int?
-  @Option(default: 0, parsing: .next, transform: { _ in 0 }) var d6: Int?
   @Option(name: .long, help: "", transform: { _ in 0 }) var d7: Int?
   @Option(name: .long, parsing: .next, transform: { _ in 0 }) var d8: Int?
-  @Option(name: .long, default: 0, transform: { _ in 0 }) var d9: Int?
   @Option(name: .long, transform: { _ in 0 }) var d10: Int?
-  @Option(default: 0, transform: { _ in 0 }) var d11: Int?
   @Option(parsing: .next, transform: { _ in 0 }) var d12: Int?
   @Option(help: "", transform: { _ in 0 }) var d13: Int?
 
@@ -179,13 +141,9 @@ struct AllFlags: ParsableArguments {
     case one, two, three
   }
 
-  @Flag(name: .long, help: "") var a: Bool
   @Flag(name: .long, help: "") var a_explicitFalse: Bool = false
-  @Flag() var a0: Bool
   @Flag() var a0_explicitFalse: Bool = false
-  @Flag(name: .long) var a1: Bool
   @Flag(name: .long) var a1_explicitFalse: Bool = false
-  @Flag(help: "") var a2: Bool
   @Flag(help: "") var a2_explicitFalse: Bool = false
 
   @Flag(name: .long, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var b: Bool
@@ -197,38 +155,22 @@ struct AllFlags: ParsableArguments {
   @Flag(name: .long, inversion: .prefixedNo) var b6: Bool
   @Flag(inversion: .prefixedNo) var b7: Bool
 
-  @Flag(name: .long, default: false, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var c: Bool
   @Flag(name: .long, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var c_newDefaultSyntax: Bool = false
-  @Flag(default: false, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var c1: Bool
   @Flag(inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var c1_newDefaultSyntax: Bool = false
-  @Flag(name: .long, default: false, inversion: .prefixedNo, help: "") var c2: Bool
   @Flag(name: .long, inversion: .prefixedNo, help: "") var c2_newDefaultSyntax: Bool = false
-  @Flag(name: .long, default: false, inversion: .prefixedNo, exclusivity: .chooseLast) var c3: Bool
   @Flag(name: .long, inversion: .prefixedNo, exclusivity: .chooseLast) var c3_newDefaultSyntax: Bool = false
-  @Flag(default: false, inversion: .prefixedNo, help: "") var c4: Bool
   @Flag(inversion: .prefixedNo, help: "") var c4_newDefaultSyntax: Bool = false
-  @Flag(default: false, inversion: .prefixedNo, exclusivity: .chooseLast) var c5: Bool
   @Flag(inversion: .prefixedNo, exclusivity: .chooseLast) var c5_newDefaultSyntax: Bool = false
-  @Flag(name: .long, default: false, inversion: .prefixedNo) var c6: Bool
   @Flag(name: .long, inversion: .prefixedNo) var c6_newDefaultSyntax: Bool = false
-  @Flag(default: false, inversion: .prefixedNo) var c7: Bool
   @Flag(inversion: .prefixedNo) var c7_newDefaultSyntax: Bool = false
 
-  @Flag(name: .long, default: nil, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var d: Bool
   @Flag(name: .long, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var d_implicitNil: Bool
-  @Flag(default: nil, inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var d1: Bool
   @Flag(inversion: .prefixedNo, exclusivity: .chooseLast, help: "") var d1_implicitNil: Bool
-  @Flag(name: .long, default: nil, inversion: .prefixedNo, help: "") var d2: Bool
   @Flag(name: .long, inversion: .prefixedNo, help: "") var d2_implicitNil: Bool
-  @Flag(name: .long, default: nil, inversion: .prefixedNo, exclusivity: .chooseLast) var d3: Bool
   @Flag(name: .long, inversion: .prefixedNo, exclusivity: .chooseLast) var d3_implicitNil: Bool
-  @Flag(default: nil, inversion: .prefixedNo, help: "") var d4: Bool
   @Flag(inversion: .prefixedNo, help: "") var d4_implicitNil: Bool
-  @Flag(default: nil, inversion: .prefixedNo, exclusivity: .chooseLast) var d5: Bool
   @Flag(inversion: .prefixedNo, exclusivity: .chooseLast) var d5_implicitNil: Bool
-  @Flag(name: .long, default: nil, inversion: .prefixedNo) var d6: Bool
   @Flag(name: .long, inversion: .prefixedNo) var d6_implicitNil: Bool
-  @Flag(default: nil, inversion: .prefixedNo) var d7: Bool
   @Flag(inversion: .prefixedNo) var d7_implicitNil: Bool
 
   @Flag(name: .long, help: "") var e: Int
@@ -236,17 +178,13 @@ struct AllFlags: ParsableArguments {
   @Flag(name: .long) var e1: Int
   @Flag(help: "") var e2: Int
 
-  @Flag(default: .one, exclusivity: .chooseLast, help: "") var f: E
   @Flag(exclusivity: .chooseLast, help: "") var f_newDefaultSyntax: E = .one
   @Flag() var f1: E
   @Flag(exclusivity: .chooseLast, help: "") var f2: E
-  @Flag(default: .one, help: "") var f3: E
   @Flag(help: "") var f3_newDefaultSyntax: E = .one
-  @Flag(default: .one, exclusivity: .chooseLast) var f4: E
   @Flag(exclusivity: .chooseLast) var f4_newDefaultSyntax: E = .one
   @Flag(help: "") var f5: E
   @Flag(exclusivity: .chooseLast) var f6: E
-  @Flag(default: .one) var f7: E
   @Flag var f7_newDefaultSyntax: E = .one
 
   @Flag(exclusivity: .chooseLast, help: "") var g: E?

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -139,9 +139,6 @@ extension HelpGenerationTests {
     @Option(help: "Your name.")
     var name: String = "John"
 
-    @Option(default: "Winston", help: "Your middle name.")
-    var middleName: String?
-
     @Option(help: "Your age.")
     var age: Int = 20
 
@@ -163,15 +160,13 @@ extension HelpGenerationTests {
 
   func testHelpWithDefaultValues() {
     AssertHelp(for: D.self, equals: """
-            USAGE: d [<occupation>] [--name <name>] [--middle-name <middle-name>] [--age <age>] [--logging <logging>] [--lucky <numbers> ...] [--optional] [--required] [--degree <degree>] [--directory <directory>]
+            USAGE: d [<occupation>] [--name <name>] [--age <age>] [--logging <logging>] [--lucky <numbers> ...] [--optional] [--required] [--degree <degree>] [--directory <directory>]
 
             ARGUMENTS:
               <occupation>            Your occupation. (default: --)
 
             OPTIONS:
               --name <name>           Your name. (default: John)
-              --middle-name <middle-name>
-                                      Your middle name. (default: Winston)
               --age <age>             Your age. (default: 20)
               --logging <logging>     Whether logging is enabled. (default: false)
               --lucky <numbers>       Your lucky numbers. (default: 7, 14)

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -176,7 +176,7 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     @Argument var foo: String
     @Option var bar: String
     @OptionGroup var options: Options
-    @Flag var flag: Bool
+    @Flag var flag = false
   }
 
   func testPositionalArgumentsValidation() throws {


### PR DESCRIPTION
These were deprecated in version 0.2.0. Time to go!