### PR TITLE
Use the correct help flag in error messages

### DIFF
--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -153,7 +153,7 @@ OPTIONS:
   -?, --help              Show help information.
 ```
 
-If you don't provide alternative help names for Subcommand then it will inherit help names from it's immediate parent.
+When not overridden, custom help names are inherited by subcommands. In this example, the parent command defines `--help` and `-?` as its help names:
 
 ```swift
 struct Parent: ParsableCommand {
@@ -168,7 +168,7 @@ struct Parent: ParsableCommand {
 }
 ```
 
-When running the command, `-h` matches the short name of the `host` property, and `-?` displays the help screen.
+The `child` subcommand inherits the parent's help names, allowing the user to distinguish between the host argument (`-h`) and help (`-?`).
 
 ```
 % parent child -h 192.0.0.0

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -64,9 +64,10 @@ public struct CommandConfiguration {
   ///     command.
   ///   - defaultSubcommand: The default command type to run if no subcommand
   ///     is given.
-  ///   - helpNames: The flag names to use for requesting help. If `helpNames`
-  ///     is `nil`, the flag names are derived by simulating a Boolean property
-  ///     named `help`.
+  ///   - helpNames: The flag names to use for requesting help, when combined
+  ///     with a simulated Boolean property named `help`. If `helpNames` is
+  ///     `nil`, the names are inherited from the parent command, if any, or
+  ///     `-h` and `--help`.
   public init(
     commandName: String? = nil,
     abstract: String = "",

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -291,15 +291,16 @@ fileprivate extension NameSpecification {
   }
 }
 
-internal extension Array where Element == ParsableCommand.Type {
+internal extension BidirectionalCollection where Element == ParsableCommand.Type {
   func getHelpNames() -> [Name] {
-    if(count == 0){
-      return CommandConfiguration.defaultHelpNames.generateHelpNames()
-    } else if let helpNames = self.last!.configuration.helpNames {
-      return helpNames.generateHelpNames()
-    } else {
-      return self.dropLast().getHelpNames()
-    }
+    return self.last(where: { $0.configuration.helpNames != nil })
+      .map { $0.configuration.helpNames!.generateHelpNames() }
+      ?? CommandConfiguration.defaultHelpNames.generateHelpNames()
+  }
+  
+  func getPrimaryHelpName() -> Name? {
+    let names = getHelpNames()
+    return names.first(where: { !$0.isShort }) ?? names.first
   }
 }
 

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -80,9 +80,12 @@ enum MessageInfo {
       parserError = .userValidationError(error)
     }
     
+    var usage = HelpGenerator(commandStack: commandStack).usageMessage()
+    
     let commandNames = commandStack.map { $0._commandName }.joined(separator: " ")
-    let usage = HelpGenerator(commandStack: commandStack).usageMessage()
-      + "\n  See '\(commandNames) --help' for more information."
+    if let helpName = commandStack.getPrimaryHelpName() {
+      usage += "\n  See '\(commandNames) \(helpName.synopsisString)' for more information."
+    }
     
     // Parsing errors and user-thrown validation errors have the usage
     // string attached. Other errors just get the error message.

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -118,7 +118,7 @@ extension ArgumentDefinition {
   }
   
   var preferredNameForSynopsis: Name? {
-    names.first{ !$0.isShort } ?? names.first
+    names.first { !$0.isShort } ?? names.first
   }
   
   var synopsisValueName: String? {

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -198,6 +198,12 @@ extension HelpTests {
   func testCustomHelpNames() {
     let names = [CustomHelp.self].getHelpNames()
     XCTAssertEqual(names, [.short("?"), .long("show-help")])
+    
+    AssertFullErrorMessage(CustomHelp.self, ["--error"], """
+      Error: Unknown option '--error'
+      Usage: custom-help
+        See 'custom-help --show-help' for more information.
+      """)
   }
 }
 
@@ -214,6 +220,11 @@ extension HelpTests {
     let names = [NoHelp.self].getHelpNames()
     XCTAssertEqual(names, [])
 
+    AssertFullErrorMessage(NoHelp.self, ["--error"], """
+      Error: Missing expected argument '--count <count>'
+      Usage: no-help --count <count>
+      """)
+
     XCTAssertEqual(
       NoHelp.message(for: CleanExit.helpRequest()).trimmingLines(),
       """
@@ -228,7 +239,7 @@ extension HelpTests {
 
 struct SubCommandCustomHelp: ParsableCommand {
   static var configuration = CommandConfiguration (
-    helpNames: [.customShort("p"), .customLong("parrent-help")]
+    helpNames: [.customShort("p"), .customLong("parent-help")]
   )
 
   struct InheritHelp: ParsableCommand {
@@ -249,7 +260,7 @@ struct SubCommandCustomHelp: ParsableCommand {
 extension HelpTests {
   func testSubCommandInheritHelpNames() {
     let names = [SubCommandCustomHelp.self, SubCommandCustomHelp.InheritHelp.self].getHelpNames()
-    XCTAssertEqual(names, [.short("p"), .long("parrent-help")])
+    XCTAssertEqual(names, [.short("p"), .long("parent-help")])
   }
 
   func testSubCommandCustomHelpNames() {


### PR DESCRIPTION
Error messages include a message that shows how to display the help screen, but the message didn't use the custom help flag names for a command if they had been specified.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
