### PR TITLE
Allow variable properties in parsable types

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -105,7 +105,7 @@ extension ArgumentDefinition {
     var formattedFlags = [String]()
     var flags = [String]()
     switch self.kind {
-    case .positional:
+    case .positional, .default:
       break
     case .named(let names):
       flags = names.map { $0.asFishSuggestion }

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -23,6 +23,7 @@ struct ArgumentDefinition {
   enum Kind {
     case named([Name])
     case positional
+    case `default`
   }
   
   struct Help {
@@ -84,7 +85,7 @@ struct ArgumentDefinition {
   var names: [Name] {
     switch kind {
     case .named(let n): return n
-    case .positional: return []
+    case .positional, .default: return []
     }
   }
   
@@ -156,6 +157,8 @@ extension ArgumentDefinition: CustomDebugStringConvertible {
         + " <\(valueName)>"
     case (.positional, _):
       return "<\(valueName)>"
+    case (.default, _):
+      return ""
     }
   }
 }

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -10,19 +10,30 @@
 //===----------------------------------------------------------------------===//
 
 struct ArgumentDefinition {
+  /// A closure that modifies a `ParsedValues` instance to include this
+  /// argument's value.
   enum Update {
     typealias Nullary = (InputOrigin, Name?, inout ParsedValues) throws -> Void
     typealias Unary = (InputOrigin, Name?, String, inout ParsedValues) throws -> Void
     
+    /// An argument that gets its value solely from its presence.
     case nullary(Nullary)
+    
+    /// An argument that takes a string as its value.
     case unary(Unary)
   }
   
   typealias Initial = (InputOrigin, inout ParsedValues) throws -> Void
   
   enum Kind {
+    /// An option or flag, with a name and an optional value.
     case named([Name])
+    
+    /// A positional argument.
     case positional
+    
+    /// A pseudo-argument that takes its value from a property's default value
+    /// instead of from command-line arguments.
     case `default`
   }
   

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -11,13 +11,29 @@
 
 /// Specifies where a given input came from.
 ///
-/// When reading from the command line, a value might originate from multiple indices.
+/// When reading from the command line, a value might originate from a sinlge
+/// index, multiple indices, or from part of an index. For this command:
 ///
-/// This is usually an index into the `SplitArguments`.
-/// In some cases it can be multiple indices.
+///     struct Example: ParsableCommand {
+///         @Flag(name: .short) var verbose = false
+///         @Flag(name: .short) var expert = false
+///
+///         @Option var count: Int
+///     }
+///
+/// ...with this usage:
+///
+///     $ example -ve --count 5
+///
+/// The parsed value for the `count` property will come from indices `1` and
+/// `2`, while the value for `verbose` will come from index `1`, sub-index `0`.
 struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
   enum Element: Comparable, Hashable {
+    /// The input value came from a property's default value, not from a
+    /// command line argument.
     case defaultValue
+    
+    /// The input value came from the specified index in the argument string.
     case argumentIndex(SplitArguments.Index)
     
     var baseIndex: Int? {

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -17,10 +17,13 @@
 /// In some cases it can be multiple indices.
 struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
   enum Element: Comparable, Hashable {
+    case defaultValue
     case argumentIndex(SplitArguments.Index)
     
     var baseIndex: Int? {
       switch self {
+      case .defaultValue:
+        return nil
       case .argumentIndex(let i):
         return i.inputIndex.rawValue
       }
@@ -28,6 +31,8 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
     
     var subIndex: Int? {
       switch self {
+      case .defaultValue:
+        return nil
       case .argumentIndex(let i):
         switch i.subIndex {
         case .complete: return nil
@@ -87,6 +92,10 @@ extension InputOrigin.Element {
     switch (lhs, rhs) {
     case (.argumentIndex(let l), .argumentIndex(let r)):
       return l < r
+    case (.argumentIndex, .defaultValue):
+      return true
+    case (.defaultValue, _):
+      return false
     }
   }
 }

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -75,6 +75,8 @@ extension ArgumentDefinition {
       }
     case .positional:
       return "<\(valueName)>"
+    case .default:
+      return ""
     }
   }
   
@@ -91,6 +93,8 @@ extension ArgumentDefinition {
       }
     case .positional:
       return "<\(valueName)>"
+    case .default:
+      return ""
     }
   }
   

--- a/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
@@ -165,3 +165,4 @@ extension ParsingEndToEndTests {
     XCTAssertThrowsError(try Qux.parse(["--first-name", "A", "--first-name", "B", "--first-name", "bad", "C", "D"]))
   }
 }
+

--- a/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
@@ -13,7 +13,22 @@ import XCTest
 import ArgumentParserTestHelpers
 import ArgumentParser
 
+struct Test: ParsableCommand {
+  @Option
+  var boop: String = "boop"
+  var blep: String = "blep"
+  mutating func run() {
+    self.blep += self.boop
+    print(self.blep)
+  }
+}
+
 final class ParsingEndToEndTests: XCTestCase {
+  func testTest() {
+    AssertParse(Test.self, []) { test in
+      
+    }
+  }
 }
 
 struct Name {

--- a/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
@@ -13,22 +13,7 @@ import XCTest
 import ArgumentParserTestHelpers
 import ArgumentParser
 
-struct Test: ParsableCommand {
-  @Option
-  var boop: String = "boop"
-  var blep: String = "blep"
-  mutating func run() {
-    self.blep += self.boop
-    print(self.blep)
-  }
-}
-
 final class ParsingEndToEndTests: XCTestCase {
-  func testTest() {
-    AssertParse(Test.self, []) { test in
-      
-    }
-  }
 }
 
 struct Name {
@@ -180,4 +165,3 @@ extension ParsingEndToEndTests {
     XCTAssertThrowsError(try Qux.parse(["--first-name", "A", "--first-name", "B", "--first-name", "bad", "C", "D"]))
   }
 }
-

--- a/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
@@ -115,3 +115,45 @@ extension SimpleEndToEndTests {
     XCTAssertThrowsError(try Baz.parse(["--name", "--format", "Bar", "Foo"]))
   }
 }
+
+// MARK: Two values + unparsed variable
+
+fileprivate struct Qux: ParsableArguments {
+  @Option() var name: String
+  @Flag() var verbose = false
+  var count = 0
+}
+
+fileprivate struct Quizzo: ParsableArguments {
+  @Option() var name: String
+  @Flag() var verbose = false
+  let count = 0
+}
+
+extension SimpleEndToEndTests {
+  func testParsing_TwoPlusUnparsed() throws {
+    AssertParse(Qux.self, ["--name", "Qux"]) { qux in
+      XCTAssertEqual(qux.name, "Qux")
+      XCTAssertFalse(qux.verbose)
+      XCTAssertEqual(qux.count, 0)
+    }
+    AssertParse(Qux.self, ["--name", "Qux", "--verbose"]) { qux in
+      XCTAssertEqual(qux.name, "Qux")
+      XCTAssertTrue(qux.verbose)
+      XCTAssertEqual(qux.count, 0)
+    }
+    
+    AssertParse(Quizzo.self, ["--name", "Qux", "--verbose"]) { quizzo in
+      XCTAssertEqual(quizzo.name, "Qux")
+      XCTAssertTrue(quizzo.verbose)
+      XCTAssertEqual(quizzo.count, 0)
+    }
+  }
+  
+  func testParsing_TwoPlusUnparsed_Fails() throws {
+    XCTAssertThrowsError(try Qux.parse([]))
+    XCTAssertThrowsError(try Qux.parse(["--name"]))
+    XCTAssertThrowsError(try Qux.parse(["--name", "Qux", "--count"]))
+    XCTAssertThrowsError(try Qux.parse(["--name", "Qux", "--count", "2"]))
+  }
+}


### PR DESCRIPTION
This captures the default value for non-parsable properties when building the ArgumentSet, which in turn get set as initial
values before decoding. Resolves #265.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
