### PR TITLE
Beautify `NSError` cases when thrown 💄 

### DIFF
--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -73,17 +73,6 @@ enum MessageInfo {
       )
       return
 
-    case let e as NSError:
-      // Send NSError back through the CommandError path
-      self.init(
-        error: CommandError(
-          commandStack: [type.asCommand],
-          parserError: .userValidationError(e)
-        ),
-        type: type
-      )
-      return
-
     default:
       commandStack = [type.asCommand]
       // if the error wasn't one of our two Error types, wrap it as a userValidationError
@@ -121,10 +110,12 @@ enum MessageInfo {
         self = .other(message: error.localizedDescription, exitCode: Int32(error.errorCode))
       case let error as LocalizedError where error.errorDescription != nil:
         self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
-      case let error as NSError:
-        self = .other(message: error.localizedDescription, exitCode: EXIT_FAILURE)
       default:
-        self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
+        if Swift.type(of: error) is NSError.Type {
+          self = .other(message: error.localizedDescription, exitCode: EXIT_FAILURE)
+        } else {
+          self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
+        }
       }
     } else if let parserError = parserError {
       let usage: String = {

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -73,6 +73,17 @@ enum MessageInfo {
       )
       return
 
+    case let e as NSError:
+      // Send NSError back through the CommandError path
+      self.init(
+        error: CommandError(
+          commandStack: [type.asCommand],
+          parserError: .userValidationError(e)
+        ),
+        type: type
+      )
+      return
+
     default:
       commandStack = [type.asCommand]
       // if the error wasn't one of our two Error types, wrap it as a userValidationError
@@ -110,6 +121,8 @@ enum MessageInfo {
         self = .other(message: error.localizedDescription, exitCode: Int32(error.errorCode))
       case let error as LocalizedError where error.errorDescription != nil:
         self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
+      case let error as NSError:
+        self = .other(message: error.localizedDescription, exitCode: Int32(error.code))
       default:
         self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
       }

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -122,7 +122,7 @@ enum MessageInfo {
       case let error as LocalizedError where error.errorDescription != nil:
         self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
       case let error as NSError:
-        self = .other(message: error.localizedDescription, exitCode: Int32(error.code))
+        self = .other(message: error.localizedDescription, exitCode: EXIT_FAILURE)
       default:
         self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
       }

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -128,9 +128,9 @@ extension ExitCodeTests {
   
   func testNSErrorIsHandled() {
     struct NSErrorCommand: ParsableCommand {
-      static let fileNotFoundNSError = NSError(domain: "", code: 4, userInfo: [NSLocalizedDescriptionKey: "The file “foo/bar” couldn’t be opened because there is no such file"])
+      static let fileNotFoundNSError = NSError(domain: "", code: 1, userInfo: [NSLocalizedDescriptionKey: "The file “foo/bar” couldn’t be opened because there is no such file"])
     }
-    XCTAssertEqual(NSErrorCommand.exitCode(for: NSErrorCommand.fileNotFoundNSError), ExitCode(rawValue: 4))
+    XCTAssertEqual(NSErrorCommand.exitCode(for: NSErrorCommand.fileNotFoundNSError), ExitCode(rawValue: 1))
     XCTAssertEqual(NSErrorCommand.message(for: NSErrorCommand.fileNotFoundNSError), "The file “foo/bar” couldn’t be opened because there is no such file")
   }
 }

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -125,4 +125,12 @@ extension ExitCodeTests {
   func testCustomErrorCodeForTheSecondCase() {
     XCTAssertEqual(CheckFirstCustomNSErrorCommand.exitCode(for: MyCustomNSError.mySecondCase), ExitCode(rawValue: 102))
   }
+  
+  func testNSErrorIsHandled() {
+    struct NSErrorCommand: ParsableCommand {
+      static let fileNotFoundNSError = NSError(domain: "", code: 4, userInfo: [NSLocalizedDescriptionKey: "The file “foo/bar” couldn’t be opened because there is no such file"])
+    }
+    XCTAssertEqual(NSErrorCommand.exitCode(for: NSErrorCommand.fileNotFoundNSError), ExitCode(rawValue: 4))
+    XCTAssertEqual(NSErrorCommand.message(for: NSErrorCommand.fileNotFoundNSError), "The file “foo/bar” couldn’t be opened because there is no such file")
+  }
 }


### PR DESCRIPTION
Ensures the `NSError` case is handled in `MessageInfo` and attempts to resolve #270 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
