### PR TITLE
Generate useful synopsis for commands with many options

### DIFF
--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -41,8 +41,10 @@ extension UsageGenerator {
     case 0:
       return toolName
     case let x where x > 12:
+      // When we have too many options, keep required and positional arguments,
+      // but discard the rest.
       let synopsis: [String] = definition.compactMap { argument in
-        guard !argument.help.options.contains(.isOptional) else {
+        guard argument.isPositional || !argument.help.options.contains(.isOptional) else {
           return nil
         }
         return argument.synopsis

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -41,6 +41,15 @@ extension UsageGenerator {
     case 0:
       return toolName
     case let x where x > 12:
+      let synopsis: [String] = definition.compactMap { argument in
+        guard !argument.help.options.contains(.isOptional) else {
+          return nil
+        }
+        return argument.synopsis
+      }
+      if !synopsis.isEmpty, synopsis.count <= 12 {
+        return "\(toolName) [<options>] \(synopsis.joined(separator: " "))"
+      }
       return "\(toolName) <options>"
     default:
       return "\(toolName) \(definition.synopsis.joined(separator: " "))"

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -113,7 +113,7 @@ extension HelpTests {
     XCTAssertEqual(
       getErrorText(Package.self, ["help", "config",  "get-mirror"]).trimmingLines(),
       """
-                USAGE: package config get-mirror <options>
+                USAGE: package config get-mirror [<options>] --package-url <package-url>
 
                 OPTIONS:
                   --build-path <build-path>

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -173,4 +173,28 @@ extension UsageGenerationTests {
     let help = UsageGenerator(toolName: "bar", parsable: L())
     XCTAssertEqual(help.synopsis, "bar [-remote <remote>]")
   }
+
+  struct M: ParsableArguments {
+    @Flag var a: Bool = false
+    @Flag var b: Bool = false
+    @Flag var c: Bool = false
+    @Flag var d: Bool = false
+    @Flag var e: Bool = false
+    @Flag var f: Bool = false
+    @Flag var g: Bool = false
+    @Flag var h: Bool = false
+    @Flag var i: Bool = false
+    @Flag var j: Bool = false
+    @Flag var k: Bool = false
+    @Flag var l: Bool = false
+    @Option var option: Bool
+    @Argument var input: String
+    @Argument var output: String
+  }
+
+  func testSynopsisWithTooManyOptions() {
+    let help = UsageGenerator(toolName: "foo", parsable: M())
+    XCTAssertEqual(help.synopsis,
+                   "foo [<options>] --option <option> <input> <output>")
+  }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -189,12 +189,12 @@ extension UsageGenerationTests {
     @Flag var l: Bool = false
     @Option var option: Bool
     @Argument var input: String
-    @Argument var output: String
+    @Argument var output: String?
   }
 
   func testSynopsisWithTooManyOptions() {
     let help = UsageGenerator(toolName: "foo", parsable: M())
     XCTAssertEqual(help.synopsis,
-                   "foo [<options>] --option <option> <input> <output>")
+                   "foo [<options>] --option <option> <input> [<output>]")
   }
 }


### PR DESCRIPTION
ArgumentParser is configured not to emit detailed synopsis when it would contain more than a dozen entries. This makes sense; however, eliding all information makes the synopsis rather useless.

While commands may have dozens of options, in most cases, only a few of them are required — so we can keep the synopsis short but still useful by only displaying the required parts.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
