### PR TITLE
Remove special casing for CustomNSError

### DIFF
--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -62,17 +62,6 @@ enum MessageInfo {
       self.init(error: CommandError(commandStack: [type.asCommand], parserError: e), type: type)
       return
 
-    case let e as CustomNSError:
-      // Send CustomNSError back through the CommandError path
-      self.init(
-        error: CommandError(
-          commandStack: [type.asCommand],
-          parserError: .userValidationError(e)
-        ),
-        type: type
-      )
-      return
-
     default:
       commandStack = [type.asCommand]
       // if the error wasn't one of our two Error types, wrap it as a userValidationError
@@ -106,8 +95,6 @@ enum MessageInfo {
         }
       case let error as ExitCode:
         self = .other(message: "", exitCode: error.rawValue)
-      case let error as CustomNSError:
-        self = .other(message: error.localizedDescription, exitCode: Int32(error.errorCode))
       case let error as LocalizedError where error.errorDescription != nil:
         self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
       default:

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -77,55 +77,9 @@ extension ExitCodeTests {
   }
 }
 
-// MARK: - CustomNSError tests
+// MARK: - NSError tests
 
 extension ExitCodeTests {
-  enum MyCustomNSError: CustomNSError {
-    case myFirstCase
-    case mySecondCase
-
-    var errorCode: Int {
-      switch self {
-      case .myFirstCase:
-        return 101
-      case .mySecondCase:
-        return 102
-      }
-    }
-
-    var errorUserInfo: [String : Any] {
-      switch self {
-      case .myFirstCase:
-        return [NSLocalizedDescriptionKey: "My first case localized description"]
-      case .mySecondCase:
-        return [:]
-      }
-    }
-  }
-
-  struct CheckFirstCustomNSErrorCommand: ParsableCommand {
-
-    @Option
-    var errorCase: Int
-
-    func run() throws {
-      switch errorCase {
-      case 101:
-        throw MyCustomNSError.myFirstCase
-      default:
-        throw MyCustomNSError.mySecondCase
-      }
-    }
-  }
-  
-  func testCustomErrorCodeForTheFirstCase() {
-    XCTAssertEqual(CheckFirstCustomNSErrorCommand.exitCode(for: MyCustomNSError.myFirstCase), ExitCode(rawValue: 101))
-  }
-
-  func testCustomErrorCodeForTheSecondCase() {
-    XCTAssertEqual(CheckFirstCustomNSErrorCommand.exitCode(for: MyCustomNSError.mySecondCase), ExitCode(rawValue: 102))
-  }
-  
   func testNSErrorIsHandled() {
     struct NSErrorCommand: ParsableCommand {
       static let fileNotFoundNSError = NSError(domain: "", code: 1, userInfo: [NSLocalizedDescriptionKey: "The file “foo/bar” couldn’t be opened because there is no such file"])


### PR DESCRIPTION
The error code in CustomNSError is actually _not_ appropriate to use as the command's exit code, as described in #269.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
