### PR TITLE
Add edge case to remove duplicate help arguments

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -60,9 +60,19 @@ extension ParsableCommand {
     _ arguments: [String]? = nil
   ) throws -> ParsableCommand {
     var parser = CommandParser(self)
-    let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
+    var arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
+    arguments = checkForDuplicateHelpCommands(arguments)
     return try parser.parse(arguments: arguments).get()
   }
+    
+    public static func checkForDuplicateHelpCommands(_ arguments: [String]) -> [String] {
+        guard arguments.count >= 2 else { return arguments }
+        let nonOptionalArguments = arguments.compactMap { $0 }
+        if nonOptionalArguments.first == "help" && nonOptionalArguments.contains("--help") {
+            return nonOptionalArguments.filter { $0 != "--help" }
+        }
+        return arguments
+    }
   
   /// Returns the text of the help screen for the given subcommand of this
   /// command.

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -60,6 +60,7 @@ final class MathExampleTests: XCTestCase {
     AssertExecuteCommand(command: "math add -h", expected: helpText)
     AssertExecuteCommand(command: "math add --help", expected: helpText)
     AssertExecuteCommand(command: "math help add", expected: helpText)
+    AssertExecuteCommand(command: "math help add --help", expected: helpText)
   }
   
   func testMath_StatsMeanHelp() throws {
@@ -80,6 +81,7 @@ final class MathExampleTests: XCTestCase {
     AssertExecuteCommand(command: "math stats average -h", expected: helpText)
     AssertExecuteCommand(command: "math stats average --help", expected: helpText)
     AssertExecuteCommand(command: "math help stats average", expected: helpText)
+    AssertExecuteCommand(command: "math help stats average --help", expected: helpText)
   }
   
   func testMath_StatsQuantilesHelp() throws {
@@ -109,6 +111,7 @@ final class MathExampleTests: XCTestCase {
     AssertExecuteCommand(command: "math stats quantiles -h", expected: helpText)
     AssertExecuteCommand(command: "math stats quantiles --help", expected: helpText)
     AssertExecuteCommand(command: "math help stats quantiles", expected: helpText)
+    AssertExecuteCommand(command: "math help stats quantiles --help", expected: helpText)
   }
   
   func testMath_CustomValidation() throws {


### PR DESCRIPTION
Resolves #259 

Literally ignores any --help flag, if the first argument is help.

I did spend a while digging into the behaviour using the debugger, but this code is fairly complex, and adding an edge case at this low level would make it harder to understand I think. This ultimately is a little hacky, but I think better than making that low level complexity more complex.

FYI, it was happening somewhere in this function: https://github.com/apple/swift-argument-parser/blob/831ed5e860a70e745bc1337830af4786b2576881/Sources/ArgumentParser/Parsing/CommandParser.swift#L155
If you add a breakpoint on the next line, run the program, continue program execution 2 times, then the `firstUnused` property jumps from 1 to 3, skipping the unused commands, causing our bug.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [questionable X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [not necessary] I've updated the documentation if necessary
