### PR TITLE
Convert all public enums to structs

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -140,7 +140,14 @@ extension Argument where Value: ExpressibleByArgument {
 
 /// The strategy to use when parsing multiple values from `@Option` arguments
 /// into an array.
-public enum ArgumentArrayParsingStrategy {
+public struct ArgumentArrayParsingStrategy: Hashable {
+  internal enum Representation {
+    case remaining
+    case unconditionalRemaining
+  }
+  
+  internal var base: Representation
+  
   /// Parse only unprefixed values from the command-line input, ignoring
   /// any inputs that have a dash prefix.
   ///
@@ -156,7 +163,9 @@ public enum ArgumentArrayParsingStrategy {
   /// `one two --other` would result in an unknown option error for `--other`.
   ///
   /// This is the default strategy for parsing argument arrays.
-  case remaining
+  public static var remaining: ArgumentArrayParsingStrategy {
+    self.init(base: .remaining)
+  }
   
   /// Parse all remaining inputs after parsing any known options or flags,
   /// including dash-prefixed inputs and the `--` terminator.
@@ -178,7 +187,9 @@ public enum ArgumentArrayParsingStrategy {
   ///   the `--` terminator. With the `remaining` parsing strategy, the input
   ///   `--verbose -- one two --other` would have the same result as the above
   ///   example: `Options(verbose: true, words: ["one", "two", "--other"])`.
-  case unconditionalRemaining
+  public static var unconditionalRemaining: ArgumentArrayParsingStrategy {
+    self.init(base: .unconditionalRemaining)
+  }
 }
 
 extension Argument {

--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -82,7 +82,14 @@ public struct ExitCode: Error, RawRepresentable, Hashable {
 ///
 /// Throwing a `CleanExit` instance from a `validate` or `run` method, or
 /// passing it to `exit(with:)`, exits the program with exit code `0`.
-public enum CleanExit: Error, CustomStringConvertible {
+public struct CleanExit: Error, CustomStringConvertible {
+  internal enum Representation {
+    case helpRequest(ParsableCommand.Type? = nil)
+    case message(String)
+  }
+  
+  internal var base: Representation
+  
   /// Treat this error as a help request and display the full help message.
   ///
   /// You can use this case to simulate the user specifying one of the help
@@ -90,16 +97,13 @@ public enum CleanExit: Error, CustomStringConvertible {
   ///
   /// - Parameter command: The command type to offer help for, if different
   ///   from the root command.
-  case helpRequest(ParsableCommand.Type? = nil)
+  public static func helpRequest(_ type: ParsableCommand.Type? = nil) -> CleanExit {
+    self.init(base: .helpRequest(type))
+  }
   
   /// Treat this error as a clean exit with the given message.
-  case message(String)
-  
-  public var description: String {
-    switch self {
-    case .helpRequest: return "--help"
-    case .message(let message): return message
-    }
+  public static func message(_ text: String) -> CleanExit {
+    self.init(base: .message(text))
   }
   
   /// Treat this error as a help request and display the full help message.
@@ -111,5 +115,12 @@ public enum CleanExit: Error, CustomStringConvertible {
   ///   the root command.
   public static func helpRequest(_ command: ParsableCommand) -> CleanExit {
     return .helpRequest(type(of: command))
+  }
+  
+  public var description: String {
+    switch self.base {
+    case .helpRequest: return "--help"
+    case .message(let message): return message
+    }
   }
 }

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -93,7 +93,14 @@ extension Flag: CustomStringConvertible {
 extension Flag: DecodableParsedWrapper where Value: Decodable {}
 
 /// The options for converting a Boolean flag into a `true`/`false` pair.
-public enum FlagInversion {
+public struct FlagInversion: Hashable {
+  internal enum Representation {
+    case prefixedNo
+    case prefixedEnableDisable
+  }
+  
+  internal var base: Representation
+  
   /// Adds a matching flag with a `no-` prefix to represent `false`.
   ///
   /// For example, the `shouldRender` property in this declaration is set to
@@ -102,7 +109,9 @@ public enum FlagInversion {
   ///
   ///     @Flag(name: .customLong("render"), inversion: .prefixedNo)
   ///     var shouldRender: Bool
-  case prefixedNo
+  public static var prefixedNo: FlagInversion {
+    self.init(base: .prefixedNo)
+  }
   
   /// Uses matching flags with `enable-` and `disable-` prefixes.
   ///
@@ -112,19 +121,35 @@ public enum FlagInversion {
   ///
   ///     @Flag(inversion: .prefixedEnableDisable)
   ///     var extraOutput: Bool
-  case prefixedEnableDisable
+  public static var prefixedEnableDisable: FlagInversion {
+    self.init(base: .prefixedEnableDisable)
+  }
 }
 
 /// The options for treating enumeration-based flags as exclusive.
-public enum FlagExclusivity {
+public struct FlagExclusivity: Hashable {
+  internal enum Representation {
+    case exclusive
+    case chooseFirst
+    case chooseLast
+  }
+  
+  internal var base: Representation
+  
   /// Only one of the enumeration cases may be provided.
-  case exclusive
+  public static var exclusive: FlagExclusivity {
+    self.init(base: .exclusive)
+  }
   
   /// The first enumeration case that is provided is used.
-  case chooseFirst
+  public static var chooseFirst: FlagExclusivity {
+    self.init(base: .chooseFirst)
+  }
   
   /// The last enumeration case that is provided is used.
-  case chooseLast
+  public static var chooseLast: FlagExclusivity {
+    self.init(base: .chooseLast)
+  }
 }
 
 extension Flag where Value == Optional<Bool> {

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -339,7 +339,7 @@ extension Flag where Value: EnumerableFlag {
         let name = Value.name(for: value)
         let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
         let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: helpForCase, defaultValue: defaultValue, key: key, isComposite: !hasCustomCaseHelp)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: initial, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
       }
@@ -428,7 +428,7 @@ extension Flag {
         let name = Element.name(for: value)
         let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
         let help = ArgumentDefinition.Help(options: .isOptional, help: helpForCase, key: key, isComposite: !hasCustomCaseHelp)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
 
@@ -453,7 +453,7 @@ extension Flag {
         let name = Element.name(for: value)
         let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
         let help = ArgumentDefinition.Help(options: .isOptional, help: helpForCase, key: key, isComposite: !hasCustomCaseHelp)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: initial, update: .nullary({ (origin, name, values) in
           values.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
             $0.append(value)
           })
@@ -530,7 +530,7 @@ extension Flag where Value: CaseIterable, Value: RawRepresentable, Value: Equata
       let args = Value.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
         let help = ArgumentDefinition.Help(options: initial != nil ? .isOptional : [], help: help, defaultValue: defaultValue, key: key, isComposite: true)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: initial, update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: initial, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
       }
@@ -556,7 +556,7 @@ extension Flag {
       let args = Element.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
         let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key, isComposite: true)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: nil as Element?, update: .nullary({ (origin, name, values) in
           hasUpdated = try ArgumentSet.updateFlag(key: key, value: value, origin: origin, values: &values, hasUpdated: hasUpdated, exclusivity: exclusivity)
         }))
       }
@@ -582,7 +582,7 @@ extension Flag {
       let args = Element.allCases.map { value -> ArgumentDefinition in
         let caseKey = InputKey(rawValue: value.rawValue)
         let help = ArgumentDefinition.Help(options: .isOptional, help: help, key: key, isComposite: true)
-        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .nextAsValue, initialValue: [Element](), update: .nullary({ (origin, name, values) in
+        return ArgumentDefinition.flag(name: name, key: key, caseKey: caseKey, help: help, parsingStrategy: .default, initialValue: [Element](), update: .nullary({ (origin, name, values) in
           values.update(forKey: key, inputOrigin: origin, initial: [Element](), closure: {
             $0.append(value)
           })

--- a/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
+++ b/Sources/ArgumentParser/Parsable Properties/NameSpecification.swift
@@ -12,13 +12,24 @@
 /// A specification for how to represent a property as a command-line argument
 /// label.
 public struct NameSpecification: ExpressibleByArrayLiteral {
-  public enum Element: Hashable {
+  public struct Element: Hashable {
+    internal enum Representation: Hashable {
+      case long
+      case customLong(_ name: String, withSingleDash: Bool)
+      case short
+      case customShort(_ char: Character, allowingJoined: Bool)
+    }
+    
+    internal var base: Representation
+    
     /// Use the property's name, converted to lowercase with words separated by
     /// hyphens.
     ///
     /// For example, a property named `allowLongNames` would be converted to the
     /// label `--allow-long-names`.
-    case long
+    public static var long: Element {
+      self.init(base: .long)
+    }
     
     /// Use the given string instead of the property's name.
     ///
@@ -30,13 +41,17 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     ///   - name: The name of the option or flag.
     ///   - withSingleDash: A Boolean value indicating whether to use a single
     ///     dash as the prefix. If `false`, the name has a double-dash prefix.
-    case customLong(_ name: String, withSingleDash: Bool = false)
+    public static func customLong(_ name: String, withSingleDash: Bool = false) -> Element {
+      self.init(base: .customLong(name, withSingleDash: withSingleDash))
+    }
     
     /// Use the first character of the property's name as a short option label.
     ///
     /// For example, a property named `verbose` would be converted to the
     /// label `-v`. Short labels can be combined into groups.
-    case short
+    public static var short: Element {
+      self.init(base: .short)
+    }
     
     /// Use the given character as a short option label.
     ///
@@ -49,7 +64,9 @@ public struct NameSpecification: ExpressibleByArrayLiteral {
     ///   - char: The name of the option or flag.
     ///   - allowingJoined: A Boolean value indicating whether this short name
     ///     allows a joined value.
-    case customShort(_ char: Character, allowingJoined: Bool = false)
+    public static func customShort(_ char: Character, allowingJoined: Bool = false) -> Element {
+      self.init(base: .customShort(char, allowingJoined: allowingJoined))
+    }
   }
   var elements: [Element]
   
@@ -116,7 +133,7 @@ extension NameSpecification {
 extension NameSpecification.Element {    
   /// Creates the argument name for this specification element.
   internal func name(for key: InputKey) -> Name? {
-    switch self {
+    switch self.base {
     case .long:
       return .long(key.rawValue.convertedToSnakeCase(separator: "-"))
     case .short:
@@ -145,7 +162,7 @@ extension FlagInversion {
     
     func makeNames(withPrefix prefix: String, includingShort: Bool) -> [Name] {
       return name.elements.compactMap { element -> Name? in
-        switch element {
+        switch element.base {
         case .short, .customShort:
           return includingShort ? element.name(for: key) : nil
         case .long:
@@ -159,7 +176,7 @@ extension FlagInversion {
       }
     }
     
-    switch (self) {
+    switch self.base {
     case .prefixedNo:
       return (
         name.makeNames(key),

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -162,7 +162,15 @@ extension Option where Value: ExpressibleByArgument {
 /// The strategy to use when parsing a single value from `@Option` arguments.
 ///
 /// - SeeAlso: `ArrayParsingStrategy``
-public enum SingleValueParsingStrategy {
+public struct SingleValueParsingStrategy: Hashable {
+  internal enum Representation {
+    case next
+    case unconditional
+    case scanningForValue
+  }
+  
+  internal var base: Representation
+  
   /// Parse the input after the option. Expect it to be a value.
   ///
   /// For inputs such as `--foo foo`, this would parse `foo` as the
@@ -174,7 +182,9 @@ public enum SingleValueParsingStrategy {
   ///     Usage: command [--foo <foo>]
   ///
   /// This is the **default behavior** for `@Option`-wrapped properties.
-  case next
+  public static var next: SingleValueParsingStrategy {
+    self.init(base: .next)
+  }
   
   /// Parse the next input, even if it could be interpreted as an option or
   /// flag.
@@ -188,7 +198,9 @@ public enum SingleValueParsingStrategy {
   /// interpreted as the start of another option.
   ///
   /// - Note: This is usually *not* what users would expect. Use with caution.
-  case unconditional
+  public static var unconditional: SingleValueParsingStrategy {
+    self.init(base: .unconditional)
+  }
   
   /// Parse the next input, as long as that input can't be interpreted as
   /// an option or flag.
@@ -199,12 +211,23 @@ public enum SingleValueParsingStrategy {
   ///
   /// For example, if `--foo` takes a value, then the input `--foo --bar bar`
   /// would be parsed such that the value `bar` is used for `--foo`.
-  case scanningForValue
+  public static var scanningForValue: SingleValueParsingStrategy {
+    self.init(base: .scanningForValue)
+  }
 }
 
 /// The strategy to use when parsing multiple values from `@Option` arguments into an
 /// array.
-public enum ArrayParsingStrategy {
+public struct ArrayParsingStrategy: Hashable {
+  internal enum Representation {
+    case singleValue
+    case unconditionalSingleValue
+    case upToNextOption
+    case remaining
+  }
+  
+  internal var base: Representation
+  
   /// Parse one value per option, joining multiple into an array.
   ///
   /// For example, for a parsable type with a property defined as
@@ -217,7 +240,9 @@ public enum ArrayParsingStrategy {
   ///     such, the value for this option will be the next value (non-option) in the input. For the
   ///     above example, the input `--read --name Foo Bar` would parse `Foo` into
   ///     `read` (and `Bar` into `name`).
-  case singleValue
+  public static var singleValue: ArrayParsingStrategy {
+    self.init(base: .singleValue)
+  }
   
   /// Parse the value immediately after the option while allowing repeating options, joining multiple into an array.
   ///
@@ -232,7 +257,9 @@ public enum ArrayParsingStrategy {
   /// - Note: However, the input `--read --name Foo Bar --read baz` would result in
   /// `read` being set to the array `["--name", "baz"]`. This is usually *not* what users
   /// would expect. Use with caution.
-  case unconditionalSingleValue
+  public static var unconditionalSingleValue: ArrayParsingStrategy {
+    self.init(base: .unconditionalSingleValue)
+  }
   
   /// Parse all values up to the next option.
   ///
@@ -244,8 +271,10 @@ public enum ArrayParsingStrategy {
   /// Parsing stops as soon as there’s another option in the input such that
   /// `--files foo bar --verbose` would also set `files` to the array
   /// `["foo", "bar"]`.
-  case upToNextOption
-  
+  public static var upToNextOption: ArrayParsingStrategy {
+    self.init(base: .upToNextOption)
+  }
+
   /// Parse all remaining arguments into an array.
   ///
   /// `.remaining` can be used for capturing pass-through flags. For example, for
@@ -269,7 +298,9 @@ public enum ArrayParsingStrategy {
   /// ```
   /// would parse the input `--name Foo -- Bar --baz` such that the `remainder`
   /// would hold the value `["Bar", "--baz"]`.
-  case remaining
+  public static var remaining: ArrayParsingStrategy {
+    self.init(base: .remaining)
+  }
 }
 
 extension Option {

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -130,7 +130,7 @@ struct ArgumentDefinition {
 
 extension ArgumentDefinition.ParsingStrategy {
   init(_ other: SingleValueParsingStrategy) {
-    switch other {
+    switch other.base {
     case .next:
       self = .nextAsValue
     case .scanningForValue:
@@ -141,7 +141,7 @@ extension ArgumentDefinition.ParsingStrategy {
   }
   
   init(_ other: ArrayParsingStrategy) {
-    switch other {
+    switch other.base {
     case .singleValue:
       self = .scanningForValue
     case .unconditionalSingleValue:

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -75,7 +75,7 @@ struct ArgumentDefinition {
   enum ParsingStrategy {
     /// Expect the next `SplitArguments.Element` to be a value and parse it. Will fail if the next
     /// input is an option.
-    case nextAsValue
+    case `default`
     /// Parse the next `SplitArguments.Element.value`
     case scanningForValue
     /// Parse the next `SplitArguments.Element` as a value, regardless of its type.
@@ -111,7 +111,7 @@ struct ArgumentDefinition {
     kind: Kind,
     help: Help,
     completion: CompletionKind,
-    parsingStrategy: ParsingStrategy = .nextAsValue,
+    parsingStrategy: ParsingStrategy = .default,
     update: Update,
     initial: @escaping Initial = { _, _ in }
   ) {
@@ -125,32 +125,6 @@ struct ArgumentDefinition {
     self.parsingStrategy = parsingStrategy
     self.update = update
     self.initial = initial
-  }
-}
-
-extension ArgumentDefinition.ParsingStrategy {
-  init(_ other: SingleValueParsingStrategy) {
-    switch other.base {
-    case .next:
-      self = .nextAsValue
-    case .scanningForValue:
-      self = .scanningForValue
-    case .unconditional:
-      self = .unconditional
-    }
-  }
-  
-  init(_ other: ArrayParsingStrategy) {
-    switch other.base {
-    case .singleValue:
-      self = .scanningForValue
-    case .unconditionalSingleValue:
-      self = .unconditional
-    case .upToNextOption:
-      self = .upToNextOption
-    case .remaining:
-      self = .allRemainingInput
-    }
   }
 }
 

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -75,7 +75,7 @@ extension ArgumentSet {
   }
 
   static func updateFlag<Value: Equatable>(key: InputKey, value: Value, origin: InputOrigin, values: inout ParsedValues, hasUpdated: Bool, exclusivity: FlagExclusivity) throws -> Bool {
-    switch (hasUpdated, exclusivity) {
+    switch (hasUpdated, exclusivity.base) {
     case (true, .exclusive):
       // This value has already been set.
       if let previous = values.element(forKey: key) {

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -138,7 +138,7 @@ extension ArgumentSet {
 
 extension ArgumentSet {
   /// Create a unary / argument that parses the string as `A`.
-  init<A: ExpressibleByArgument>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ArgumentDefinition.ParsingStrategy = .nextAsValue, parseType type: A.Type, name: NameSpecification, default initial: A?, help: ArgumentHelp?, completion: CompletionKind) {
+  init<A: ExpressibleByArgument>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ArgumentDefinition.ParsingStrategy = .default, parseType type: A.Type, name: NameSpecification, default initial: A?, help: ArgumentHelp?, completion: CompletionKind) {
     var arg = ArgumentDefinition(key: key, kind: kind, parsingStrategy: parsingStrategy, parser: A.init(argument:), default: initial, completion: completion)
     arg.help.help = help
     arg.help.defaultValue = initial.map { "\($0.defaultValueDescription)" }
@@ -148,7 +148,7 @@ extension ArgumentSet {
 
 extension ArgumentDefinition {
   /// Create a unary / argument that parses using the given closure.
-  init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .nextAsValue, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind) {
+  init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .default, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind) {
     let initialValueCreator: (InputOrigin, inout ParsedValues) throws -> Void
     if let initialValue = initial {
       initialValueCreator = { origin, values in
@@ -199,7 +199,7 @@ extension ArgumentSet {
     ) throws {
       let origin = InputOrigin(elements: [originElement])
       switch argument.parsingStrategy {
-      case .nextAsValue:
+      case .default:
         // We need a value for this option.
         if let value = parsed.value {
           // This was `--foo=bar` style:

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -84,7 +84,7 @@ enum MessageInfo {
       case let error as ValidationError:
         self = .validation(message: error.message, usage: usage, help: "")
       case let error as CleanExit:
-        switch error {
+        switch error.base {
         case .helpRequest(let command):
           if let command = command {
             commandStack = CommandParser(type.asCommand).commandStack(for: command)


### PR DESCRIPTION
Using structs for these public types (instead of enums) will let us add members in the future without breaking source compatibility. This is a source-breaking change, but not alarmingly so — these enum cases are typically used as static members, and that usage is maintained. Only switch exhaustivity is altered here.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary