### PR TITLE
Exclude supercommands from help

### DIFF
--- a/Documentation/04 Customizing Help.md
+++ b/Documentation/04 Customizing Help.md
@@ -193,7 +193,45 @@ struct Example: ParsableCommand {
     var experimentalEnableWidgets: Bool
 }
 ```
+## Excluding Super Commands from printing their help
 
+When printing help for a subcommand you may find it desirable to exclude any help that comes from a super command. You can prevent the help for super commands by adding `includeSuperCommandInHelp = false` to your struct.
+
+```swift
+public struct Foo: ParsableCommand {
+    public static var configuration = CommandConfiguration(
+        commandName: "foo",
+        subcommands: [Bar.self])
+        
+        @OptionGroup()
+        var fooOptions: FooToolOptions
+        
+        public init() {}
+}
+
+extension Foo {
+    struct Bar: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Make Bar")
+            
+        static let includeSuperCommandInHelp = false
+        
+        @Option(name: .customLong("name"), help: "Provide custom name")
+        var barName: String?
+    }
+}
+```
+```
+$ foo bar --help
+OVERVIEW: Make Bar
+
+USAGE: foo bar [--name <name>]
+
+OPTIONS:
+  --name <name>           Provide custom name 
+  --version               Show the version.
+  -help, -h, --help       Show help information.
+```
 ## Generating Help Text Programmatically
 
 The help screen is automatically shown to users when they call your command with the help flag. You can generate the same text from within your program by calling the `helpMessage()` method.

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -47,6 +47,8 @@ public struct CommandConfiguration {
   /// Flag names to be used for help.
   public var helpNames: NameSpecification?
   
+  public var includeSuperCommandInHelp: Bool?
+  
   /// Creates the configuration for a command.
   ///
   /// - Parameters:
@@ -76,7 +78,8 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
-    helpNames: NameSpecification? = nil
+    helpNames: NameSpecification? = nil,
+    includeSuperCommandInHelp: Bool? = nil
   ) {
     self.commandName = commandName
     self.abstract = abstract
@@ -86,6 +89,7 @@ public struct CommandConfiguration {
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand
     self.helpNames = helpNames
+    self.includeSuperCommandInHelp = includeSuperCommandInHelp
   }
 
   /// Creates the configuration for a command with a "super-command".
@@ -99,7 +103,8 @@ public struct CommandConfiguration {
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
-    helpNames: NameSpecification? = nil
+    helpNames: NameSpecification? = nil,
+    includeSuperCommandInHelp: Bool? = nil
   ) {
     self.commandName = commandName
     self._superCommandName = _superCommandName
@@ -110,5 +115,6 @@ public struct CommandConfiguration {
     self.subcommands = subcommands
     self.defaultSubcommand = defaultSubcommand
     self.helpNames = helpNames
+    self.includeSuperCommandInHelp = includeSuperCommandInHelp
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -22,6 +22,7 @@ public protocol ParsableCommand: ParsableArguments {
   /// can pass through the wrapped type's name.
   static var _commandName: String { get }
   
+  static var includeSuperCommandInHelp: Bool { get }
   /// Runs this command.
   ///
   /// After implementing this method, you can run your command-line
@@ -41,6 +42,10 @@ extension ParsableCommand {
     CommandConfiguration()
   }
   
+  public static var includeSuperCommandInHelp: Bool {
+    configuration.includeSuperCommandInHelp ?? true
+  }
+    
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -144,8 +144,16 @@ internal struct HelpGenerator {
     var optionElements: [Section.Element] = []
     /// Used to keep track of elements already seen from parent commands.
     var alreadySeenElements = Set<Section.Element>()
-
+    
+    var commandsToShowHelp = [ParsableCommand.Type]()
     for commandType in commandStack {
+      // This will remove all super commands in the event that a subcommand does not
+      // want to include their respective help
+      if !commandType.includeSuperCommandInHelp { commandsToShowHelp.removeAll() }
+      commandsToShowHelp.append(commandType)
+    }
+
+    for commandType in commandsToShowHelp {
       let args = Array(ArgumentSet(commandType))
       
       var i = 0


### PR DESCRIPTION
Currently when asking for help with a subcommand we will receive help for it, and all supercommands that precede it. I propose the ability to only print help for the subcommand. The best example of this is in SwiftPM.

Current Behavior:

```
$ swift package init --help
OVERVIEW: Initialize a new package

USAGE: swift package init <options>

OPTIONS:
  -Xcc <Xcc>              Pass flag through to all C compiler invocations 
  -Xswiftc <Xswiftc>      Pass flag through to all Swift compiler invocations 
  -Xlinker <Xlinker>      Pass flag through to all linker invocations 
  -Xcxx <Xcxx>            Pass flag through to all C++ compiler invocations 
  -c, --configuration <configuration>
                          Build with configuration (default: debug)
  --build-path <build-path>
                          Specify build/cache directory 
  --cache-path <cache-path>
                          Specify the shared cache directory 
  --enable-repository-cache/--disable-repository-cache
                          Use a shared cache when fetching repositories (default: true)
  -C, --chdir <chdir>
  --package-path <package-path>
                          Change working directory before any other operation 
  --multiroot-data-file <multiroot-data-file>
  --enable-prefetching/--disable-prefetching
                          (default: true)
  -v, --verbose           Increase verbosity of informational output 
  --disable-sandbox       Disable using the sandbox when executing subprocesses 
  --manifest-cache <manifest-cache>
                          Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none:
                          disabled (default: shared)
  --destination <destination>
  --triple <triple>
  --sdk <sdk>
  --toolchain <toolchain>
  --static-swift-stdlib/--no-static-swift-stdlib
                          Link Swift stdlib statically (default: false)
  --skip-update           Skip updating dependencies from their remote during a resolution 
  --sanitize <sanitize>   Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo 
  --enable-code-coverage/--disable-code-coverage
                          Enable code coverage (default: false)
  --force-resolved-versions, --disable-automatic-resolution
                          Disable automatic resolution if Package.resolved file is out-of-date 
  --enable-index-store/--disable-index-store
                          Enable or disable  indexing-while-building feature 
  --enable-parseable-module-interfaces
  --trace-resolver
  -j, --jobs <jobs>       The number of jobs to spawn in parallel during the build process 
  --enable-build-manifest-caching/--disable-build-manifest-caching
                          (default: true)
  --emit-swift-module-separately
  --use-integrated-swift-driver
  --experimental-explicit-module-build
  --print-manifest-job-graph
                          Write the command graph for the build manifest as a graphviz file 
  --build-system <build-system>
                          (default: native)
  --netrc
  --netrc-optional
  --netrc-file <netrc-file>
  --type <type>           (default: library)
  --name <name>           Provide custom package name 
  --version               Show the version.
  -help, -h, --help       Show help information.
```

Proposed Behavior
```
swift package init --help
OVERVIEW: Initialize a new package

USAGE: swift package init [--type <type>] [--name <name>]

OPTIONS:
  --type <type>           Package type: empty | library | executable | system-module | manifest (default: library)
  --name <name>           Provide custom package name 
  --version               Show the version.
  -help, -h, --help       Show help information.
```

These changes are fully backwards compatible, with no changes needed to existing sources that depend on `ArgumentParser`.

To access this new feature a user would just need to add `includeSuperCommandInHelp = false` to their struct that conforms to `ParsableCommand`

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
