### PR TITLE
Hide option group with new OptionGroup constructor

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -27,7 +27,8 @@ public struct Argument<Value>:
   Decodable, ParsedWrapper
 {
   internal var _parsedValue: Parsed<Value>
-  
+  internal var _hiddenFromHelp: Bool = false
+    
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -39,7 +39,8 @@
 @propertyWrapper
 public struct Flag<Value>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
-  
+  internal var _hiddenFromHelp: Bool = false
+    
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -29,7 +29,8 @@
 @propertyWrapper
 public struct Option<Value>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
-  
+  internal var _hiddenFromHelp: Bool = false
+    
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -31,6 +31,7 @@
 @propertyWrapper
 public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
+  internal var _hidden: Bool?
   
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
@@ -84,7 +85,17 @@ extension OptionGroup: CustomStringConvertible {
     case .value(let v):
       return String(describing: v)
     case .definition:
+      if let hidden = _hidden {
+        return "OptionGroup(*definition*) _hidden: \(hidden)"
+      }
       return "OptionGroup(*definition*)"
     }
   }
+}
+
+extension OptionGroup {
+    public init(_hidden: Bool) {
+        self.init()
+        self._hidden = _hidden
+    }
 }

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -31,7 +31,7 @@
 @propertyWrapper
 public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
-  internal var _hidden: Bool?
+  internal var _hiddenFromHelp: Bool = false
   
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
@@ -85,17 +85,15 @@ extension OptionGroup: CustomStringConvertible {
     case .value(let v):
       return String(describing: v)
     case .definition:
-      if let hidden = _hidden {
-        return "OptionGroup(*definition*) _hidden: \(hidden)"
-      }
       return "OptionGroup(*definition*)"
     }
   }
 }
 
+// Experimental use with caution
 extension OptionGroup {
-    public init(_hidden: Bool) {
+    public init(_hiddenFromHelp: Bool) {
         self.init()
-        self._hidden = _hidden
+        self._hiddenFromHelp = _hiddenFromHelp
     }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -229,6 +229,8 @@ func nilOrValue(_ value: Any) -> Any? {
 /// the argument set that they define.
 protocol ArgumentSetProvider {
   func argumentSet(for key: InputKey) -> ArgumentSet
+    
+  var _hiddenFromHelp: Bool { get }
 }
 
 extension ArgumentSet {
@@ -247,11 +249,11 @@ extension ArgumentSet {
       .compactMap { child in
         guard var codingKey = child.label else { return nil }
         
-        if creatingHelp {
-          guard !String(describing: child.value).contains("_hidden: true") else { return nil }
-        }
-        
         if let parsed = child.value as? ArgumentSetProvider {
+          if creatingHelp {
+            guard !parsed._hiddenFromHelp else { return nil }
+          }
+
           // Property wrappers have underscore-prefixed names
           codingKey = String(codingKey.first == "_"
                               ? codingKey.dropFirst(1)

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -232,7 +232,7 @@ protocol ArgumentSetProvider {
 }
 
 extension ArgumentSet {
-  init(_ type: ParsableArguments.Type) {
+  init(_ type: ParsableArguments.Type, creatingHelp: Bool = false) {
     
     #if DEBUG
     do {
@@ -246,6 +246,10 @@ extension ArgumentSet {
       .children
       .compactMap { child in
         guard var codingKey = child.label else { return nil }
+        
+        if creatingHelp {
+          guard !String(describing: child.value).contains("_hidden: true") else { return nil }
+        }
         
         if let parsed = child.value as? ArgumentSetProvider {
           // Property wrappers have underscore-prefixed names

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -149,7 +149,7 @@ internal struct HelpGenerator {
       return []
     }
     
-    let args = Array(ArgumentSet(commandType))
+    let args = Array(ArgumentSet(commandType, creatingHelp: true))
     
     var i = 0
     while i < args.count {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -485,7 +485,7 @@ extension HelpGenerationTests {
   struct HideDriver: ParsableCommand {
     static let configuration = CommandConfiguration(commandName: "driver", abstract: "Demo hiding option groups")
     
-    @OptionGroup(_hidden: true)
+    @OptionGroup(_hiddenFromHelp: true)
     var hideMe: optionsToHide
     
     @Option(help: "Time to wait before timeout (in seconds)")

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -473,4 +473,36 @@ extension HelpGenerationTests {
     
     """)
   }
+    
+  struct optionsToHide: ParsableArguments {
+    @Flag(help: "Verbose")
+    var verbose: Bool = false
+    
+    @Option(help: "Custom Name")
+    var customName: String?
+  }
+    
+  struct HideDriver: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "driver", abstract: "Demo hiding option groups")
+    
+    @OptionGroup(_hidden: true)
+    var hideMe: optionsToHide
+    
+    @Option(help: "Time to wait before timeout (in seconds)")
+    var timeout: Int?
+  }
+    
+  func testHidingOptionGroup() throws {
+    AssertHelp(for: HideDriver.self, equals: """
+        OVERVIEW: Demo hiding option groups
+
+        USAGE: driver [--verbose] [--custom-name <custom-name>] [--timeout <timeout>]
+
+        OPTIONS:
+          --timeout <timeout>     Time to wait before timeout (in seconds)
+          -h, --help              Show help information.
+        
+        """
+    )
+  }
 }


### PR DESCRIPTION
Second PR that is needed to fix --help for SwiftPM

Related PRs:

[SwiftPM](https://github.com/apple/swift-package-manager/pull/3407)
[ArgumentParser](https://github.com/apple/swift-argument-parser/pull/300)


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
