### PR TITLE
Expose ArgumentParserTestHelpers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,9 @@ var package = Package(
         .library(
             name: "ArgumentParser",
             targets: ["ArgumentParser"]),
+        .library(
+            name: "ArgumentParserTestHelpers",
+            targets: ["ArgumentParserTestHelpers"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
It would be nice to have access to ArgumentParserTestHelpers, this would allow SwiftPM to use `AssertHelp` to prevent regression.
### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
