### PR TITLE
Capture values across multiple .upToNextOption option uses

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -287,9 +287,6 @@ extension ArgumentSet {
         }
         
       case .upToNextOption:
-        // Reset initial value with the found source index
-        try argument.initial(origin, &result)
-        
         // Use an attached value if it exists...
         if let value = parsed.value {
           // This was `--foo=bar` style:

--- a/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
@@ -153,7 +153,7 @@ extension JoinedEndToEndTests {
     }
     
     AssertParse(Baz.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { baz in
-      XCTAssertEqual(baz.debug, ["debug3", "debug4"])
+      XCTAssertEqual(baz.debug, ["debug1", "debug2", "debug3", "debug4"])
     }
   }
   

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -175,18 +175,16 @@ extension RepeatingEndToEndTests {
       XCTAssertNil(qux.extra)
     }
 
-    // TODO: Is this the right behavior? Or should an option always consume
-    // _at least one_ value even if it's set to `upToNextOption`.
-    AssertParse(Qux.self, ["--names", "--verbose"]) { qux in
+    AssertParse(Qux.self, ["--names", "one", "two", "--verbose", "--names", "three", "--names", "four"]) { qux in
       XCTAssertTrue(qux.verbose)
-      XCTAssertTrue(qux.names.isEmpty)
+      XCTAssertEqual(qux.names, ["one", "two", "three", "four"])
       XCTAssertNil(qux.extra)
     }
 
-    AssertParse(Qux.self, ["--names", "--verbose", "three"]) { qux in
+    AssertParse(Qux.self, ["extra", "--names", "one", "--names", "two", "--verbose", "--names", "three", "four"]) { qux in
       XCTAssertTrue(qux.verbose)
-      XCTAssertTrue(qux.names.isEmpty)
-      XCTAssertEqual(qux.extra, "three")
+      XCTAssertEqual(qux.names, ["one", "two", "three", "four"])
+      XCTAssertEqual(qux.extra, "extra")
     }
 
     AssertParse(Qux.self, ["--names", "one", "two"]) { qux in
@@ -217,8 +215,9 @@ extension RepeatingEndToEndTests {
   func testParsing_repeatingStringUpToNext_Fails() throws {
     XCTAssertThrowsError(try Qux.parse(["--names", "one", "--other"]))
     XCTAssertThrowsError(try Qux.parse(["--names", "one", "two", "--other"]))
-    // TODO: See above
     XCTAssertThrowsError(try Qux.parse(["--names", "--other"]))
+    XCTAssertThrowsError(try Qux.parse(["--names", "--verbose"]))
+    XCTAssertThrowsError(try Qux.parse(["--names", "--verbose", "three"]))
   }
 }
 


### PR DESCRIPTION
This fixes a bug where an `@Option` array defined with the `.upToNextOption` parsing strategy would only capture the last "group" of elements. e.g. in:

    example --test one two --test three four

the `--test` property would only have the value `["three", "four"]`.

Fixes rdar://73908471

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
