### PR TITLE
fix: change help subcommand position

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -263,10 +263,10 @@ internal struct HelpGenerator {
     var helpSubcommandMessage: String = ""
     if includesSubcommands {
       var names = commandStack.map { $0._commandName }
+      names.insert("help", at: 1)
       if let superName = commandStack.first!.configuration._superCommandName {
         names.insert(superName, at: 0)
       }
-      names.insert("help", at: 1)
 
       helpSubcommandMessage = """
 

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -474,6 +474,33 @@ extension HelpGenerationTests {
     """)
   }
     
+  struct Baz: ParsableCommand {
+
+    struct Cmd: ParsableCommand {
+      static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Command name.")
+    }
+
+    static var configuration = CommandConfiguration(
+      commandName: "baz",
+      _superCommandName: "foo",
+      subcommands: [Cmd.self]
+    )
+  }
+
+  func testHelpWithSuperCommand() {
+    AssertHelp(for: Baz.self, equals: """
+    USAGE: foo baz <subcommand>
+
+    OPTIONS:
+      -h, --help              Show help information.
+
+    SUBCOMMANDS:
+      cmd                     Command name.
+
+      See 'foo baz help <subcommand>' for detailed help.
+    """)
+  }
+
   struct optionsToHide: ParsableArguments {
     @Flag(help: "Verbose")
     var verbose: Bool = false


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Change help subcommand position

See `swift package` help detail

```
➜ swift package
OVERVIEW: Perform operations on Swift packages

SEE ALSO: swift build, swift run, swift test

USAGE: swift package <options> <subcommand>

OPTIONS:
  -Xcc <Xcc>              Pass flag through to all C compiler invocations
  ……

SUBCOMMANDS:
  clean                   Delete build artifacts
  ……

  See 'swift help package <subcommand>' for detailed help.
```
`See 'swift help package <subcommand>' for detailed help.` should be `See 'swift package help <subcommand>' for detailed help.`


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
