### PR TITLE
Use custom help flags in completion scripts

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -44,8 +44,6 @@ struct BashCompletionsGenerator {
     // as all the subcommand names.
     let completionWords = generateArgumentWords(commands)
       + subcommands.map { $0._commandName }
-      // FIXME: These shouldn't be hard-coded, since they're overridable
-      + ["-h", "--help"]
     
     // Generate additional top-level completions — these are completion lists
     // or custom function-based word lists from positional arguments.
@@ -124,8 +122,7 @@ struct BashCompletionsGenerator {
 
   /// Returns the option and flag names that can be top-level completions.
   fileprivate static func generateArgumentWords(_ commands: [ParsableCommand.Type]) -> [String] {
-    ArgumentSet(commands.last!)
-      .flatMap { $0.bashCompletionWords() }
+    commands.argumentsForHelp().flatMap { $0.bashCompletionWords() }
   }
 
   /// Returns additional top-level completions from positional arguments.

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -55,7 +55,8 @@ struct FishCompletionsGenerator {
       return complete(ancestors: commandChain, suggestion: suggestion)
     }
 
-    let argumentCompletions = ArgumentSet(type)
+    let argumentCompletions = commands
+      .argumentsForHelp()
       .flatMap { $0.argumentSegments(commandChain) }
       .map { complete(ancestors: $0, suggestion: $1) }
 

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -36,7 +36,6 @@ struct ZshCompletionsGenerator {
     let isRootCommand = commands.count == 1
     
     var args = generateCompletionArguments(commands)
-    args.append("'(-h --help)'{-h,--help}'[Print help information.]'")
     
     var subcommands = type.configuration.subcommands
     var subcommandHandler = ""
@@ -105,8 +104,7 @@ struct ZshCompletionsGenerator {
   }
 
   static func generateCompletionArguments(_ commands: [ParsableCommand.Type]) -> [String] {
-    ArgumentSet(commands.last!)
-      .compactMap { $0.zshCompletionString(commands) }
+    commands.argumentsForHelp().compactMap { $0.zshCompletionString(commands) }
   }
 }
 

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -38,6 +38,14 @@ struct ArgumentSet {
   init(sets: [ArgumentSet]) {
     self.init(sets.joined())
   }
+  
+  mutating func append(_ arg: ArgumentDefinition) {
+    let newPosition = content.count
+    content.append(arg)
+    for name in arg.names where namePositions[name.nameToMatch] == nil {
+      namePositions[name.nameToMatch] = newPosition
+    }
+  }
 }
 
 extension ArgumentSet: CustomDebugStringConvertible {
@@ -48,9 +56,11 @@ extension ArgumentSet: CustomDebugStringConvertible {
   }
 }
 
-extension ArgumentSet: Sequence {
-  func makeIterator() -> Array<ArgumentDefinition>.Iterator {
-    return content.makeIterator()
+extension ArgumentSet: RandomAccessCollection {
+  var startIndex: Int { content.startIndex }
+  var endIndex: Int { content.endIndex }
+  subscript(position: Int) -> ArgumentDefinition {
+    content[position]
   }
 }
 

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -232,7 +232,7 @@ _math() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     COMPREPLY=()
-    opts="add multiply stats help -h --help"
+    opts="--version -h --help add multiply stats help"
     if [[ $COMP_CWORD == "1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -258,7 +258,7 @@ _math() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_add() {
-    opts="--hex-output -x -h --help"
+    opts="--hex-output -x --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -266,7 +266,7 @@ _math_add() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_multiply() {
-    opts="--hex-output -x -h --help"
+    opts="--hex-output -x --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -274,7 +274,7 @@ _math_multiply() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_stats() {
-    opts="average stdev quantiles -h --help"
+    opts="--version -h --help average stdev quantiles"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -296,7 +296,7 @@ _math_stats() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_stats_average() {
-    opts="--kind -h --help"
+    opts="--kind --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -310,7 +310,7 @@ _math_stats_average() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_stats_stdev() {
-    opts="-h --help"
+    opts="--version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -318,7 +318,7 @@ _math_stats_stdev() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_stats_quantiles() {
-    opts="--file --directory --shell --custom -h --help"
+    opts="--file --directory --shell --custom --version -h --help"
     opts="$opts alphabet alligator branch braggart"
     opts="$opts $(math ---completion stats quantiles -- customArg "$COMP_WORDS")"
     if [[ $COMP_CWORD == "$1" ]]; then
@@ -346,7 +346,7 @@ _math_stats_quantiles() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_help() {
-    opts="-h --help"
+    opts="--version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -368,7 +368,8 @@ _math() {
     integer ret=1
     local -a args
     args+=(
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
         '(-): :->command'
         '(-)*:: :->arg'
     )
@@ -411,7 +412,8 @@ _math_add() {
     args+=(
         '(--hex-output -x)'{--hex-output,-x}'[Use hexadecimal notation for the result.]'
         ':values:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -424,7 +426,8 @@ _math_multiply() {
     args+=(
         '(--hex-output -x)'{--hex-output,-x}'[Use hexadecimal notation for the result.]'
         ':values:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -435,7 +438,8 @@ _math_stats() {
     integer ret=1
     local -a args
     args+=(
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
         '(-): :->command'
         '(-)*:: :->arg'
     )
@@ -474,7 +478,8 @@ _math_stats_average() {
     args+=(
         '--kind[The kind of average to provide.]:kind:(mean median mode)'
         ':values:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -486,7 +491,8 @@ _math_stats_stdev() {
     local -a args
     args+=(
         ':values:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -504,7 +510,8 @@ _math_stats_quantiles() {
         '--directory:directory:_files -/'
         '--shell:shell:{local -a list; list=(${(f)"$(head -100 /usr/share/dict/words | tail -50)"}); _describe '''' list}'
         '--custom:custom:{_custom_completion $_math_commandname ---completion stats quantiles -- --custom $words}'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -516,7 +523,8 @@ _math_help() {
     local -a args
     args+=(
         ':subcommands:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '--version[Show the version.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -545,18 +553,26 @@ function __fish_math_using_command
     end
     return 1
 end
+complete -c math -n '__fish_math_using_command math' -f -l version -d 'Show the version.'
+complete -c math -n '__fish_math_using_command math' -f -s h -l help -d 'Show help information.'
 complete -c math -n '__fish_math_using_command math' -f -a 'add' -d 'Print the sum of the values.'
 complete -c math -n '__fish_math_using_command math' -f -a 'multiply' -d 'Print the product of the values.'
 complete -c math -n '__fish_math_using_command math' -f -a 'stats' -d 'Calculate descriptive statistics.'
 complete -c math -n '__fish_math_using_command math' -f -a 'help' -d 'Show subcommand help information.'
 complete -c math -n '__fish_math_using_command math add' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
+complete -c math -n '__fish_math_using_command math add' -f -s h -l help -d 'Show help information.'
 complete -c math -n '__fish_math_using_command math multiply' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
+complete -c math -n '__fish_math_using_command math multiply' -f -s h -l help -d 'Show help information.'
+complete -c math -n '__fish_math_using_command math stats' -f -s h -l help -d 'Show help information.'
 complete -c math -n '__fish_math_using_command math stats' -f -a 'average' -d 'Print the average of the values.'
 complete -c math -n '__fish_math_using_command math stats' -f -a 'stdev' -d 'Print the standard deviation of the values.'
 complete -c math -n '__fish_math_using_command math stats' -f -a 'quantiles' -d 'Print the quantiles of the values (TBD).'
 complete -c math -n '__fish_math_using_command math stats' -f -a 'help' -d 'Show subcommand help information.'
 complete -c math -n '__fish_math_using_command math stats average' -f -r -l kind -d 'The kind of average to provide.'
 complete -c math -n '__fish_math_using_command math stats average --kind' -f -k -a 'mean median mode'
+complete -c math -n '__fish_math_using_command math stats average' -f -l version -d 'Show the version.'
+complete -c math -n '__fish_math_using_command math stats average' -f -s h -l help -d 'Show help information.'
+complete -c math -n '__fish_math_using_command math stats stdev' -f -s h -l help -d 'Show help information.'
 complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l file
 complete -c math -n '__fish_math_using_command math stats quantiles --file' -f -a '(for i in *.{txt,md}; echo $i;end)'
 complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l directory
@@ -565,4 +581,7 @@ complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l sh
 complete -c math -n '__fish_math_using_command math stats quantiles --shell' -f -a '(head -100 /usr/share/dict/words | tail -50)'
 complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l custom
 complete -c math -n '__fish_math_using_command math stats quantiles --custom' -f -a '(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])'
+complete -c math -n '__fish_math_using_command math stats quantiles' -f -s h -l help -d 'Show help information.'
+complete -c math -n '__fish_math_using_command math stats help' -f -s h -l help -d 'Show help information.'
+complete -c math -n '__fish_math_using_command math help' -f -s h -l help -d 'Show help information.'
 """

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -61,7 +61,6 @@ extension CompletionScriptTests {
   func testBase_Bash() throws {
     let script1 = try CompletionsGenerator(command: Base.self, shell: .bash)
           .generateCompletionScript()
-
     XCTAssertEqual(bashBaseCompletions, script1)
     
     let script2 = try CompletionsGenerator(command: Base.self, shellName: "bash")
@@ -151,7 +150,7 @@ _base() {
         '--path1:path1:_files'
         '--path2:path2:_files'
         '--path3:path3:(a b c)'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -223,7 +222,7 @@ _escaped-command() {
     local -a args
     args+=(
         '--one[Escaped chars: '"'"'\\[\\]\\\\.]:one:'
-        '(-h --help)'{-h,--help}'[Print help information.]'
+        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -263,4 +262,5 @@ complete -c base -n '__fish_base_using_command base' -f -r -l path2
 complete -c base -n '__fish_base_using_command base --path2' -f -a '(for i in *.{}; echo $i;end)'
 complete -c base -n '__fish_base_using_command base' -f -r -l path3
 complete -c base -n '__fish_base_using_command base --path3' -f -k -a 'a b c'
+complete -c base -n '__fish_base_using_command base' -f -s h -l help -d 'Show help information.'
 """

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -469,7 +469,7 @@ extension HelpGenerationTests {
     OPTIONS:
       --bar-strength <bar-strength>
                               Bar Strength
-      -help, -h, --help       Show help information.
+      -h, -help, --help       Show help information.
     
     """)
   }


### PR DESCRIPTION
This uses the customized help flags when generating completion scripts and includes the `--version` flag when appropriate. (Fish completions didn't include the help flags at all, which is now fixed as well.)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
