### PR TITLE
Ignore extra help flags when given with the 'help' subcommand

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -12,9 +12,15 @@
 struct HelpCommand: ParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "help",
-    abstract: "Show subcommand help information.")
+    abstract: "Show subcommand help information.",
+    helpNames: [])
   
+  /// Any subcommand names provided after the `help` subcommand.
   @Argument var subcommands: [String] = []
+  
+  /// Capture and ignore any extra help flags given by the user.
+  @Flag(name: [.short, .long, .customLong("help", withSingleDash: true)], help: .hidden)
+  var help = false
   
   private(set) var commandStack: [ParsableCommand.Type] = []
   
@@ -34,15 +40,18 @@ struct HelpCommand: ParsableCommand {
   
   enum CodingKeys: CodingKey {
     case subcommands
+    case help
   }
   
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self._subcommands = Argument(_parsedValue: .value(try container.decode([String].self, forKey: .subcommands)))
+    self.subcommands = try container.decode([String].self, forKey: .subcommands)
+    self.help = try container.decode(Bool.self, forKey: .help)
   }
   
   init(commandStack: [ParsableCommand.Type]) {
     self.commandStack = commandStack
-    self._subcommands = Argument(_parsedValue: .value(commandStack.map { $0._commandName }))
+    self.subcommands = commandStack.map { $0._commandName }
+    self.help = false
   }
 }

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -60,6 +60,11 @@ final class MathExampleTests: XCTestCase {
     AssertExecuteCommand(command: "math add -h", expected: helpText)
     AssertExecuteCommand(command: "math add --help", expected: helpText)
     AssertExecuteCommand(command: "math help add", expected: helpText)
+    
+    // Verify that extra help flags are ignored.
+    AssertExecuteCommand(command: "math help add -h", expected: helpText)
+    AssertExecuteCommand(command: "math help add -help", expected: helpText)
+    AssertExecuteCommand(command: "math help add --help", expected: helpText)
   }
   
   func testMath_StatsMeanHelp() throws {
@@ -346,7 +351,7 @@ _math_stats_quantiles() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_help() {
-    opts="--version -h --help"
+    opts="--version"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -524,7 +529,6 @@ _math_help() {
     args+=(
         ':subcommands:'
         '--version[Show the version.]'
-        '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0
 
@@ -582,6 +586,4 @@ complete -c math -n '__fish_math_using_command math stats quantiles --shell' -f 
 complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l custom
 complete -c math -n '__fish_math_using_command math stats quantiles --custom' -f -a '(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])'
 complete -c math -n '__fish_math_using_command math stats quantiles' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math stats help' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math help' -f -s h -l help -d 'Show help information.'
 """


### PR DESCRIPTION
This resolves #259 — a bit more involved than I expected, as `HelpCommand` uses a custom decoder.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
