### PR TITLE
Clean up internal property nesting

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -179,9 +179,9 @@ struct BashCompletionsGenerator {
 extension ArgumentDefinition {
   /// Returns the different completion names for this argument.
   fileprivate func bashCompletionWords() -> [String] {
-    return help.help?.shouldDisplay == false
-      ? []
-      : names.map { $0.synopsisString }
+    return help.shouldDisplay
+      ? names.map { $0.synopsisString }
+      : []
   }
 
   /// Returns the bash completions that can follow this argument's `--name`.

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -100,7 +100,7 @@ extension Name {
 
 extension ArgumentDefinition {
   fileprivate func argumentSegments(_ commandChain: [String]) -> [([String], String)] {
-    guard help.help?.shouldDisplay != false else { return [] }
+    guard help.shouldDisplay else { return [] }
 
     var results = [([String], String)]()
     var formattedFlags = [String]()
@@ -114,8 +114,8 @@ extension ArgumentDefinition {
       if !flags.isEmpty {
         // add these flags to suggestions
         var suggestion = "-f\(isNullary ? "" : " -r") \(flags.joined(separator: " "))"
-        if let abstract = help.help?.abstract, !abstract.isEmpty {
-          suggestion += " -d '\(abstract.fishEscape())'"
+        if !help.abstract.isEmpty {
+          suggestion += " -d '\(help.abstract.fishEscape())'"
         }
 
         results.append((commandChain, suggestion))

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -128,15 +128,12 @@ extension String {
 
 extension ArgumentDefinition {
   var zshCompletionAbstract: String {
-    guard
-        let abstract = help.help?.abstract,
-        !abstract.isEmpty
-        else { return "" }
-    return "[\(abstract.zshEscaped())]"
+    guard !help.abstract.isEmpty else { return "" }
+    return "[\(help.abstract.zshEscaped())]"
   }
   
   func zshCompletionString(_ commands: [ParsableCommand.Type]) -> String? {
-    guard help.help?.shouldDisplay != false else { return nil }
+    guard help.shouldDisplay else { return nil }
     
     var inputs: String
     switch update {

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -207,7 +207,7 @@ extension Argument {
         parser: T.init(argument:),
         default: nil,
         completion: completion ?? T.defaultCompletionKind)
-      arg.help.help = help
+      arg.help.updateArgumentHelp(help: help)
       return ArgumentSet(arg.optional)
     })
   }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -317,7 +317,7 @@ extension Option {
         parser: T.init(argument:),
         default: nil,
         completion: completion ?? T.defaultCompletionKind)
-      arg.help.help = help
+      arg.help.updateArgumentHelp(help: help)
       return ArgumentSet(arg.optional)
     })
   }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -268,7 +268,7 @@ extension ArgumentSet {
             parser: { _ in nil },
             default: nilOrValue(child.value),
             completion: .default)
-          definition.help.help = .hidden
+          definition.help.updateArgumentHelp(help: .hidden)
           return ArgumentSet(definition)
         }
       }

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -39,8 +39,13 @@ struct ArgumentDefinition {
   
   struct Help {
     var options: Options
-    var help: ArgumentHelp?
-    var discussion: String?
+
+    // `ArgumentHelp` members
+    var abstract: String = ""
+    var discussion: String = ""
+    var valueName: String = ""
+    var shouldDisplay: Bool = true
+
     var defaultValue: String?
     var keys: [InputKey]
     var allValues: [String] = []
@@ -55,18 +60,26 @@ struct ArgumentDefinition {
     
     init(options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey, isComposite: Bool = false) {
       self.options = options
-      self.help = help
       self.defaultValue = defaultValue
       self.keys = [key]
       self.isComposite = isComposite
+      updateArgumentHelp(help: help)
     }
     
     init<T: ExpressibleByArgument>(type: T.Type, options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey) {
       self.options = options
-      self.help = help
+
       self.defaultValue = defaultValue
       self.keys = [key]
       self.allValues = type.allValueStrings
+      updateArgumentHelp(help: help)
+    }
+
+    mutating func updateArgumentHelp(help: ArgumentHelp?) {
+      self.abstract = help?.abstract ?? ""
+      self.discussion = help?.discussion ?? ""
+      self.valueName = help?.valueName ?? ""
+      self.shouldDisplay = help?.shouldDisplay ?? true
     }
   }
   
@@ -101,12 +114,13 @@ struct ArgumentDefinition {
   }
   
   var valueName: String {
-    return help.help?.valueName
-      ?? preferredNameForSynopsis?.valueString
-      ?? help.keys.first?.rawValue.convertedToSnakeCase(separator: "-")
-      ?? "value"
+    help.valueName.mapEmpty {
+      preferredNameForSynopsis?.valueString
+        ?? help.keys.first?.rawValue.convertedToSnakeCase(separator: "-")
+        ?? "value"
+    }
   }
-  
+
   init(
     kind: Kind,
     help: Help,

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -150,7 +150,7 @@ extension ArgumentSet {
   /// Create a unary / argument that parses the string as `A`.
   init<A: ExpressibleByArgument>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ArgumentDefinition.ParsingStrategy = .default, parseType type: A.Type, name: NameSpecification, default initial: A?, help: ArgumentHelp?, completion: CompletionKind) {
     var arg = ArgumentDefinition(key: key, kind: kind, parsingStrategy: parsingStrategy, parser: A.init(argument:), default: initial, completion: completion)
-    arg.help.help = help
+    arg.help.updateArgumentHelp(help: help)
     arg.help.defaultValue = initial.map { "\($0.defaultValueDescription)" }
     self.init(arg)
   }

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -150,7 +150,7 @@ internal struct HelpGenerator {
     var args = commandStack.argumentsForHelp()[...]
     
     while let arg = args.popFirst() {
-      guard arg.help.help?.shouldDisplay != false else { continue }
+      guard arg.help.shouldDisplay else { continue }
       
       let synopsis: String
       let description: String
@@ -165,20 +165,28 @@ internal struct HelpGenerator {
         synopsis = groupedArgs.compactMap { $0.synopsisForHelp }.joined(separator: "/")
 
         let defaultValue = arg.help.defaultValue.map { "(default: \($0))" } ?? ""
-        let descriptionString = groupedArgs.lazy.compactMap({ $0.help.help?.abstract }).first
+        let descriptionString = groupedArgs
+          .lazy
+          .map { $0.help.abstract }
+          .first { !$0.isEmpty }
+
         description = [descriptionString, defaultValue]
+          .lazy
           .compactMap { $0 }
+          .filter { !$0.isEmpty }
           .joined(separator: " ")
       } else {
         synopsis = arg.synopsisForHelp ?? ""
 
         let defaultValue = arg.help.defaultValue.flatMap { $0.isEmpty ? nil : "(default: \($0))" }
-        description = [arg.help.help?.abstract, defaultValue]
+        description = [arg.help.abstract, defaultValue]
+          .lazy
           .compactMap { $0 }
+          .filter { !$0.isEmpty }
           .joined(separator: " ")
       }
       
-      let element = Section.Element(label: synopsis, abstract: description, discussion: arg.help.help?.discussion ?? "")
+      let element = Section.Element(label: synopsis, abstract: description, discussion: arg.help.discussion)
       if case .positional = arg.kind {
         positionalElements.append(element)
       } else {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -68,9 +68,7 @@ extension ArgumentSet {
 
 extension ArgumentDefinition {
   var synopsisForHelp: String? {
-    guard help.help?.shouldDisplay != false else {
-      return nil
-    }
+    guard help.shouldDisplay else { return nil }
     
     switch kind {
     case .named:
@@ -110,9 +108,7 @@ extension ArgumentDefinition {
   }
   
   var synopsis: String? {
-    guard help.help?.shouldDisplay != false else {
-      return nil
-    }
+    guard help.shouldDisplay else { return nil }
     
     guard !help.options.contains(.isOptional) else {
       var n = self
@@ -382,7 +378,7 @@ extension ErrorMessageGenerator {
   }
   
   func unableToParseHelpMessage(origin: InputOrigin, name: Name?, value: String, key: InputKey, error: Error?) -> String {
-    guard let abstract = help(for: key)?.help?.abstract else { return "" }
+    guard let abstract = help(for: key)?.abstract else { return "" }
     
     let valueName = arguments(for: key).first?.valueName
     

--- a/Sources/ArgumentParser/Utilities/CollectionExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/CollectionExtensions.swift
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  func mapEmpty(_ replacement: () -> Self) -> Self {
+    isEmpty ? replacement() : self
+  }
+}


### PR DESCRIPTION
- Removes one layer of help properties by directly including the members
  of ArgumentHelp in ArgumentDefinition.Help. This also results in the
  discussion field which previously existed in both structures, now
  having a single source of truth. Adds helper method for setting each
  of these members using an instance of ArgumentHelp and additionally
  annotates each of the String? members with a new `@NonEmpty` property
  wrapper that ensures the wrapped string is either nil or nonempty so
  clients no do not need to check for the empty string case.

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
