### PR TITLE
Simplify synopsis string generation

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -145,7 +145,7 @@ struct BashCompletionsGenerator {
           let commandName = commands.first!._commandName
           let subcommandNames = commands.dropFirst().map { $0._commandName }.joined(separator: " ")
           // TODO: Make this work for @Arguments
-          let argumentName = arg.preferredNameForSynopsis?.synopsisString
+          let argumentName = arg.names.preferredName?.synopsisString
                 ?? arg.help.keys.first?.rawValue ?? "---"
           
           return """

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -102,7 +102,7 @@ extension ArgumentDefinition {
   /// this argument.
   func customCompletionCall(_ commands: [ParsableCommand.Type]) -> String {
     let subcommandNames = commands.dropFirst().map { $0._commandName }.joined(separator: " ")
-    let argumentName = preferredNameForSynopsis?.synopsisString
+    let argumentName = names.preferredName?.synopsisString
           ?? self.help.keys.first?.rawValue ?? "---"
     return "---completion \(subcommandNames) -- \(argumentName)"
   }

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -115,7 +115,7 @@ struct ArgumentDefinition {
   
   var valueName: String {
     help.valueName.mapEmpty {
-      preferredNameForSynopsis?.valueString
+      names.preferredName?.valueString
         ?? help.keys.first?.rawValue.convertedToSnakeCase(separator: "-")
         ?? "value"
     }
@@ -165,7 +165,6 @@ extension ArgumentDefinition: CustomDebugStringConvertible {
 extension ArgumentDefinition {
   var optional: ArgumentDefinition {
     var result = self
-    
     result.help.options.insert(.isOptional)
     return result
   }

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -159,15 +159,6 @@ extension ArgumentSet {
 extension ArgumentDefinition {
   /// Create a unary / argument that parses using the given closure.
   init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .default, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind) {
-    let initialValueCreator: (InputOrigin, inout ParsedValues) throws -> Void
-    if let initialValue = initial {
-      initialValueCreator = { origin, values in
-        values.set(initialValue, forKey: key, inputOrigin: origin)
-      }
-    } else {
-      initialValueCreator = { _, _ in }
-    }
-    
     self.init(kind: kind, help: ArgumentDefinition.Help(key: key), completion: completion, parsingStrategy: parsingStrategy, update: .unary({ (origin, name, value, values) in
       guard let v = parser(value) else {
         throw ParserError.unableToParseValue(origin, name, value, forKey: key)

--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-enum Name: Hashable {
+enum Name {
   /// A name (usually multi-character) prefixed with `--` (2 dashes) or equivalent.
   case long(String)
   /// A single character name prefixed with `-` (1 dash) or equivalent.
@@ -18,7 +18,9 @@ enum Name: Hashable {
   case short(Character, allowingJoined: Bool = false)
   /// A name (usually multi-character) prefixed with `-` (1 dash).
   case longWithSingleDash(String)
-  
+}
+
+extension Name {
   init(_ baseName: Substring) {
     assert(baseName.first == "-", "Attempted to create name for unprefixed argument")
     if baseName.hasPrefix("--") {
@@ -27,6 +29,35 @@ enum Name: Hashable {
       self = .short(baseName.last!)
     } else { // long name with single dash
       self = .longWithSingleDash(String(baseName.dropFirst()))
+    }
+  }
+}
+
+// short argument names based on the synopsisString
+// this will put the single - options before the -- options
+extension Name: Comparable {
+  static func < (lhs: Name, rhs: Name) -> Bool {
+    return lhs.synopsisString < rhs.synopsisString
+  }
+}
+
+extension Name: Hashable { }
+
+extension Name {
+  enum Case: Equatable {
+    case long
+    case short
+    case longWithSingleDash
+  }
+
+  var `case`: Case {
+    switch self {
+    case .short:
+      return .short
+    case .longWithSingleDash:
+      return .longWithSingleDash
+    case .long:
+      return .long
     }
   }
 }
@@ -53,16 +84,7 @@ extension Name {
       return n
     }
   }
-  
-  var isShort: Bool {
-    switch self {
-    case .short:
-      return true
-    default:
-      return false
-    }
-  }
-  
+
   var allowsJoined: Bool {
     switch self {
     case .short(_, let allowingJoined):
@@ -82,10 +104,12 @@ extension Name {
   }
 }
 
-// short argument names based on the synopsisString
-// this will put the single - options before the -- options
-extension Name: Comparable {
-  static func < (lhs: Name, rhs: Name) -> Bool {
-    return lhs.synopsisString < rhs.synopsisString
+extension BidirectionalCollection where Element == Name {
+  var preferredName: Name? {
+    first { $0.case != .short } ?? first
+  }
+
+  var paritioned: [Name] {
+    filter { $0.case == .short } + filter { $0.case != .short }
   }
 }

--- a/Sources/ArgumentParser/Parsing/Name.swift
+++ b/Sources/ArgumentParser/Parsing/Name.swift
@@ -109,7 +109,7 @@ extension BidirectionalCollection where Element == Name {
     first { $0.case != .short } ?? first
   }
 
-  var paritioned: [Name] {
+  var partitioned: [Name] {
     filter { $0.case == .short } + filter { $0.case != .short }
   }
 }

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -71,7 +71,7 @@ extension ArgumentDefinition {
     switch kind {
     case .named:
       let joinedSynopsisString = names
-        .paritioned
+        .partitioned
         .map { $0.synopsisString }
         .joined(separator: ", ")
 


### PR DESCRIPTION
- Removes unused codepaths.
- Simplifies synopsis string codepaths by removing optionality. This
  complexity is moved to the caller who is now responsible for filtering
  out hidden arguments and options. This change is desirable as it
  allows the caller to determine if the argument should be hidden. For
  example, while it makes sense to hide arguments in help text, it may
  not make sense to hide them when dumping the arguments for another
  tool to consume.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
