### PR TITLE
Fix default value description for URL

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -25,7 +25,7 @@ extension URL: ExpressibleByArgument {
   }
 
   public var defaultValueDescription: String {
-    self.absoluteString == FileManager.default.currentDirectoryPath
+    self.path == FileManager.default.currentDirectoryPath && self.isFileURL
       ? "current directory"
       : String(describing: self)
   }
@@ -156,7 +156,7 @@ extension HelpGenerationTests {
     var degree: Degree = .bachelor
 
     @Option(help: "Directory.")
-    var directory: URL = URL(string: FileManager.default.currentDirectoryPath)!
+    var directory: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
   }
 
   func testHelpWithDefaultValues() {


### PR DESCRIPTION
At first I noticed a crash when running the tests of this project. It was due to weird chars in my CWD.
This lead me to discover a bug where the default value description of a URL checks for the `absoluteString` value of itself instead of the path + whether it is a file URL!

Note: I did not add a test specifically, I don’t really know how this would be tested. Maybe create a folder with a weird name and check everything is good? Also a test with an https URL as default w/ a path being the same as current CWD?
Tell me, I’ll do them if needed.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
