### PR TITLE
Fix executable path when calling custom completion in bash

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -142,14 +142,13 @@ struct BashCompletionsGenerator {
           return "$(\(command))"
         case .custom:
           // Generate a call back into the command to retrieve a completions list
-          let commandName = commands.first!._commandName
           let subcommandNames = commands.dropFirst().map { $0._commandName }.joined(separator: " ")
           // TODO: Make this work for @Arguments
           let argumentName = arg.names.preferredName?.synopsisString
                 ?? arg.help.keys.first?.rawValue ?? "---"
           
           return """
-            $(\(commandName) ---completion \(subcommandNames) -- \(argumentName) "${COMP_WORDS[@]}")
+            $("${COMP_WORDS[0]}" ---completion \(subcommandNames) -- \(argumentName) "${COMP_WORDS[@]}")
             """
         }
       }
@@ -206,8 +205,7 @@ extension ArgumentDefinition {
         
     case .custom:
       // Generate a call back into the command to retrieve a completions list
-      let commandName = commands.first!._commandName      
-      return #"COMPREPLY=( $(compgen -W "$(\#(commandName) \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "$cur") )"#
+      return #"COMPREPLY=( $(compgen -W "$("${COMP_WORDS[0]}" \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "$cur") )"#
     }
   }
 }

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -325,7 +325,7 @@ _math_stats_stdev() {
 _math_stats_quantiles() {
     opts="--file --directory --shell --custom --version -h --help"
     opts="$opts alphabet alligator branch braggart"
-    opts="$opts $(math ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
+    opts="$opts $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -344,7 +344,7 @@ _math_stats_quantiles() {
             return
         ;;
         --custom)
-            COMPREPLY=( $(compgen -W "$(math ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur") )
+            COMPREPLY=( $(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur") )
             return
         ;;
     esac


### PR DESCRIPTION
In Bash, when calling completion for an executable written with full path (e.g. `/opt/brew/bin/example`), the completion script might call another executable if another executable with the same name happens to be first in the PATH. (This is particularly annoying when debugging completion in a project!) This PR fixes that.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
