### PR TITLE
[documentation] Fix guard syntax error in 06 Manual Parsing and Testing

### DIFF
--- a/Documentation/06 Manual Parsing and Testing.md
+++ b/Documentation/06 Manual Parsing and Testing.md
@@ -28,7 +28,7 @@ The static `parseOrExit()` method either returns a fully initialized instance of
 We can perform validation on the inputs and exit the script if necessary:
 
 ```swift
-guard let options.elements.count >= options.count else {
+guard options.elements.count >= options.count else {
     let error = ValidationError("Please specify a 'count' less than the number of elements.")
     SelectOptions.exit(withError: error)
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Fixed minor syntax error in Documentation/06 Manual Parsing and Testing.md

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
