### PR TITLE
Stop parsing earlier when a catch-all argument is present

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -139,13 +139,13 @@ extension Argument where Value: ExpressibleByArgument {
   }
 }
 
-/// The strategy to use when parsing multiple values from `@Option` arguments
+/// The strategy to use when parsing multiple values from positional arguments
 /// into an array.
 public struct ArgumentArrayParsingStrategy: Hashable {
   internal var base: ArgumentDefinition.ParsingStrategy
   
   /// Parse only unprefixed values from the command-line input, ignoring
-  /// any inputs that have a dash prefix.
+  /// any inputs that have a dash prefix. This is the default strategy.
   ///
   /// For example, for a parsable type defined as following:
   ///
@@ -166,23 +166,29 @@ public struct ArgumentArrayParsingStrategy: Hashable {
   /// Parse all remaining inputs after parsing any known options or flags,
   /// including dash-prefixed inputs and the `--` terminator.
   ///
-  /// For example, for a parsable type defined as following:
+  /// When you use the `unconditionalRemaining` parsing strategy, the parser
+  /// stops parsing flags and options as soon as it encounters a positional
+  /// argument or an unrecognized flag. For example, for a parsable type
+  /// defined as following:
   ///
   ///     struct Options: ParsableArguments {
-  ///         @Flag var verbose: Bool
-  ///         @Argument(parsing: .unconditionalRemaining) var words: [String]
+  ///         @Flag
+  ///         var verbose: Bool = false
+  ///
+  ///         @Argument(parsing: .unconditionalRemaining)
+  ///         var words: [String] = []
   ///     }
   ///
-  /// Parsing the input `--verbose one two --other` would include the `--other`
-  /// flag in `words`, resulting in
-  /// `Options(verbose: true, words: ["one", "two", "--other"])`.
+  /// Parsing the input `--verbose one two --verbose` includes the second
+  /// `--verbose` flag in `words`, resulting in
+  /// `Options(verbose: true, words: ["one", "two", "--verbose"])`.
   ///
   /// - Note: This parsing strategy can be surprising for users, particularly
   ///   when combined with options and flags. Prefer `remaining` whenever
   ///   possible, since users can always terminate options and flags with
   ///   the `--` terminator. With the `remaining` parsing strategy, the input
-  ///   `--verbose -- one two --other` would have the same result as the above
-  ///   example: `Options(verbose: true, words: ["one", "two", "--other"])`.
+  ///   `--verbose -- one two --verbose` would have the same result as the above
+  ///   example: `Options(verbose: true, words: ["one", "two", "--verbose"])`.
   public static var unconditionalRemaining: ArgumentArrayParsingStrategy {
     self.init(base: .allRemainingInput)
   }

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -329,6 +329,7 @@ fileprivate struct Foozle: ParsableArguments {
   @Flag var verbose: Bool = false
   @Flag(name: .customShort("f")) var useFiles: Bool = false
   @Flag(name: .customShort("i")) var useStandardInput: Bool = false
+  @Option var config = "debug"
   @Argument(parsing: .unconditionalRemaining) var names: [String] = []
 }
 
@@ -350,8 +351,8 @@ extension RepeatingEndToEndTests {
     }
 
     AssertParse(Foozle.self, ["one", "two", "three", "--other", "--verbose"]) { foozle in
-      XCTAssertTrue(foozle.verbose)
-      XCTAssertEqual(foozle.names, ["one", "two", "three", "--other"])
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertEqual(foozle.names, ["one", "two", "three", "--other", "--verbose"])
     }
 
     AssertParse(Foozle.self, ["--verbose", "--other", "one", "two", "three"]) { foozle in
@@ -381,11 +382,28 @@ extension RepeatingEndToEndTests {
       XCTAssertEqual(foozle.names, ["-one", "-two", "three"])
     }
 
-    AssertParse(Foozle.self, ["-one", "-two", "three", "-if"]) { foozle in
+    AssertParse(Foozle.self, ["--config", "release", "one", "two", "--config", "debug"]) { foozle in
+      XCTAssertEqual(foozle.config, "release")
+      XCTAssertEqual(foozle.names, ["one", "two", "--config", "debug"])
+    }
+
+    AssertParse(Foozle.self, ["--config", "release", "--config", "debug", "one", "two"]) { foozle in
+      XCTAssertEqual(foozle.config, "debug")
+      XCTAssertEqual(foozle.names, ["one", "two"])
+    }
+
+    AssertParse(Foozle.self, ["-if", "-one", "-two", "three"]) { foozle in
       XCTAssertFalse(foozle.verbose)
       XCTAssertTrue(foozle.useFiles)
       XCTAssertTrue(foozle.useStandardInput)
       XCTAssertEqual(foozle.names, ["-one", "-two", "three"])
+    }
+
+    AssertParse(Foozle.self, ["-one", "-two", "-three", "-if"]) { foozle in
+      XCTAssertFalse(foozle.verbose)
+      XCTAssertFalse(foozle.useFiles)
+      XCTAssertFalse(foozle.useStandardInput)
+      XCTAssertEqual(foozle.names, ["-one", "-two", "-three", "-if"])
     }
   }
 


### PR DESCRIPTION
If a command defines an `@Argument` property with the `.unconditionalRemaining` parsing strategy, we need to stop parsing input when we encounter either a positional argument or an unrecognized option/flag label. Note that this is a change in behavior, as seen in the modified test.

Resolves #331.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
