### PR TITLE
Fix version documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ add the following line to the dependencies in your `Package.swift` file:
 ```
 
 Because `ArgumentParser` is under active development,
-source-stability is only guaranteed within minor versions (e.g. between `0.0.3` and `0.0.4`).
+source-stability is only guaranteed within patch versions (e.g. between `0.0.3` and `0.0.4`).
 If you don't want potentially source-breaking package updates,
 use this dependency specification instead:
 


### PR DESCRIPTION
README file incorrectly referenced 'minor' version when it should be 'patch' version.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
