### PR TITLE
Propogate ExpressibleByArgument conformance

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -53,22 +53,22 @@ struct ArgumentDefinition {
     
     struct Options: OptionSet {
       var rawValue: UInt
-      
+
       static let isOptional = Options(rawValue: 1 << 0)
       static let isRepeating = Options(rawValue: 1 << 1)
     }
-    
-    init(options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey, isComposite: Bool = false) {
+
+    init(allValues: [String] = [], options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey, isComposite: Bool = false) {
       self.options = options
       self.defaultValue = defaultValue
       self.keys = [key]
+      self.allValues = allValues
       self.isComposite = isComposite
       updateArgumentHelp(help: help)
     }
-    
+
     init<T: ExpressibleByArgument>(type: T.Type, options: Options = [], help: ArgumentHelp? = nil, defaultValue: String? = nil, key: InputKey) {
       self.options = options
-
       self.defaultValue = defaultValue
       self.keys = [key]
       self.allValues = type.allValueStrings

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -159,7 +159,16 @@ extension ArgumentSet {
 extension ArgumentDefinition {
   /// Create a unary / argument that parses using the given closure.
   init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .default, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind) {
-    self.init(kind: kind, help: ArgumentDefinition.Help(key: key), completion: completion, parsingStrategy: parsingStrategy, update: .unary({ (origin, name, value, values) in
+    self.init(key: key, kind: kind, parsingStrategy: parsingStrategy, parser: parser, parseType: type, default: initial, completion: completion, help: ArgumentDefinition.Help(key: key))
+  }
+
+  /// Create a unary / argument that parses using the given closure.
+  init<A: ExpressibleByArgument>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .default, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind) {
+    self.init(key: key, kind: kind, parsingStrategy: parsingStrategy, parser: parser, parseType: type, default: initial, completion: completion, help: ArgumentDefinition.Help(type: A.self, key: key))
+  }
+
+  private init<A>(key: InputKey, kind: ArgumentDefinition.Kind, parsingStrategy: ParsingStrategy = .default, parser: @escaping (String) -> A?, parseType type: A.Type = A.self, default initial: A?, completion: CompletionKind, help: ArgumentDefinition.Help) {
+    self.init(kind: kind, help: help, completion: completion, parsingStrategy: parsingStrategy, update: .unary({ (origin, name, value, values) in
       guard let v = parser(value) else {
         throw ParserError.unableToParseValue(origin, name, value, forKey: key)
       }
@@ -172,9 +181,9 @@ extension ArgumentDefinition {
         values.set(initial, forKey: key, inputOrigin: origin)
       }
     })
-    
-    help.options.formUnion(ArgumentDefinition.Help.Options(type: type))
-    help.defaultValue = initial.map { "\($0)" }
+
+    self.help.options.formUnion(ArgumentDefinition.Help.Options(type: type))
+    self.help.defaultValue = initial.map { "\($0)" }
     if initial != nil {
       self = self.optional
     }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -505,6 +505,48 @@ extension HelpGenerationTests {
         """
     )
   }
+
+  struct AllValues: ParsableCommand {
+    enum Manual: Int, ExpressibleByArgument {
+      case foo
+      static var allValueStrings = ["bar"]
+    }
+
+    enum UnspecializedSynthesized: Int, CaseIterable, ExpressibleByArgument {
+      case one, two
+    }
+
+    enum SpecializedSynthesized: String, CaseIterable, ExpressibleByArgument {
+      case apple = "Apple", banana = "Banana"
+    }
+
+    @Argument var manualArgument: Manual
+    @Option var manualOption: Manual
+
+    @Argument var unspecializedSynthesizedArgument: UnspecializedSynthesized
+    @Option var unspecializedSynthesizedOption: UnspecializedSynthesized
+
+    @Argument var specializedSynthesizedArgument: SpecializedSynthesized
+    @Option var specializedSynthesizedOption: SpecializedSynthesized
+  }
+
+  func testAllValueStrings() throws {
+    XCTAssertEqual(AllValues.Manual.allValueStrings, ["bar"])
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, ["one", "two"])
+    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, ["Apple", "Banana"])
+  }
+
+  func testAllValues() {
+    let opts = ArgumentSet(AllValues.self)
+    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[0].help.allValues)
+    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[1].help.allValues)
+
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[2].help.allValues)
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[3].help.allValues)
+
+    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[4].help.allValues)
+    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[5].help.allValues)
+  }
 }
 
 // MARK: - Issue #278 https://github.com/apple/swift-argument-parser/issues/278


### PR DESCRIPTION
- Adds an overload of ArgumentDefinition.init with a generic constraint
  on ExpressibleByArgument that propogates the conformance to the
  construction of ArgumentDefinition.Help. This allows the
  allValueStrings of the type conforming to ExpressibleByArgument to
  become the allValues property of the help object.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

Fixes #340 