### PR TITLE
Work around runtime issue introduced in 0.4.3

### DIFF
--- a/Examples/repeat/main.swift
+++ b/Examples/repeat/main.swift
@@ -11,27 +11,34 @@
 
 import ArgumentParser
 
-struct Repeat: ParsableCommand {
-    @Option(help: "The number of times to repeat 'phrase'.")
-    var count: Int?
+import Foundation
 
-    @Flag(help: "Include a counter with each repetition.")
-    var includeCounter = false
-
-    @Argument(help: "The phrase to repeat.")
-    var phrase: String
-
-    mutating func run() throws {
-        let repeatCount = count ?? .max
-
-        for i in 1...repeatCount {
-            if includeCounter {
-                print("\(i): \(phrase)")
-            } else {
-                print(phrase)
-            }
-        }
+struct CustomStruct {
+    let urlValue: URL
+    init?() {
+        return nil
     }
 }
 
-Repeat.main()
+extension CustomStruct: ExpressibleByArgument {
+    init?(argument: String) {
+        _ = CustomStruct()
+        return nil
+    }
+}
+
+struct CustomGroup: ParsableArguments {
+    @Option()
+    var optionalOption: CustomStruct?
+}
+
+struct MainCommand: ParsableCommand {
+    @OptionGroup()
+    var group: CustomGroup
+
+    func run() {
+        print("Hello, world!")
+    }
+}
+
+MainCommand.main()

--- a/Examples/repeat/main.swift
+++ b/Examples/repeat/main.swift
@@ -11,34 +11,27 @@
 
 import ArgumentParser
 
-import Foundation
+struct Repeat: ParsableCommand {
+    @Option(help: "The number of times to repeat 'phrase'.")
+    var count: Int?
 
-struct CustomStruct {
-    let urlValue: URL
-    init?() {
-        return nil
+    @Flag(help: "Include a counter with each repetition.")
+    var includeCounter = false
+
+    @Argument(help: "The phrase to repeat.")
+    var phrase: String
+
+    mutating func run() throws {
+        let repeatCount = count ?? .max
+
+        for i in 1...repeatCount {
+            if includeCounter {
+                print("\(i): \(phrase)")
+            } else {
+                print(phrase)
+            }
+        }
     }
 }
 
-extension CustomStruct: ExpressibleByArgument {
-    init?(argument: String) {
-        _ = CustomStruct()
-        return nil
-    }
-}
-
-struct CustomGroup: ParsableArguments {
-    @Option()
-    var optionalOption: CustomStruct?
-}
-
-struct MainCommand: ParsableCommand {
-    @OptionGroup()
-    var group: CustomGroup
-
-    func run() {
-        print("Hello, world!")
-    }
-}
-
-MainCommand.main()
+Repeat.main()

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -27,8 +27,7 @@ public struct Argument<Value>:
   Decodable, ParsedWrapper
 {
   internal var _parsedValue: Parsed<Value>
-  internal var _hiddenFromHelp: Bool = false
-    
+
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -39,8 +39,7 @@
 @propertyWrapper
 public struct Flag<Value>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
-  internal var _hiddenFromHelp: Bool = false
-    
+
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -29,8 +29,7 @@
 @propertyWrapper
 public struct Option<Value>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
-  internal var _hiddenFromHelp: Bool = false
-    
+  
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -33,6 +33,10 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
   internal var _parsedValue: Parsed<Value>
   internal var _hiddenFromHelp: Bool = false
   
+  // FIXME: Adding this property works around the crasher described in
+  // https://github.com/apple/swift-argument-parser/issues/338
+  internal var _dummy: Bool = false
+
   internal init(_parsedValue: Parsed<Value>) {
     self._parsedValue = _parsedValue
   }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -237,6 +237,10 @@ protocol ArgumentSetProvider {
   var _hiddenFromHelp: Bool { get }
 }
 
+extension ArgumentSetProvider {
+  var _hiddenFromHelp: Bool { false }
+}
+
 extension ArgumentSet {
   init(_ type: ParsableArguments.Type, creatingHelp: Bool = false) {
     


### PR DESCRIPTION
ArgumentParser version 0.4.3 added an experimental feature for hiding option groups at the command level, which is triggering a runtime crash when commands are compiled in release mode, as described in #338 and rdar://80796582. This includes changes that work around both of those crashes. I'll cherry pick this change over to the current release as 0.4.4 as well.