### PR TITLE
Add supported platform to manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 //===----------------------------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift Argument Parser open source project
@@ -14,6 +14,9 @@ import PackageDescription
 
 var package = Package(
     name: "swift-argument-parser",
+    platforms: [
+        .macOS(.v12)
+    ],
     products: [
         .library(
             name: "ArgumentParser",


### PR DESCRIPTION
I'm trying to solve the issue that Xcode cannot determine the correct deployment target for this project. See issue https://github.com/apple/swift-argument-parser/issues/345

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
