### PR TITLE
build: repair the build of ArgumentParser with CMake

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -47,7 +47,8 @@ set_target_properties(ArgumentParser PROPERTIES
 target_compile_options(ArgumentParser PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(ArgumentParser PRIVATE
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  ArgumentParserToolInfo)
 
 
 _install_target(ArgumentParser)

--- a/Sources/ArgumentParserToolInfo/CMakeLists.txt
+++ b/Sources/ArgumentParserToolInfo/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(ArgumentParserToolInfo
+  ToolInfo.swift)
+# NOTE: workaround for CMake not setting up include flags yet
+set_target_properties(ArgumentParserToolInfo PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_options(ArgumentParserToolInfo PRIVATE
+  $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
+
+
+_install_target(ArgumentParserToolInfo)
+set_property(GLOBAL APPEND PROPERTY ArgumentParser_EXPORTS ArgumentParserToolInfo)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(ArgumentParser)
+add_subdirectory(ArgumentParserToolInfo)
 if(BUILD_TESTING)
   add_subdirectory(ArgumentParserTestHelpers)
 endif()


### PR DESCRIPTION
The changes in #335 introduced a new library but failed to actually
build the library and update the dependency structure.  Update the build
system to build and install the new target.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
