### PR TITLE
Mark the dump help feature as experimental for now

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -122,7 +122,7 @@ public struct CleanExit: Error, CustomStringConvertible {
     switch self.base {
     case .helpRequest: return "--help"
     case .message(let message): return message
-    case .dumpRequest: return "--dump-help"
+    case .dumpRequest: return "--experimental-dump-help"
     }
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -141,10 +141,8 @@ extension ParsableArguments {
     HelpGenerator(self).rendered(screenWidth: columns)
   }
 
-  /// Returns the json representation of the type.
-  ///
-  /// - Returns: The json representation for this type.
-  public static func dumpMessage() -> String {
+  /// Returns the JSON representation of this type.
+  public static func _dumpHelp() -> String {
     DumpHelpGenerator(self).rendered()
   }
 

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -80,7 +80,7 @@ extension CommandParser {
     }
     
     // Look for the "dump help" request
-    guard !split.contains(Name.long("dump-help")) else {
+    guard !split.contains(Name.long("experimental-dump-help")) else {
       throw CommandError(commandStack: commandStack, parserError: .dumpHelpRequested)
     }
 

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -311,7 +311,7 @@ internal extension BidirectionalCollection where Element == ParsableCommand.Type
   
   func dumpHelpArgumentDefinition() -> ArgumentDefinition {
     return ArgumentDefinition(
-      kind: .named([.long("dump-help")]),
+      kind: .named([.long("experimental-dump-help")]),
       help: .init(
         help: ArgumentHelp("Dump help information as JSON."),
         key: InputKey(rawValue: "")),

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -151,7 +151,7 @@ public func AssertDump<T: ParsableArguments>(
     try AssertJSONEqualFromString(actual: dumpString, expected: expected, for: ToolInfoV0.self)
   }
 
-  try AssertJSONEqualFromString(actual: T.dumpMessage(), expected: expected, for: ToolInfoV0.self)
+  try AssertJSONEqualFromString(actual: T._dumpHelp(), expected: expected, for: ToolInfoV0.self)
 }
 
 public func AssertJSONEqualFromString<T: Codable & Equatable>(actual: String, expected: String, for type: T.Type) throws {

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -144,7 +144,7 @@ public func AssertDump<T: ParsableArguments>(
   file: StaticString = #file, line: UInt = #line
 ) throws {
   do {
-    _ = try T.parse(["--dump-help"])
+    _ = try T.parse(["--experimental-dump-help"])
     XCTFail(file: (file), line: line)
   } catch {
     let dumpString = T.fullMessage(for: error)
@@ -265,7 +265,7 @@ extension XCTest {
     process.waitUntilExit()
 
     let outputString = try XCTUnwrap(String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8))
-    XCTAssertTrue(error.fileHandleForReading.readDataToEndOfFile().isEmpty, "Error occurred with `--dump-help`")
+    XCTAssertTrue(error.fileHandleForReading.readDataToEndOfFile().isEmpty, "Error occurred with `--experimental-dump-help`")
     try AssertJSONEqualFromString(actual: outputString, expected: expected, for: ToolInfoV0.self)
   }
 }

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -58,10 +58,10 @@ extension DumpHelpGenerationTests {
     }
     
     let testCases: [UInt : TestCase] = [
-      #line : .init(expected: Self.mathDumpText, command: "math --dump-help"),
-      #line : .init(expected: Self.mathAddDumpText, command: "math add --dump-help"),
-      #line : .init(expected: Self.mathMultiplyDumpText, command: "math multiply --dump-help"),
-      #line : .init(expected: Self.mathStatsDumpText, command: "math stats --dump-help")
+      #line : .init(expected: Self.mathDumpText, command: "math --experimental-dump-help"),
+      #line : .init(expected: Self.mathAddDumpText, command: "math add --experimental-dump-help"),
+      #line : .init(expected: Self.mathMultiplyDumpText, command: "math multiply --experimental-dump-help"),
+      #line : .init(expected: Self.mathStatsDumpText, command: "math stats --experimental-dump-help")
     ]
     
     try testCases.forEach { line, testCase in


### PR DESCRIPTION
### Description
This marks the two entry points of the "dump help" feature as experimental.

### Detailed Design
1. The `--dump-help` flag is now `--experimental-dump-flag`
2. The `dumpMessage()` method on `ParsableArguments` has been renamed to `_dumpHelp()`

### Documentation Plan
This feature isn't covered in the documentation yet.

### Test Plan
Updated the test with new names, as above.

### Source Impact
None — this feature hasn't yet shipped in a release.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
