### PR TITLE
Fix compile failure on iOS for Mac Catalyst support

### DIFF
--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -26,7 +26,7 @@ internal struct DumpHelpGenerator {
   func rendered() -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
-    if #available(macOS 10.13, *) {
+    if #available(macOS 10.13, iOS 11.0, *) {
       encoder.outputFormatting.insert(.sortedKeys)
     }
     guard let encoded = try? encoder.encode(self.toolInfo) else { return "" }

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -26,7 +26,7 @@ internal struct DumpHelpGenerator {
   func rendered() -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
-    if #available(macOS 10.13, iOS 11.0, *) {
+    if #available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
       encoder.outputFormatting.insert(.sortedKeys)
     }
     guard let encoded = try? encoder.encode(self.toolInfo) else { return "" }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR fixes compile failure on iOS, which happens if you are adding CLI support for a Mac Catalyst app. Specifically, it fixes:
```
'sortedKeys' is only available in iOS 11.0 or newer
```

### Checklist
- [N/A] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary
