### PR TITLE
Fixed custom completion not working in zsh when command name contains a dash

### DIFF
--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -185,7 +185,7 @@ extension ArgumentDefinition {
 
     case .custom:
       // Generate a call back into the command to retrieve a completions list
-      let commandName = commands.first!._commandName
+      let commandName = commands.first!._commandName.zshEscapingCommandName()
       return "{_custom_completion $_\(commandName)_commandname \(customCompletionCall(commands)) $words}"
     }
   }

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -127,6 +127,9 @@ extension CompletionScriptTests {
   struct EscapedCommand: ParsableCommand {
     @Option(help: #"Escaped chars: '[]\."#)
     var one: String
+    
+    @Argument(completion: .custom { _ in ["d", "e", "f"] })
+    var two: String
   }
 
   func testEscaped_Zsh() throws {
@@ -222,6 +225,7 @@ _escaped-command() {
     local -a args
     args+=(
         '--one[Escaped chars: '"'"'\\[\\]\\\\.]:one:'
+        ':two:{_custom_completion $_escaped_command_commandname ---completion  -- two $words}'
         '(-h --help)'{-h,--help}'[Show help information.]'
     )
     _arguments -w -s -S $args[@] && ret=0


### PR DESCRIPTION
### Related issues and PRs

- #277 
- #284 

### Description
This adds onto the fix from #284 that added support for commands with dashes in the name. 

When getting completions for an argument using `CompletionKind.custom(...)` an error occurs. #284 updated [a variable](https://github.com/apple/swift-argument-parser/pull/284/files#diff-b243e9c8a946a341ab514c2d5ce1b9f27a3bb6cf672b14ab02f0d221a491d645R20) but missed updating where that variable is used to also escape the command name.

This updates the usage of that variable to also escape the command name and updates the tests to check for it.

### Example
If I have a command called `cli-tools` with an argument that has a `CompletionKind.custom(...)`, typing `cli-tools a` then pressing tab will produce the following error.

```
cli-tools a_custom_completion:1: command not found: -tools_commandname
_custom_completion:1: command not found: -tools_commandname
  cli-tools a
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary