### PR TITLE
Fix compile failure on iOS for Mac Catalyst support

### DIFF
--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -175,7 +175,7 @@ extension XCTest {
     command: String,
     expected: String? = nil,
     exitCode: ExitCode = .success,
-    file: StaticString = #file, line: UInt = #line)
+    file: StaticString = #file, line: UInt = #line) throws
   {
     let splitCommand = command.split(separator: " ")
     let arguments = splitCommand.dropFirst().map(String.init)
@@ -188,6 +188,7 @@ extension XCTest {
       return
     }
     
+    #if !canImport(Darwin) || os(macOS)
     let process = Process()
     if #available(macOS 10.13, *) {
       process.executableURL = commandURL
@@ -222,6 +223,9 @@ extension XCTest {
     }
 
     XCTAssertEqual(process.terminationStatus, exitCode.rawValue, file: (file), line: line)
+    #else
+    throw XCTSkip("Not supported on this platform")
+    #endif
   }
 
   public func AssertJSONOutputEqual(
@@ -241,6 +245,7 @@ extension XCTest {
       return
     }
 
+    #if !canImport(Darwin) || os(macOS)
     let process = Process()
     if #available(macOS 10.13, *) {
       process.executableURL = commandURL
@@ -267,5 +272,8 @@ extension XCTest {
     let outputString = try XCTUnwrap(String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8))
     XCTAssertTrue(error.fileHandleForReading.readDataToEndOfFile().isEmpty, "Error occurred with `--experimental-dump-help`")
     try AssertJSONEqualFromString(actual: outputString, expected: expected, for: ToolInfoV0.self)
+    #else
+    throw XCTSkip("Not supported on this platform")
+    #endif
   }
 }

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -15,8 +15,8 @@ import ArgumentParserTestHelpers
 
 final class MathExampleTests: XCTestCase {
   func testMath_Simple() throws {
-    AssertExecuteCommand(command: "math 1 2 3 4 5", expected: "15")
-    AssertExecuteCommand(command: "math multiply 1 2 3 4 5", expected: "120")
+    try AssertExecuteCommand(command: "math 1 2 3 4 5", expected: "15")
+    try AssertExecuteCommand(command: "math multiply 1 2 3 4 5", expected: "120")
   }
   
   func testMath_Help() throws {
@@ -37,9 +37,9 @@ final class MathExampleTests: XCTestCase {
           See 'math help <subcommand>' for detailed help.
         """
     
-    AssertExecuteCommand(command: "math -h", expected: helpText)
-    AssertExecuteCommand(command: "math --help", expected: helpText)
-    AssertExecuteCommand(command: "math help", expected: helpText)
+    try AssertExecuteCommand(command: "math -h", expected: helpText)
+    try AssertExecuteCommand(command: "math --help", expected: helpText)
+    try AssertExecuteCommand(command: "math help", expected: helpText)
   }
   
   func testMath_AddHelp() throws {
@@ -57,14 +57,14 @@ final class MathExampleTests: XCTestCase {
           -h, --help              Show help information.
         """
     
-    AssertExecuteCommand(command: "math add -h", expected: helpText)
-    AssertExecuteCommand(command: "math add --help", expected: helpText)
-    AssertExecuteCommand(command: "math help add", expected: helpText)
+    try AssertExecuteCommand(command: "math add -h", expected: helpText)
+    try AssertExecuteCommand(command: "math add --help", expected: helpText)
+    try AssertExecuteCommand(command: "math help add", expected: helpText)
     
     // Verify that extra help flags are ignored.
-    AssertExecuteCommand(command: "math help add -h", expected: helpText)
-    AssertExecuteCommand(command: "math help add -help", expected: helpText)
-    AssertExecuteCommand(command: "math help add --help", expected: helpText)
+    try AssertExecuteCommand(command: "math help add -h", expected: helpText)
+    try AssertExecuteCommand(command: "math help add -help", expected: helpText)
+    try AssertExecuteCommand(command: "math help add --help", expected: helpText)
   }
   
   func testMath_StatsMeanHelp() throws {
@@ -82,9 +82,9 @@ final class MathExampleTests: XCTestCase {
           -h, --help              Show help information.
         """
     
-    AssertExecuteCommand(command: "math stats average -h", expected: helpText)
-    AssertExecuteCommand(command: "math stats average --help", expected: helpText)
-    AssertExecuteCommand(command: "math help stats average", expected: helpText)
+    try AssertExecuteCommand(command: "math stats average -h", expected: helpText)
+    try AssertExecuteCommand(command: "math stats average --help", expected: helpText)
+    try AssertExecuteCommand(command: "math help stats average", expected: helpText)
   }
   
   func testMath_StatsQuantilesHelp() throws {
@@ -109,15 +109,15 @@ final class MathExampleTests: XCTestCase {
     
     // The "quantiles" subcommand's run() method is unimplemented, so it
     // just generates the help text.
-    AssertExecuteCommand(command: "math stats quantiles", expected: helpText)
+    try AssertExecuteCommand(command: "math stats quantiles", expected: helpText)
     
-    AssertExecuteCommand(command: "math stats quantiles -h", expected: helpText)
-    AssertExecuteCommand(command: "math stats quantiles --help", expected: helpText)
-    AssertExecuteCommand(command: "math help stats quantiles", expected: helpText)
+    try AssertExecuteCommand(command: "math stats quantiles -h", expected: helpText)
+    try AssertExecuteCommand(command: "math stats quantiles --help", expected: helpText)
+    try AssertExecuteCommand(command: "math help stats quantiles", expected: helpText)
   }
   
   func testMath_CustomValidation() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats average --kind mode",
       expected: """
             Error: Please provide at least one value to calculate the mode.
@@ -128,38 +128,38 @@ final class MathExampleTests: XCTestCase {
   }
   
   func testMath_Versions() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --version",
       expected: "1.0.0")
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats --version",
       expected: "1.0.0")
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats average --version",
       expected: "1.5.0-alpha")
   }
 
   func testMath_ExitCodes() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats quantiles --test-success-exit-code",
       expected: "",
       exitCode: .success)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats quantiles --test-failure-exit-code",
       expected: "",
       exitCode: .failure)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats quantiles --test-validation-exit-code",
       expected: "",
       exitCode: .validationFailure)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math stats quantiles --test-custom-exit-code 42",
       expected: "",
       exitCode: ExitCode(42))
   }
   
   func testMath_Fail() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --foo",
       expected: """
             Error: Unknown option '--foo'
@@ -168,7 +168,7 @@ final class MathExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
     
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math ZZZ",
       expected: """
             Error: The value 'ZZZ' is invalid for '<values>'
@@ -183,29 +183,29 @@ final class MathExampleTests: XCTestCase {
 // MARK: - Completion Script
 
 extension MathExampleTests {
-  func testMath_CompletionScript() {
-    AssertExecuteCommand(
+  func testMath_CompletionScript() throws {
+    try AssertExecuteCommand(
       command: "math --generate-completion-script=bash",
       expected: bashCompletionScriptText)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --generate-completion-script bash",
       expected: bashCompletionScriptText)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --generate-completion-script=zsh",
       expected: zshCompletionScriptText)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --generate-completion-script zsh",
       expected: zshCompletionScriptText)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --generate-completion-script=fish",
       expected: fishCompletionScriptText)
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math --generate-completion-script fish",
       expected: fishCompletionScriptText)
   }
   
-  func testMath_CustomCompletion() {
-    AssertExecuteCommand(
+  func testMath_CustomCompletion() throws {
+    try AssertExecuteCommand(
       command: "math ---completion stats quantiles -- --custom",
       expected: """
         hello
@@ -213,7 +213,7 @@ extension MathExampleTests {
         heliotrope
         """)
     
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math ---completion stats quantiles -- --custom h",
       expected: """
         hello
@@ -221,7 +221,7 @@ extension MathExampleTests {
         heliotrope
         """)
   
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "math ---completion stats quantiles -- --custom a",
       expected: """
         aardvark

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -15,7 +15,7 @@ import ArgumentParserTestHelpers
 
 final class RepeatExampleTests: XCTestCase {
   func testRepeat() throws {
-    AssertExecuteCommand(command: "repeat hello --count 6", expected: """
+    try AssertExecuteCommand(command: "repeat hello --count 6", expected: """
         hello
         hello
         hello
@@ -38,12 +38,12 @@ final class RepeatExampleTests: XCTestCase {
           -h, --help              Show help information.
         """
     
-    AssertExecuteCommand(command: "repeat -h", expected: helpText)
-    AssertExecuteCommand(command: "repeat --help", expected: helpText)
+    try AssertExecuteCommand(command: "repeat -h", expected: helpText)
+    try AssertExecuteCommand(command: "repeat --help", expected: helpText)
   }
   
   func testRepeat_Fail() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "repeat",
       expected: """
             Error: Missing expected argument '<phrase>'
@@ -60,7 +60,7 @@ final class RepeatExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
 
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "repeat hello --count",
       expected: """
             Error: Missing value for '--count <count>'
@@ -70,7 +70,7 @@ final class RepeatExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
     
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "repeat hello --count ZZZ",
       expected: """
             Error: The value 'ZZZ' is invalid for '--count <count>'
@@ -80,7 +80,7 @@ final class RepeatExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
     
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "repeat --version hello",
       expected: """
             Error: Unknown option '--version'

--- a/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
@@ -15,7 +15,7 @@ import ArgumentParserTestHelpers
 
 final class RollDiceExampleTests: XCTestCase {
   func testRollDice() throws {
-    AssertExecuteCommand(command: "roll --times 6")
+    try AssertExecuteCommand(command: "roll --times 6")
   }
   
   func testRollDice_Help() throws {
@@ -31,12 +31,12 @@ final class RollDiceExampleTests: XCTestCase {
           -h, --help              Show help information.
         """
     
-    AssertExecuteCommand(command: "roll -h", expected: helpText)
-    AssertExecuteCommand(command: "roll --help", expected: helpText)
+    try AssertExecuteCommand(command: "roll -h", expected: helpText)
+    try AssertExecuteCommand(command: "roll --help", expected: helpText)
   }
   
   func testRollDice_Fail() throws {
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "roll --times",
       expected: """
             Error: Missing value for '--times <n>'
@@ -46,7 +46,7 @@ final class RollDiceExampleTests: XCTestCase {
             """,
       exitCode: .validationFailure)
     
-    AssertExecuteCommand(
+    try AssertExecuteCommand(
       command: "roll --times ZZZ",
       expected: """
             Error: The value 'ZZZ' is invalid for '--times <n>'


### PR DESCRIPTION
#356 fixed compile failure on iOS, which happens if you are adding CLI support for a Mac Catalyst app.

This patch also fixes the tests compilation.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
