### PR TITLE
Rename `...using_command` fish function, set `$cmd` in local scope

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -2,8 +2,8 @@ struct FishCompletionsGenerator {
   static func generateCompletionScript(_ type: ParsableCommand.Type) -> String {
     let programName = type._commandName
     let helper = """
-    function __fish_\(programName)_using_command
-        set cmd (commandline -opc)
+    function _swift_\(programName)_using_command
+        set -l cmd (commandline -opc)
         if [ (count $cmd) -eq (count $argv) ]
             for i in (seq (count $argv))
                 if [ $cmd[$i] != $argv[$i] ]
@@ -14,7 +14,6 @@ struct FishCompletionsGenerator {
         end
         return 1
     end
-
     """
 
     let completions = generateCompletions(commandChain: [programName], [type])
@@ -37,7 +36,7 @@ struct FishCompletionsGenerator {
       }
     }
 
-    let prefix = "complete -c \(programName) -n '__fish_\(programName)_using_command"
+    let prefix = "complete -c \(programName) -n '_swift_\(programName)_using_command"
     /// We ask each suggestion to produce 2 pieces of information
     /// - Parameters
     ///   - ancestors: a list of "ancestor" which must be present in the current shell buffer for

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -14,6 +14,7 @@ struct FishCompletionsGenerator {
         end
         return 1
     end
+    
     """
 
     let completions = generateCompletions(commandChain: [programName], [type])

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -545,8 +545,8 @@ _math
 """
 
 private let fishCompletionScriptText = """
-function __fish_math_using_command
-    set cmd (commandline -opc)
+function _swift_math_using_command
+    set -l cmd (commandline -opc)
     if [ (count $cmd) -eq (count $argv) ]
         for i in (seq (count $argv))
             if [ $cmd[$i] != $argv[$i] ]
@@ -557,33 +557,33 @@ function __fish_math_using_command
     end
     return 1
 end
-complete -c math -n '__fish_math_using_command math' -f -l version -d 'Show the version.'
-complete -c math -n '__fish_math_using_command math' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math' -f -a 'add' -d 'Print the sum of the values.'
-complete -c math -n '__fish_math_using_command math' -f -a 'multiply' -d 'Print the product of the values.'
-complete -c math -n '__fish_math_using_command math' -f -a 'stats' -d 'Calculate descriptive statistics.'
-complete -c math -n '__fish_math_using_command math' -f -a 'help' -d 'Show subcommand help information.'
-complete -c math -n '__fish_math_using_command math add' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
-complete -c math -n '__fish_math_using_command math add' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math multiply' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
-complete -c math -n '__fish_math_using_command math multiply' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math stats' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math stats' -f -a 'average' -d 'Print the average of the values.'
-complete -c math -n '__fish_math_using_command math stats' -f -a 'stdev' -d 'Print the standard deviation of the values.'
-complete -c math -n '__fish_math_using_command math stats' -f -a 'quantiles' -d 'Print the quantiles of the values (TBD).'
-complete -c math -n '__fish_math_using_command math stats' -f -a 'help' -d 'Show subcommand help information.'
-complete -c math -n '__fish_math_using_command math stats average' -f -r -l kind -d 'The kind of average to provide.'
-complete -c math -n '__fish_math_using_command math stats average --kind' -f -k -a 'mean median mode'
-complete -c math -n '__fish_math_using_command math stats average' -f -l version -d 'Show the version.'
-complete -c math -n '__fish_math_using_command math stats average' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math stats stdev' -f -s h -l help -d 'Show help information.'
-complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l file
-complete -c math -n '__fish_math_using_command math stats quantiles --file' -f -a '(for i in *.{txt,md}; echo $i;end)'
-complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l directory
-complete -c math -n '__fish_math_using_command math stats quantiles --directory' -f -a '(__fish_complete_directories)'
-complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l shell
-complete -c math -n '__fish_math_using_command math stats quantiles --shell' -f -a '(head -100 /usr/share/dict/words | tail -50)'
-complete -c math -n '__fish_math_using_command math stats quantiles' -f -r -l custom
-complete -c math -n '__fish_math_using_command math stats quantiles --custom' -f -a '(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])'
-complete -c math -n '__fish_math_using_command math stats quantiles' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math' -f -l version -d 'Show the version.'
+complete -c math -n '_swift_math_using_command math' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math' -f -a 'add' -d 'Print the sum of the values.'
+complete -c math -n '_swift_math_using_command math' -f -a 'multiply' -d 'Print the product of the values.'
+complete -c math -n '_swift_math_using_command math' -f -a 'stats' -d 'Calculate descriptive statistics.'
+complete -c math -n '_swift_math_using_command math' -f -a 'help' -d 'Show subcommand help information.'
+complete -c math -n '_swift_math_using_command math add' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
+complete -c math -n '_swift_math_using_command math add' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math multiply' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
+complete -c math -n '_swift_math_using_command math multiply' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math stats' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math stats' -f -a 'average' -d 'Print the average of the values.'
+complete -c math -n '_swift_math_using_command math stats' -f -a 'stdev' -d 'Print the standard deviation of the values.'
+complete -c math -n '_swift_math_using_command math stats' -f -a 'quantiles' -d 'Print the quantiles of the values (TBD).'
+complete -c math -n '_swift_math_using_command math stats' -f -a 'help' -d 'Show subcommand help information.'
+complete -c math -n '_swift_math_using_command math stats average' -f -r -l kind -d 'The kind of average to provide.'
+complete -c math -n '_swift_math_using_command math stats average --kind' -f -k -a 'mean median mode'
+complete -c math -n '_swift_math_using_command math stats average' -f -l version -d 'Show the version.'
+complete -c math -n '_swift_math_using_command math stats average' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math stats stdev' -f -s h -l help -d 'Show help information.'
+complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l file
+complete -c math -n '_swift_math_using_command math stats quantiles --file' -f -a '(for i in *.{txt,md}; echo $i;end)'
+complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l directory
+complete -c math -n '_swift_math_using_command math stats quantiles --directory' -f -a '(_swift_complete_directories)'
+complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l shell
+complete -c math -n '_swift_math_using_command math stats quantiles --shell' -f -a '(head -100 /usr/share/dict/words | tail -50)'
+complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l custom
+complete -c math -n '_swift_math_using_command math stats quantiles --custom' -f -a '(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])'
+complete -c math -n '_swift_math_using_command math stats quantiles' -f -s h -l help -d 'Show help information.'
 """

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -580,7 +580,7 @@ complete -c math -n '_swift_math_using_command math stats stdev' -f -s h -l help
 complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l file
 complete -c math -n '_swift_math_using_command math stats quantiles --file' -f -a '(for i in *.{txt,md}; echo $i;end)'
 complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l directory
-complete -c math -n '_swift_math_using_command math stats quantiles --directory' -f -a '(_swift_complete_directories)'
+complete -c math -n '_swift_math_using_command math stats quantiles --directory' -f -a '(__fish_complete_directories)'
 complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l shell
 complete -c math -n '_swift_math_using_command math stats quantiles --shell' -f -a '(head -100 /usr/share/dict/words | tail -50)'
 complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l custom

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -243,8 +243,8 @@ _escaped-command
 """
 
 private let fishBaseCompletions = """
-function __fish_base_using_command
-    set cmd (commandline -opc)
+function _swift_base_using_command
+    set -l cmd (commandline -opc)
     if [ (count $cmd) -eq (count $argv) ]
         for i in (seq (count $argv))
             if [ $cmd[$i] != $argv[$i] ]
@@ -255,16 +255,16 @@ function __fish_base_using_command
     end
     return 1
 end
-complete -c base -n '__fish_base_using_command base' -f -r -l name -d 'The user\\'s name.'
-complete -c base -n '__fish_base_using_command base' -f -r -l kind
-complete -c base -n '__fish_base_using_command base --kind' -f -k -a 'one two custom-three'
-complete -c base -n '__fish_base_using_command base' -f -r -l other-kind
-complete -c base -n '__fish_base_using_command base --other-kind' -f -k -a '1 2 3'
-complete -c base -n '__fish_base_using_command base' -f -r -l path1
-complete -c base -n '__fish_base_using_command base --path1' -f -a '(for i in *.{}; echo $i;end)'
-complete -c base -n '__fish_base_using_command base' -f -r -l path2
-complete -c base -n '__fish_base_using_command base --path2' -f -a '(for i in *.{}; echo $i;end)'
-complete -c base -n '__fish_base_using_command base' -f -r -l path3
-complete -c base -n '__fish_base_using_command base --path3' -f -k -a 'a b c'
-complete -c base -n '__fish_base_using_command base' -f -s h -l help -d 'Show help information.'
+complete -c base -n '_swift_base_using_command base' -f -r -l name -d 'The user\\'s name.'
+complete -c base -n '_swift_base_using_command base' -f -r -l kind
+complete -c base -n '_swift_base_using_command base --kind' -f -k -a 'one two custom-three'
+complete -c base -n '_swift_base_using_command base' -f -r -l other-kind
+complete -c base -n '_swift_base_using_command base --other-kind' -f -k -a '1 2 3'
+complete -c base -n '_swift_base_using_command base' -f -r -l path1
+complete -c base -n '_swift_base_using_command base --path1' -f -a '(for i in *.{}; echo $i;end)'
+complete -c base -n '_swift_base_using_command base' -f -r -l path2
+complete -c base -n '_swift_base_using_command base --path2' -f -a '(for i in *.{}; echo $i;end)'
+complete -c base -n '_swift_base_using_command base' -f -r -l path3
+complete -c base -n '_swift_base_using_command base --path3' -f -k -a 'a b c'
+complete -c base -n '_swift_base_using_command base' -f -s h -l help -d 'Show help information.'
 """


### PR DESCRIPTION
This PR has two minor changes for FishCompletionsGenerator.swift.

The first is related to the name of the fish function created that's used to determine whether to show completions or not, depending on the commandline entered thus far. Functions beginning with `__fish` **really** ought only be things internal to fish that are included with the shell. So prefix the function `_swift` instead.

Secondly, `set --local cmd` instead of `set cmd` - this ensures running the function does not accidentally clobber a global or universal variable.