### PR TITLE
List valid options in error messages

### DIFF
--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -408,17 +408,7 @@ extension ErrorMessageGenerator {
       case let err?:
         return ": " + String(describing: err)
       default:
-        if let help = argumentValue?.help, !help.allValues.isEmpty {
-            let quotedValues = help.allValues.map { "'\($0)'" }
-            let validList: String
-            if quotedValues.count <= 2 {
-                validList = quotedValues.joined(separator: " and ")
-            } else {
-                validList = quotedValues.dropLast().joined(separator: ", ") + " and \(quotedValues.last!)"
-            }
-          return ". Choose from \(validList)."
-        }
-        return ""
+        return argumentValue?.formattedValueList ?? ""
       }
     }()
 
@@ -431,6 +421,28 @@ extension ErrorMessageGenerator {
       return "The value '\(value)' is invalid for '\(n.synopsisString)'\(customErrorMessage)"
     case (nil, nil):
       return "The value '\(value)' is invalid.\(customErrorMessage)"
+    }
+  }
+}
+
+private extension ArgumentDefinition {
+  var formattedValueList: String {
+    if help.allValues.isEmpty {
+      return ""
+    }
+
+    if help.allValues.count < 6 {
+      let quotedValues = help.allValues.map { "'\($0)'" }
+      let validList: String
+      if quotedValues.count <= 2 {
+        validList = quotedValues.joined(separator: " and ")
+      } else {
+        validList = quotedValues.dropLast().joined(separator: ", ") + " or \(quotedValues.last!)"
+      }
+      return ". Please provide one of \(validList)."
+    } else {
+      let bulletValueList = help.allValues.map { "  - \($0)" }.joined(separator: "\n")
+      return ". Please provide one of the following:\n\(bulletValueList)"
     }
   }
 }

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -394,8 +394,9 @@ extension ErrorMessageGenerator {
   }
   
   func unableToParseValueMessage(origin: InputOrigin, name: Name?, value: String, key: InputKey, error: Error?) -> String {
-    let valueName = arguments(for: key).first?.valueName
-    
+    let argumentValue = arguments(for: key).first
+    let valueName = argumentValue?.valueName
+
     // We want to make the "best effort" in producing a custom error message.
     // We favour `LocalizedError.errorDescription` and fall back to
     // `CustomStringConvertible`. To opt in, return your custom error message
@@ -407,10 +408,20 @@ extension ErrorMessageGenerator {
       case let err?:
         return ": " + String(describing: err)
       default:
+        if let help = argumentValue?.help, !help.allValues.isEmpty {
+            let quotedValues = help.allValues.map { "'\($0)'" }
+            let validList: String
+            if quotedValues.count <= 2 {
+                validList = quotedValues.joined(separator: " and ")
+            } else {
+                validList = quotedValues.dropLast().joined(separator: ", ") + " and \(quotedValues.last!)"
+            }
+          return ". Choose from \(validList)."
+        }
         return ""
       }
     }()
-    
+
     switch (name, valueName) {
     case let (n?, v?):
       return "The value '\(value)' is invalid for '\(n.synopsisString) <\(v)>'\(customErrorMessage)"

--- a/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
+++ b/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
@@ -70,14 +70,48 @@ fileprivate struct Foo: ParsableArguments {
     case json
     case csv
   }
+
+  enum Name: String, Equatable, Decodable, ExpressibleByArgument, CaseIterable {
+    case bruce
+    case clint
+    case hulk
+    case natasha
+    case steve
+    case thor
+    case tony
+  }
   @Option(name: [.short, .long])
   var format: Format
+  @Option(name: [.short, .long])
+  var name: Name?
 }
 
 extension ErrorMessageTests {
   func testWrongEnumValue() {
-    AssertErrorMessage(Foo.self, ["--format", "png"], "The value 'png' is invalid for '--format <format>'. Choose from 'text', 'json' and 'csv'.")
-    AssertErrorMessage(Foo.self, ["-f", "png"], "The value 'png' is invalid for '-f <format>'. Choose from 'text', 'json' and 'csv'.")
+    AssertErrorMessage(Foo.self, ["--format", "png"], "The value 'png' is invalid for '--format <format>'. Please provide one of 'text', 'json' or 'csv'.")
+    AssertErrorMessage(Foo.self, ["-f", "png"], "The value 'png' is invalid for '-f <format>'. Please provide one of 'text', 'json' or 'csv'.")
+    AssertErrorMessage(Foo.self, ["-f", "text", "--name", "loki"],
+      """
+      The value 'loki' is invalid for '--name <name>'. Please provide one of the following:
+        - bruce
+        - clint
+        - hulk
+        - natasha
+        - steve
+        - thor
+        - tony
+      """)
+    AssertErrorMessage(Foo.self, ["-f", "text", "-n", "loki"],
+      """
+      The value 'loki' is invalid for '-n <name>'. Please provide one of the following:
+        - bruce
+        - clint
+        - hulk
+        - natasha
+        - steve
+        - thor
+        - tony
+      """)
   }
 }
 

--- a/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
+++ b/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
@@ -65,9 +65,10 @@ extension ErrorMessageTests {
 }
 
 fileprivate struct Foo: ParsableArguments {
-  enum Format: String, Equatable, Decodable, ExpressibleByArgument {
+  enum Format: String, Equatable, Decodable, ExpressibleByArgument, CaseIterable {
     case text
     case json
+    case csv
   }
   @Option(name: [.short, .long])
   var format: Format
@@ -75,8 +76,8 @@ fileprivate struct Foo: ParsableArguments {
 
 extension ErrorMessageTests {
   func testWrongEnumValue() {
-    AssertErrorMessage(Foo.self, ["--format", "png"], "The value 'png' is invalid for '--format <format>'")
-    AssertErrorMessage(Foo.self, ["-f", "png"], "The value 'png' is invalid for '-f <format>'")
+    AssertErrorMessage(Foo.self, ["--format", "png"], "The value 'png' is invalid for '--format <format>'. Choose from 'text', 'json' and 'csv'.")
+    AssertErrorMessage(Foo.self, ["-f", "png"], "The value 'png' is invalid for '-f <format>'. Choose from 'text', 'json' and 'csv'.")
   }
 }
 


### PR DESCRIPTION
When an option value fails to parse, no custom error message is
provided, and a list of valid candidate values is available, include the
list as part of the error message.

Addresses #344.


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
