### PR TITLE
Handle failures getting terminal size on windows

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -353,8 +353,9 @@ func _terminalSize() -> (width: Int, height: Int) {
   return (80, 25)
 #elseif os(Windows)
   var csbi: CONSOLE_SCREEN_BUFFER_INFO = CONSOLE_SCREEN_BUFFER_INFO()
-
-  GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)
+  guard GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi) else {
+    return (80, 25)
+  }
   return (width: Int(csbi.srWindow.Right - csbi.srWindow.Left) + 1,
           height: Int(csbi.srWindow.Bottom - csbi.srWindow.Top) + 1)
 #else


### PR DESCRIPTION
- Fixes #369
- Adds an error check for the return value of GetConsoleScreenBufferInfo
  Windows. If GetConsoleScreenBufferInfo a default size of 80 by 25 is
  used.