### PR TITLE
Correct Typos

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -41,7 +41,7 @@ struct FishCompletionsGenerator {
     /// We ask each suggestion to produce 2 pieces of information
     /// - Parameters
     ///   - ancestors: a list of "ancestor" which must be present in the current shell buffer for
-    ///                this suggetion to be considered. This could be a combination of (nested)
+    ///                this suggestion to be considered. This could be a combination of (nested)
     ///                subcommands and flags.
     ///   - suggestion: text for the actual suggestion
     /// - Returns: A completion expression

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -481,7 +481,7 @@ extension Argument {
   ///
   /// This method is called to initialize an array `Argument` with no default value such as:
   /// ```swift
-  /// @Argument(tranform: baz)
+  /// @Argument(transform: baz)
   /// var foo: [String]
   /// ```
   ///

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -120,7 +120,7 @@ extension Argument where Value: ExpressibleByArgument {
   /// ```
   ///
   /// - Parameters:
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - help: Information about how to use this argument.
   public init(
     wrappedValue: Value,

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -231,7 +231,7 @@ extension Flag where Value == Bool {
   /// Creates a Boolean property with default value provided by standard Swift default value syntax that reads its value from the presence of a flag.
   ///
   /// - Parameters:
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - name: A specification for what names are allowed for this flag.
   ///   - help: Information about how to use this flag.
   public init(
@@ -273,7 +273,7 @@ extension Flag where Value == Bool {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - inversion: The method for converting this flag's name into an on/off pair.
   ///   - exclusivity: The behavior to use when an on/off pair of flags is specified.
   ///   - help: Information about how to use this flag.
@@ -305,7 +305,7 @@ extension Flag where Value == Bool {
   ///
   /// - Parameters:
   ///   - name: A specification for what names are allowed for this flag.
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - inversion: The method for converting this flag's name into an on/off pair.
   ///   - exclusivity: The behavior to use when an on/off pair of flags is specified.
   ///   - help: Information about how to use this flag.
@@ -393,7 +393,7 @@ extension Flag where Value: EnumerableFlag {
   /// ```
   ///
   /// - Parameters:
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - exclusivity: The behavior to use when multiple flags are specified.
   ///   - help: Information about how to use this flag.
   public init(

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -134,7 +134,7 @@ extension Option where Value: ExpressibleByArgument {
   /// ```
   ///
   /// - Parameters:
-  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during propery wrapper initialization.
+  ///   - wrappedValue: A default value to use for this property, provided implicitly by the compiler during property wrapper initialization.
   ///   - name: A specification for what names are allowed for this flag.
   ///   - parsingStrategy: The behavior to use when looking for this option's value.
   ///   - help: Information about how to use this option.

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -11,7 +11,7 @@
 
 /// Specifies where a given input came from.
 ///
-/// When reading from the command line, a value might originate from a sinlge
+/// When reading from the command line, a value might originate from a single
 /// index, multiple indices, or from part of an index. For this command:
 ///
 ///     struct Example: ParsableCommand {

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -169,7 +169,7 @@ struct SplitArguments {
     }
   }
   
-  /// The parsed arguments. Onl
+  /// The parsed arguments.
   var _elements: [Element] = []
   var firstUnused: Int = 0
 

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -398,7 +398,7 @@ extension ErrorMessageGenerator {
     let valueName = argumentValue?.valueName
 
     // We want to make the "best effort" in producing a custom error message.
-    // We favour `LocalizedError.errorDescription` and fall back to
+    // We favor `LocalizedError.errorDescription` and fall back to
     // `CustomStringConvertible`. To opt in, return your custom error message
     // as the `description` property of `CustomStringConvertible`.
     let customErrorMessage: String = {

--- a/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SequenceExtensions.swift
@@ -11,7 +11,7 @@
 
 extension Sequence where Element: Hashable {
   /// Returns an array with only the unique elements of this sequence, in the
-  /// order of the first occurence of each unique element.
+  /// order of the first occurrence of each unique element.
   func uniquing() -> [Element] {
     var seen = Set<Element>()
     return self.filter { seen.insert($0).0 }

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -135,7 +135,7 @@ extension ValidationEndToEndTests {
   }
 
   func testCustomErrorValidation() {
-    // verify that error description is printed if avaiable via LocalizedError
+    // verify that error description is printed if available via LocalizedError
     AssertErrorMessage(Foo.self, ["--throw", "Joe"], UserValidationError.userValidationError.errorDescription!)
   }
 


### PR DESCRIPTION
Corrects a number of typos that I saw throughout comments in the codebase.
| Original | Replacement |
|----|----|
| avaiable | available |
| favour | favor |
| occurence | occurrence |
| Onl | |
| propery | property |
| sinlge | single |
| suggetion | suggestion |
| tranform | transform |

### Checklist
- [N/A] I've added at least one test that validates that my change is working, if appropriate
- [N/A] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary
