### PR TITLE
Deprecate Option initializer and add a new one with parameters in order

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -127,6 +127,23 @@ extension Option where Value: ExpressibleByArgument {
   }
 
   /// Creates a property with a default value provided by standard Swift default value syntax.
+  @available(*, deprecated, message: "Swap the order of your 'help' and 'completion' arguments.")
+  public init(
+    wrappedValue: Value,
+    name: NameSpecification = .long,
+    parsing parsingStrategy: SingleValueParsingStrategy = .next,
+    completion: CompletionKind?,
+    help: ArgumentHelp?
+  ) {
+    self.init(
+      name: name,
+      initial: wrappedValue,
+      parsingStrategy: parsingStrategy,
+      help: help,
+      completion: completion)
+  }
+
+  /// Creates a property with a default value provided by standard Swift default value syntax.
   ///
   /// This method is called to initialize an `Option` with a default value such as:
   /// ```swift
@@ -138,12 +155,13 @@ extension Option where Value: ExpressibleByArgument {
   ///   - name: A specification for what names are allowed for this flag.
   ///   - parsingStrategy: The behavior to use when looking for this option's value.
   ///   - help: Information about how to use this option.
+  ///   - completion: Kind of completion provided to the user for this option.
   public init(
     wrappedValue: Value,
     name: NameSpecification = .long,
     parsing parsingStrategy: SingleValueParsingStrategy = .next,
-    completion: CompletionKind? = nil,
-    help: ArgumentHelp? = nil
+    help: ArgumentHelp? = nil,
+    completion: CompletionKind? = nil
   ) {
     self.init(
       name: name,

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -777,3 +777,19 @@ extension DefaultsEndToEndTests {
     }
   }
 }
+
+@available(*, deprecated)
+fileprivate struct OptionPropertyDeprecatedInit_NoDefault: ParsableArguments {
+  @Option(completion: .file(), help: "")
+  var data: String = "test"
+}
+
+extension DefaultsEndToEndTests {
+  /// Tests that instances created using deprecated initializer with completion and help arguments swapped are constructed and parsed correctly.
+  @available(*, deprecated)
+  func testParsing_OptionPropertyDeprecatedInit_NoDefault() {
+    AssertParse(OptionPropertyDeprecatedInit_NoDefault.self, []) { arguments in
+      XCTAssertEqual(arguments.data, "test")
+    }
+  }
+}


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR marks an `Option` initializer as deprecated because it had its last 2 parameters inverted (help should be before completion, following order of all other initializers).
It also adds a new one with parameters in correct order.
It follows recommendations of @natecook1000 in issue https://github.com/apple/swift-argument-parser/issues/381.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
