### PR TITLE
Fix issue with unconditional remaining properties in subcommands

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -31,6 +31,8 @@ public protocol ParsableCommand: ParsableArguments {
   mutating func run() throws
 }
 
+// MARK: - Default implementations
+
 extension ParsableCommand {
   public static var _commandName: String {
     configuration.commandName ??
@@ -43,18 +45,6 @@ extension ParsableCommand {
 
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
-  }
-  
-  internal static var includesUnconditionalArguments: Bool {
-    ArgumentSet(self).contains(where: {
-      $0.isRepeatingPositional && $0.parsingStrategy == .allRemainingInput
-    })
-  }
-
-  internal static var remainingInputSubcommands: [ParsableCommand.Type] {
-    configuration
-      .subcommands
-      .filter { $0.includesUnconditionalArguments }
   }
 }
 
@@ -115,5 +105,24 @@ extension ParsableCommand {
   /// relevant error message if necessary.
   public static func main() {
     self.main(nil)
+  }
+}
+
+// MARK: - Internal API
+
+extension ParsableCommand {
+  /// `true` if this command contains any array arguments that are declared
+  /// with `.unconditionalRemaining`.
+  internal static var includesUnconditionalArguments: Bool {
+    ArgumentSet(self).contains(where: {
+      $0.isRepeatingPositional && $0.parsingStrategy == .allRemainingInput
+    })
+  }
+  
+  /// `true` if this command's default subcommand contains any array arguments
+  /// that are declared with `.unconditionalRemaining`. This is `false` if
+  /// there's no default subcommand.
+  internal static var defaultIncludesUnconditionalArguments: Bool {
+    configuration.defaultSubcommand?.includesUnconditionalArguments == true
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -44,6 +44,18 @@ extension ParsableCommand {
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }
+  
+  internal static var includesUnconditionalArguments: Bool {
+    ArgumentSet(self).contains(where: {
+      $0.isRepeatingPositional && $0.parsingStrategy == .allRemainingInput
+    })
+  }
+
+  internal static var remainingInputSubcommands: [ParsableCommand.Type] {
+    configuration
+      .subcommands
+      .filter { $0.includesUnconditionalArguments }
+  }
 }
 
 // MARK: - API

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -192,23 +192,24 @@ extension ArgumentDefinition {
 
 // MARK: - Parsing from SplitArguments
 extension ArgumentSet {
-  /// Parse the given input (`SplitArguments`) for the given `commandStack` of previously parsed commands.
+  /// Parse the given input for this set of defined arguments.
   ///
-  /// This method will gracefully fail if there are extra arguments that it doesn’t understand. Hence the
-  /// *lenient* name. If so, it will return `.partial`.
+  /// This method will consume only the arguments that it understands. If any
+  /// arguments are declared to capture all remaining input, or a subcommand
+  /// is configured as such, parsing stops on the first positional argument or
+  /// unrecognized dash-prefixed argument.
   ///
-  /// When dealing with commands, this will be called iteratively in order to find
-  /// the matching command(s).
-  ///
-  /// - Parameter all: The input (from the command line) that needs to be parsed
-  /// - Parameter commandStack: commands that have been parsed
+  /// - Parameter input: The input that needs to be parsed.
+  /// - Parameter subcommands: Any subcommands of the current command.
+  /// - Parameter defaultCapturesAll: `true` if the default subcommand has an
+  ///   argument that captures all remaining input.
   func lenientParse(
-    _ all: SplitArguments,
-    subcommandNames: [String],
-    overrideCapturesAll: Bool
+    _ input: SplitArguments,
+    subcommands: [ParsableCommand.Type],
+    defaultCapturesAll: Bool
   ) throws -> ParsedValues {
     // Create a local, mutable copy of the arguments:
-    var inputArguments = all
+    var inputArguments = input
     
     func parseValue(
       _ argument: ArgumentDefinition,
@@ -344,11 +345,11 @@ extension ArgumentSet {
     // captures all remaining input, we use a different behavior, where we
     // shortcut out at the first sign of a positional argument or unrecognized
     // option/flag label.
-    let capturesAll = overrideCapturesAll || self.contains(where: { arg in
+    let capturesAll = defaultCapturesAll || self.contains(where: { arg in
       arg.isRepeatingPositional && arg.parsingStrategy == .allRemainingInput
     })
     
-    var result = ParsedValues(elements: [:], originalInput: all.originalInput)
+    var result = ParsedValues(elements: [:], originalInput: input.originalInput)
     var allUsedOrigins = InputOrigin()
     
     try setInitialValues(into: &result)
@@ -364,9 +365,21 @@ extension ArgumentSet {
       
       switch next.value {
       case .value(let argument):
+        // Special handling for matching subcommand names. We generally want
+        // parsing to skip over unrecognized input, but if the current
+        // command or the matched subcommand captures all remaining input,
+        // then we want to break out of parsing at this point.
+        if let matchedSubcommand = subcommands.first(where: { $0._commandName == argument }) {
+          if !matchedSubcommand.includesUnconditionalArguments && defaultCapturesAll {
+            continue ArgumentLoop
+          } else if matchedSubcommand.includesUnconditionalArguments {
+            break ArgumentLoop
+          }
+        }
+        
         // If we're capturing all, the first positional value represents the
         // start of positional input.
-        if capturesAll || subcommandNames.contains(argument) { break ArgumentLoop }
+        if capturesAll { break ArgumentLoop }
         // We'll parse positional values later.
         break
       case let .option(parsed):
@@ -407,7 +420,7 @@ extension ArgumentSet {
     
     // We have parsed all non-positional values at this point.
     // Next: parse / consume the positional values.
-    var unusedArguments = all
+    var unusedArguments = input
     unusedArguments.removeAll(in: allUsedOrigins)
     try parsePositionalValues(from: unusedArguments, into: &result)
 

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -202,7 +202,11 @@ extension ArgumentSet {
   ///
   /// - Parameter all: The input (from the command line) that needs to be parsed
   /// - Parameter commandStack: commands that have been parsed
-  func lenientParse(_ all: SplitArguments) throws -> ParsedValues {
+  func lenientParse(
+    _ all: SplitArguments,
+    subcommandNames: [String],
+    overrideCapturesAll: Bool
+  ) throws -> ParsedValues {
     // Create a local, mutable copy of the arguments:
     var inputArguments = all
     
@@ -340,7 +344,7 @@ extension ArgumentSet {
     // captures all remaining input, we use a different behavior, where we
     // shortcut out at the first sign of a positional argument or unrecognized
     // option/flag label.
-    let capturesAll = self.contains(where: { arg in
+    let capturesAll = overrideCapturesAll || self.contains(where: { arg in
       arg.isRepeatingPositional && arg.parsingStrategy == .allRemainingInput
     })
     
@@ -359,10 +363,10 @@ extension ArgumentSet {
       }
       
       switch next.value {
-      case .value:
+      case .value(let argument):
         // If we're capturing all, the first positional value represents the
         // start of positional input.
-        if capturesAll { break ArgumentLoop }
+        if capturesAll || subcommandNames.contains(argument) { break ArgumentLoop }
         // We'll parse positional values later.
         break
       case let .option(parsed):

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -125,9 +125,11 @@ extension CommandParser {
     // Build the argument set (i.e. information on how to parse):
     let commandArguments = ArgumentSet(currentNode.element)
     
+    let subcommandNames = currentNode.element.remainingInputSubcommands.map { $0._commandName }
+    let defaultCapturesAll = currentNode.element.configuration.defaultSubcommand?.includesUnconditionalArguments == true
     // Parse the arguments, ignoring anything unexpected
-    let values = try commandArguments.lenientParse(split)
-    
+    let values = try commandArguments.lenientParse(split, subcommandNames: subcommandNames, overrideCapturesAll: defaultCapturesAll)
+
     // Decode the values from ParsedValues into the ParsableCommand:
     let decoder = ArgumentDecoder(values: values, previouslyDecoded: decodedArguments)
     var decodedResult: ParsableCommand

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -125,10 +125,11 @@ extension CommandParser {
     // Build the argument set (i.e. information on how to parse):
     let commandArguments = ArgumentSet(currentNode.element)
     
-    let subcommandNames = currentNode.element.remainingInputSubcommands.map { $0._commandName }
-    let defaultCapturesAll = currentNode.element.configuration.defaultSubcommand?.includesUnconditionalArguments == true
     // Parse the arguments, ignoring anything unexpected
-    let values = try commandArguments.lenientParse(split, subcommandNames: subcommandNames, overrideCapturesAll: defaultCapturesAll)
+    let values = try commandArguments.lenientParse(
+      split,
+      subcommands: currentNode.element.configuration.subcommands,
+      defaultCapturesAll: currentNode.element.defaultIncludesUnconditionalArguments)
 
     // Decode the values from ParsedValues into the ParsableCommand:
     let decoder = ArgumentDecoder(values: values, previouslyDecoded: decodedArguments)


### PR DESCRIPTION
This extends the current behavior of `@Argument` array properties defined with the `.unconditionalRemaining` parsing strategy to work with subcommands, as well. For example, with a command hierarchy like this:

```swift
@main
struct Root: ParsableCommand {
    static var configuration: CommandConfiguration {
        .init(subcommands: [Sub.self])
    }

    @Flag var verbose = false
}

struct Sub: ParsableCommand {
    @Argument(parsing: .unconditionalRemaining)
    var remainder: [String] = []

    @OptionGroup var root: Root

    func run() {
        print("Verbose:", root.verbose)
        print("Remainder:", remainder)
    }
}
```

We want the `Sub` command to capture any arguments after the subcommand name appears in the command-line arguments. This fix enables the following behavior:

```
$ root --verbose sub foo --bar
Verbose: true
Remainder: foo --bar
$ root sub foo --bar --verbose 
Verbose: false
Remainder: foo --bar --verbose
$ root --verbose sub foo --bar --verbose 
Verbose: true
Remainder: foo --bar --verbose
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
