### PR TITLE
Forward ArgumentVisibility to ArgumentDefinition

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(ArgumentParser
 
   "Parsable Properties/Argument.swift"
   "Parsable Properties/ArgumentHelp.swift"
+  "Parsable Properties/ArgumentVisibility.swift"
   "Parsable Properties/CompletionKind.swift"
   "Parsable Properties/Errors.swift"
   "Parsable Properties/Flag.swift"

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -178,7 +178,7 @@ struct BashCompletionsGenerator {
 extension ArgumentDefinition {
   /// Returns the different completion names for this argument.
   fileprivate func bashCompletionWords() -> [String] {
-    return help.shouldDisplay
+    return help.visibility == .default
       ? names.map { $0.synopsisString }
       : []
   }

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -100,7 +100,7 @@ extension Name {
 
 extension ArgumentDefinition {
   fileprivate func argumentSegments(_ commandChain: [String]) -> [([String], String)] {
-    guard help.shouldDisplay else { return [] }
+    guard help.visibility == .default else { return [] }
 
     var results = [([String], String)]()
     var formattedFlags = [String]()

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -132,7 +132,7 @@ extension ArgumentDefinition {
   }
   
   func zshCompletionString(_ commands: [ParsableCommand.Type]) -> String? {
-    guard help.shouldDisplay else { return nil }
+    guard help.visibility == .default else { return nil }
     
     var inputs: String
     switch update {

--- a/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
@@ -11,18 +11,6 @@
 
 /// Help information for a command-line argument.
 public struct ArgumentHelp {
-  /// Visibility level of an argument's help.
-  public enum Visibility {
-      /// Show help for this argument whenever appropriate.
-      case `default`
-
-      /// Only show help for this argument in the extended help screen.
-      case hidden
-
-      /// Never show help for this argument.
-      case `private`
-  }
-
   /// A short description of the argument.
   public var abstract: String = ""
   
@@ -38,7 +26,7 @@ public struct ArgumentHelp {
   
   /// A visibility level indicating whether this argument should be shown in
   /// the extended help display.
-  public var visibility: Visibility = .default
+  public var visibility: ArgumentVisibility = .default
 
   /// A Boolean value indicating whether this argument should be shown in
   /// the extended help display.
@@ -71,7 +59,7 @@ public struct ArgumentHelp {
     _ abstract: String = "",
     discussion: String = "",
     valueName: String? = nil,
-    visibility: Visibility = .default)
+    visibility: ArgumentVisibility = .default)
   {
     self.abstract = abstract
     self.discussion = discussion

--- a/Sources/ArgumentParser/Parsable Properties/ArgumentVisibility.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentVisibility.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Visibility level of an argument's help.
+public enum ArgumentVisibility {
+    /// Show help for this argument whenever appropriate.
+    case `default`
+
+    /// Only show help for this argument in the extended help screen.
+    case hidden
+
+    /// Never show help for this argument.
+    case `private`
+}

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -44,7 +44,7 @@ struct ArgumentDefinition {
     var abstract: String = ""
     var discussion: String = ""
     var valueName: String = ""
-    var shouldDisplay: Bool = true
+    var visibility: ArgumentVisibility = .default
 
     var defaultValue: String?
     var keys: [InputKey]
@@ -79,7 +79,7 @@ struct ArgumentDefinition {
       self.abstract = help?.abstract ?? ""
       self.discussion = help?.discussion ?? ""
       self.valueName = help?.valueName ?? ""
-      self.shouldDisplay = (help?.visibility ?? .default) == .default
+      self.visibility = help?.visibility ?? .default
     }
   }
   

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -125,7 +125,7 @@ fileprivate extension ArgumentInfoV0 {
     guard let kind = ArgumentInfoV0.KindV0(argument: argument) else { return nil }
     self.init(
       kind: kind,
-      shouldDisplay: argument.help.shouldDisplay,
+      shouldDisplay: argument.help.visibility == .default,
       isOptional: argument.help.options.contains(.isOptional),
       isRepeating: argument.help.options.contains(.isRepeating),
       names: argument.names.map(ArgumentInfoV0.NameInfoV0.init),

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -141,7 +141,7 @@ internal struct HelpGenerator {
     var args = commandStack.argumentsForHelp(includeHidden: includeHidden)[...]
     
     while let arg = args.popFirst() {
-      guard arg.help.shouldDisplay else { continue }
+      guard arg.help.visibility == .default else { continue }
       
       let synopsis: String
       let description: String
@@ -155,7 +155,7 @@ internal struct HelpGenerator {
 
         synopsis = groupedArgs
           .lazy
-          .filter { $0.help.shouldDisplay }
+          .filter { $0.help.visibility == .default }
           .map { $0.synopsisForHelp }
           .joined(separator: "/")
 
@@ -173,7 +173,7 @@ internal struct HelpGenerator {
           .filter { !$0.isEmpty }
           .joined(separator: " ")
       } else {
-        synopsis = arg.help.shouldDisplay
+        synopsis = arg.help.visibility == .default
           ? arg.synopsisForHelp
           : ""
 

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -38,7 +38,7 @@ extension UsageGenerator {
   var synopsis: String {
     // Filter out options that should not be displayed.
     var options = definition
-      .filter { $0.help.shouldDisplay }
+      .filter { $0.help.visibility == .default }
     switch options.count {
     case 0:
       return toolName
@@ -344,7 +344,7 @@ extension ErrorMessageGenerator {
   func noValueMessage(key: InputKey) -> String? {
     let args = arguments(for: key)
     let possibilities: [String] = args.compactMap {
-      $0.help.shouldDisplay
+      $0.help.visibility == .default
         ? $0.nonOptional.synopsis
         : nil
     }


### PR DESCRIPTION
- Renames ArgumentHelp.Visibility to ArgumentVisibility.
- Replaces ArgumentDefinition.shouldDisplay with a visibility property
  whose value is derived from ArgumentHelp.visibility.