### PR TITLE
Provide non-experimental help-hidden flags

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -76,16 +76,17 @@ extension CommandParser {
   /// Throws a `HelpRequested` error if the user has specified either of the
   /// built in help flags.
   func checkForBuiltInFlags(_ split: SplitArguments) throws {
-    guard !split.contains(Name.long("experimental-help-hidden")) else {
-      throw HelpRequested(visibility: .hidden)
-    }
-
     // Look for help flags
-    guard !split.contains(anyOf: self.commandStack.getHelpNames()) else {
+    guard !split.contains(anyOf: self.commandStack.getHelpNames(visibility: .default)) else {
       throw HelpRequested(visibility: .default)
     }
 
-    // Look for the "dump help" request
+    // Look for help-hidden flags
+    guard !split.contains(anyOf: self.commandStack.getHelpNames(visibility: .hidden)) else {
+      throw HelpRequested(visibility: .hidden)
+    }
+
+    // Look for dump-help flag
     guard !split.contains(Name.long("experimental-dump-help")) else {
       throw CommandError(commandStack: commandStack, parserError: .dumpHelpRequested)
     }

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -144,7 +144,7 @@ public func AssertHelpHidden<T: ParsableArguments>(
   file: StaticString = #file, line: UInt = #line
 ) {
   do {
-    _ = try T.parse(["--experimental-help-hidden"])
+    _ = try T.parse(["--help-hidden"])
     XCTFail(file: (file), line: line)
   } catch {
     let helpString = T.fullMessage(for: error)

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -193,9 +193,11 @@ struct CustomHelp: ParsableCommand {
 
 extension HelpTests {
   func testCustomHelpNames() {
-    let names = [CustomHelp.self].getHelpNames()
-    XCTAssertEqual(names, [.short("?"), .long("show-help")])
-    
+    let helpNames = [CustomHelp.self].getHelpNames(visibility: .default)
+    XCTAssertEqual(helpNames, [.short("?"), .long("show-help")])
+    let helpHiddenNames = [CustomHelp.self].getHelpNames(visibility: .hidden)
+    XCTAssertEqual(helpHiddenNames, [.long("show-help-hidden")])
+
     AssertFullErrorMessage(CustomHelp.self, ["--error"], """
       Error: Unknown option '--error'
       Usage: custom-help
@@ -214,8 +216,10 @@ struct NoHelp: ParsableCommand {
 
 extension HelpTests {
   func testNoHelpNames() {
-    let names = [NoHelp.self].getHelpNames()
-    XCTAssertEqual(names, [])
+    let helpNames = [NoHelp.self].getHelpNames(visibility: .default)
+    XCTAssertEqual(helpNames, [])
+    let helpHiddenNames = [NoHelp.self].getHelpNames(visibility: .hidden)
+    XCTAssertEqual(helpHiddenNames, [])
 
     AssertFullErrorMessage(NoHelp.self, ["--error"], """
       Error: Missing expected argument '--count <count>'
@@ -257,12 +261,18 @@ struct SubCommandCustomHelp: ParsableCommand {
 
 extension HelpTests {
   func testSubCommandInheritHelpNames() {
-    let names = [SubCommandCustomHelp.self, SubCommandCustomHelp.InheritHelp.self].getHelpNames()
+    let names = [
+      SubCommandCustomHelp.self,
+      SubCommandCustomHelp.InheritHelp.self,
+    ].getHelpNames(visibility: .default)
     XCTAssertEqual(names, [.short("p"), .long("parent-help")])
   }
 
   func testSubCommandCustomHelpNames() {
-    let names = [SubCommandCustomHelp.self, SubCommandCustomHelp.ModifiedHelp.self].getHelpNames()
+    let names = [
+      SubCommandCustomHelp.self,
+      SubCommandCustomHelp.ModifiedHelp.self
+    ].getHelpNames(visibility: .default)
     XCTAssertEqual(names, [.short("s"), .long("subcommand-help")])
   }
 
@@ -271,7 +281,7 @@ extension HelpTests {
       SubCommandCustomHelp.self,
       SubCommandCustomHelp.ModifiedHelp.self,
       SubCommandCustomHelp.ModifiedHelp.InheritImmediateParentdHelp.self
-    ].getHelpNames()
+    ].getHelpNames(visibility: .default)
     XCTAssertEqual(names, [.short("s"), .long("subcommand-help")])
   }
 }


### PR DESCRIPTION
- Adds help-hidden flags generated based on each ParsableCommand's help
  names. The help-hidden flag is only generated if the help names
  contain at least one .long name.