### PR TITLE
Show hidden args/opts/flags with --help-hidden

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -270,7 +270,6 @@ extension ArgumentSetProvider {
 
 extension ArgumentSet {
   init(_ type: ParsableArguments.Type, visibility: ArgumentVisibility) {
-    
     #if DEBUG
     do {
       try type._validate()
@@ -306,7 +305,8 @@ extension ArgumentSet {
           return ArgumentSet(definition)
         }
       }
-    self.init(sets: a)
+    self.init(a.joined()
+          .filter { $0.help.visibility.isAtLeastAsVisible(as: visibility) })
   }
 }
 

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -295,18 +295,12 @@ extension ArgumentSet {
           return parsed.argumentSet(for: key)
         } else {
           // Save a non-wrapped property as is
-          var definition = ArgumentDefinition(
-            key: InputKey(rawValue: codingKey),
-            kind: .default,
-            parser: { _ in nil },
-            default: nilOrValue(child.value),
-            completion: .default)
-          definition.help.updateArgumentHelp(help: .hidden)
-          return ArgumentSet(definition)
+          return ArgumentSet(
+            ArgumentDefinition(unparsedKey: codingKey, default: nilOrValue(child.value)))
         }
       }
-    self.init(a.joined()
-          .filter { $0.help.visibility.isAtLeastAsVisible(as: visibility) })
+    self.init(
+      a.joined().filter { $0.help.visibility.isAtLeastAsVisible(as: visibility) })
   }
 }
 

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -190,6 +190,23 @@ extension ArgumentDefinition {
   }
 }
 
+extension ArgumentDefinition {
+  /// Creates an argument definition for a property that isn't parsed from the
+  /// command line.
+  ///
+  /// This initializer is used for any property defined on a `ParsableArguments`
+  /// type that isn't decorated with one of ArgumentParser's property wrappers.
+  init(unparsedKey: String, default defaultValue: Any?) {
+    self.init(
+      key: InputKey(rawValue: unparsedKey),
+      kind: .default,
+      parser: { _ in nil },
+      default: defaultValue,
+      completion: .default)
+    help.updateArgumentHelp(help: .private)
+  }
+}
+
 // MARK: - Parsing from SplitArguments
 extension ArgumentSet {
   /// Parse the given input for this set of defined arguments.

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -106,7 +106,8 @@ internal struct HelpGenerator {
     if let usage = currentCommand.configuration.usage {
       self.usage = usage
     } else {
-      var usage = UsageGenerator(toolName: toolName, definition: [currentArgSet]).synopsis
+      var usage = UsageGenerator(toolName: toolName, definition: [currentArgSet])
+        .synopsis(visibility: visibility)
       if !currentCommand.configuration.subcommands.isEmpty {
         if usage.last != " " { usage += " " }
         usage += "<subcommand>"
@@ -140,7 +141,8 @@ internal struct HelpGenerator {
     /// more elements at a time.
     var args = commandStack.argumentsForHelp(visibility: visibility)[...]
     while let arg = args.popFirst() {
-      guard arg.help.visibility == .default else { continue }
+      guard arg.help.visibility.isAtLeastAsVisible(as: visibility)
+        else { continue }
       
       let synopsis: String
       let description: String
@@ -154,7 +156,6 @@ internal struct HelpGenerator {
 
         synopsis = groupedArgs
           .lazy
-          .filter { $0.help.visibility == .default }
           .map { $0.synopsisForHelp }
           .joined(separator: "/")
 
@@ -172,9 +173,7 @@ internal struct HelpGenerator {
           .filter { !$0.isEmpty }
           .joined(separator: " ")
       } else {
-        synopsis = arg.help.visibility == .default
-          ? arg.synopsisForHelp
-          : ""
+        synopsis = arg.synopsisForHelp
 
         let defaultValue = arg.help.defaultValue.flatMap { $0.isEmpty ? nil : "(default: \($0))" }
         description = [arg.help.abstract, defaultValue]

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -107,7 +107,7 @@ internal struct HelpGenerator {
       self.usage = usage
     } else {
       var usage = UsageGenerator(toolName: toolName, definition: [currentArgSet])
-        .synopsis(visibility: visibility)
+        .synopsis()
       if !currentCommand.configuration.subcommands.isEmpty {
         if usage.last != " " { usage += " " }
         usage += "<subcommand>"
@@ -141,8 +141,7 @@ internal struct HelpGenerator {
     /// more elements at a time.
     var args = commandStack.argumentsForHelp(visibility: visibility)[...]
     while let arg = args.popFirst() {
-      guard arg.help.visibility.isAtLeastAsVisible(as: visibility)
-        else { continue }
+      assert(arg.help.visibility.isAtLeastAsVisible(as: visibility))
       
       let synopsis: String
       let description: String

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -22,10 +22,10 @@ extension UsageGenerator {
     self.init(toolName: toolName, definition: definition)
   }
   
-  init(toolName: String, parsable: ParsableArguments) {
+  init(toolName: String, parsable: ParsableArguments, visibility: ArgumentVisibility) {
     self.init(
       toolName: toolName,
-      definition: ArgumentSet(type(of: parsable), visibility: .default))
+      definition: ArgumentSet(type(of: parsable), visibility: visibility))
   }
   
   init(toolName: String, definition: [ArgumentSet]) {
@@ -37,10 +37,8 @@ extension UsageGenerator {
   /// The tool synopsis.
   ///
   /// In `roff`.
-  func synopsis(visibility: ArgumentVisibility = .default) -> String {
-    // Filter out options that should not be displayed.
-    var options = definition
-      .filter { $0.help.visibility.isAtLeastAsVisible(as: visibility) }
+  func synopsis() -> String {
+    var options = Array(definition)
     switch options.count {
     case 0:
       return toolName

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -37,10 +37,10 @@ extension UsageGenerator {
   /// The tool synopsis.
   ///
   /// In `roff`.
-  var synopsis: String {
+  func synopsis(visibility: ArgumentVisibility = .default) -> String {
     // Filter out options that should not be displayed.
     var options = definition
-      .filter { $0.help.visibility == .default }
+      .filter { $0.help.visibility.isAtLeastAsVisible(as: visibility) }
     switch options.count {
     case 0:
       return toolName

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -72,11 +72,6 @@ extension HelpGenerationTests {
 
             """)
 
-#if !os(Linux)
-    XCTExpectFailure("""
-            The following test fails to properly generate the help-hidden
-            message properly because help-hidden is not fully supported yet.
-            """)
     AssertHelp(.hidden, for: B.self, equals: """
             USAGE: b --name <name> [--title <title>] [<hidden-name>] [--hidden-title <hidden-title>] [--hidden-flag] [--hidden-inverted-flag] [--no-hidden-inverted-flag]
 
@@ -93,7 +88,6 @@ extension HelpGenerationTests {
               -h, --help              Show help information.
 
             """)
-#endif
   }
 
   struct C: ParsableArguments {

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -33,7 +33,7 @@ extension UsageGenerationTests {
 
   func testSynopsis() {
     let help = UsageGenerator(toolName: "bar", parsable: A())
-    XCTAssertEqual(help.synopsis, "bar --first-name <first-name> --title <title>")
+    XCTAssertEqual(help.synopsis(), "bar --first-name <first-name> --title <title>")
   }
 
   struct B: ParsableArguments {
@@ -43,7 +43,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithOptional() {
     let help = UsageGenerator(toolName: "bar", parsable: B())
-    XCTAssertEqual(help.synopsis, "bar [--first-name <first-name>] [--title <title>]")
+    XCTAssertEqual(help.synopsis(), "bar [--first-name <first-name>] [--title <title>]")
   }
 
   struct C: ParsableArguments {
@@ -53,7 +53,7 @@ extension UsageGenerationTests {
 
   func testFlagSynopsis() {
     let help = UsageGenerator(toolName: "bar", parsable: C())
-    XCTAssertEqual(help.synopsis, "bar [--log] [--verbose ...]")
+    XCTAssertEqual(help.synopsis(), "bar [--log] [--verbose ...]")
   }
 
   struct D: ParsableArguments {
@@ -63,7 +63,7 @@ extension UsageGenerationTests {
 
   func testPositionalSynopsis() {
     let help = UsageGenerator(toolName: "bar", parsable: D())
-    XCTAssertEqual(help.synopsis, "bar <first-name> [<title>]")
+    XCTAssertEqual(help.synopsis(), "bar <first-name> [<title>]")
   }
 
   struct E: ParsableArguments {
@@ -79,7 +79,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithDefaults() {
     let help = UsageGenerator(toolName: "bar", parsable: E())
-    XCTAssertEqual(help.synopsis, "bar [--name <name>] [--count <count>] [<arg>]")
+    XCTAssertEqual(help.synopsis(), "bar [--name <name>] [--count <count>] [<arg>]")
   }
 
   struct F: ParsableArguments {
@@ -89,7 +89,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithRepeats() {
     let help = UsageGenerator(toolName: "bar", parsable: F())
-    XCTAssertEqual(help.synopsis, "bar [--name <name> ...] [<name-counts> ...]")
+    XCTAssertEqual(help.synopsis(), "bar [--name <name> ...] [<name-counts> ...]")
   }
 
   struct G: ParsableArguments {
@@ -102,7 +102,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithCustomization() {
     let help = UsageGenerator(toolName: "bar", parsable: G())
-    XCTAssertEqual(help.synopsis, "bar [--file-path <path>] <user-home-path>")
+    XCTAssertEqual(help.synopsis(), "bar [--file-path <path>] <user-home-path>")
   }
 
   struct H: ParsableArguments {
@@ -112,7 +112,8 @@ extension UsageGenerationTests {
 
   func testSynopsisWithHidden() {
     let help = UsageGenerator(toolName: "bar", parsable: H())
-    XCTAssertEqual(help.synopsis, "bar")
+    XCTAssertEqual(help.synopsis(), "bar")
+    XCTAssertEqual(help.synopsis(visibility: .hidden), "bar [--first-name <first-name>] [<title>]")
   }
 
   struct I: ParsableArguments {
@@ -136,7 +137,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithDefaultValueAndTransform() {
     let help = UsageGenerator(toolName: "bar", parsable: I())
-    XCTAssertEqual(help.synopsis, "bar [--color <color>]")
+    XCTAssertEqual(help.synopsis(), "bar [--color <color>]")
   }
 
   struct J: ParsableArguments {
@@ -147,7 +148,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithTransform() {
     let help = UsageGenerator(toolName: "bar", parsable: J())
-    XCTAssertEqual(help.synopsis, "bar --req <req> [--opt <opt>]")
+    XCTAssertEqual(help.synopsis(), "bar --req <req> [--opt <opt>]")
   }
 
   struct K: ParsableArguments {
@@ -159,7 +160,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithMultipleCustomNames() {
     let help = UsageGenerator(toolName: "bar", parsable: K())
-    XCTAssertEqual(help.synopsis, "bar [--remote <remote>]")
+    XCTAssertEqual(help.synopsis(), "bar [--remote <remote>]")
   }
 
   struct L: ParsableArguments {
@@ -171,7 +172,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithSingleDashLongNameFirst() {
     let help = UsageGenerator(toolName: "bar", parsable: L())
-    XCTAssertEqual(help.synopsis, "bar [-remote <remote>]")
+    XCTAssertEqual(help.synopsis(), "bar [-remote <remote>]")
   }
 
   struct M: ParsableArguments {
@@ -194,7 +195,7 @@ extension UsageGenerationTests {
 
   func testSynopsisWithTooManyOptions() {
     let help = UsageGenerator(toolName: "foo", parsable: M())
-    XCTAssertEqual(help.synopsis,
+    XCTAssertEqual(help.synopsis(),
                    "foo [<options>] --option <option> <input> [<output>]")
   }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -15,6 +15,17 @@ import XCTest
 final class UsageGenerationTests: XCTestCase {
 }
 
+func _testSynopsis<T: ParsableArguments>(
+  _ type: T.Type,
+  visibility: ArgumentVisibility = .default,
+  expected: String,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  let help = UsageGenerator(toolName: "example", parsable: T(), visibility: visibility)
+  XCTAssertEqual(help.synopsis(), expected, file: file, line: line)
+}
+
 // MARK: -
 
 extension UsageGenerationTests {
@@ -32,8 +43,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsis() {
-    let help = UsageGenerator(toolName: "bar", parsable: A())
-    XCTAssertEqual(help.synopsis(), "bar --first-name <first-name> --title <title>")
+    _testSynopsis(A.self, expected: "example --first-name <first-name> --title <title>")
   }
 
   struct B: ParsableArguments {
@@ -42,8 +52,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithOptional() {
-    let help = UsageGenerator(toolName: "bar", parsable: B())
-    XCTAssertEqual(help.synopsis(), "bar [--first-name <first-name>] [--title <title>]")
+    _testSynopsis(B.self, expected: "example [--first-name <first-name>] [--title <title>]")
   }
 
   struct C: ParsableArguments {
@@ -52,8 +61,7 @@ extension UsageGenerationTests {
   }
 
   func testFlagSynopsis() {
-    let help = UsageGenerator(toolName: "bar", parsable: C())
-    XCTAssertEqual(help.synopsis(), "bar [--log] [--verbose ...]")
+    _testSynopsis(C.self, expected: "example [--log] [--verbose ...]")
   }
 
   struct D: ParsableArguments {
@@ -62,8 +70,7 @@ extension UsageGenerationTests {
   }
 
   func testPositionalSynopsis() {
-    let help = UsageGenerator(toolName: "bar", parsable: D())
-    XCTAssertEqual(help.synopsis(), "bar <first-name> [<title>]")
+    _testSynopsis(D.self, expected: "example <first-name> [<title>]")
   }
 
   struct E: ParsableArguments {
@@ -78,8 +85,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithDefaults() {
-    let help = UsageGenerator(toolName: "bar", parsable: E())
-    XCTAssertEqual(help.synopsis(), "bar [--name <name>] [--count <count>] [<arg>]")
+    _testSynopsis(E.self, expected: "example [--name <name>] [--count <count>] [<arg>]")
   }
 
   struct F: ParsableArguments {
@@ -88,8 +94,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithRepeats() {
-    let help = UsageGenerator(toolName: "bar", parsable: F())
-    XCTAssertEqual(help.synopsis(), "bar [--name <name> ...] [<name-counts> ...]")
+    _testSynopsis(F.self, expected: "example [--name <name> ...] [<name-counts> ...]")
   }
 
   struct G: ParsableArguments {
@@ -101,8 +106,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithCustomization() {
-    let help = UsageGenerator(toolName: "bar", parsable: G())
-    XCTAssertEqual(help.synopsis(), "bar [--file-path <path>] <user-home-path>")
+    _testSynopsis(G.self, expected: "example [--file-path <path>] <user-home-path>")
   }
 
   struct H: ParsableArguments {
@@ -111,9 +115,8 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithHidden() {
-    let help = UsageGenerator(toolName: "bar", parsable: H())
-    XCTAssertEqual(help.synopsis(), "bar")
-    XCTAssertEqual(help.synopsis(visibility: .hidden), "bar [--first-name <first-name>] [<title>]")
+    _testSynopsis(H.self, expected: "example")
+    _testSynopsis(H.self, visibility: .hidden, expected: "example [--first-name <first-name>] [<title>]")
   }
 
   struct I: ParsableArguments {
@@ -136,8 +139,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithDefaultValueAndTransform() {
-    let help = UsageGenerator(toolName: "bar", parsable: I())
-    XCTAssertEqual(help.synopsis(), "bar [--color <color>]")
+    _testSynopsis(I.self, expected: "example [--color <color>]")
   }
 
   struct J: ParsableArguments {
@@ -147,8 +149,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithTransform() {
-    let help = UsageGenerator(toolName: "bar", parsable: J())
-    XCTAssertEqual(help.synopsis(), "bar --req <req> [--opt <opt>]")
+    _testSynopsis(J.self, expected: "example --req <req> [--opt <opt>]")
   }
 
   struct K: ParsableArguments {
@@ -159,8 +160,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithMultipleCustomNames() {
-    let help = UsageGenerator(toolName: "bar", parsable: K())
-    XCTAssertEqual(help.synopsis(), "bar [--remote <remote>]")
+    _testSynopsis(K.self, expected: "example [--remote <remote>]")
   }
 
   struct L: ParsableArguments {
@@ -171,8 +171,7 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithSingleDashLongNameFirst() {
-    let help = UsageGenerator(toolName: "bar", parsable: L())
-    XCTAssertEqual(help.synopsis(), "bar [-remote <remote>]")
+    _testSynopsis(L.self, expected: "example [-remote <remote>]")
   }
 
   struct M: ParsableArguments {
@@ -194,8 +193,6 @@ extension UsageGenerationTests {
   }
 
   func testSynopsisWithTooManyOptions() {
-    let help = UsageGenerator(toolName: "foo", parsable: M())
-    XCTAssertEqual(help.synopsis(),
-                   "foo [<options>] --option <option> <input> [<output>]")
+    _testSynopsis(M.self, expected: "example [<options>] --option <option> <input> [<output>]")
   }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -195,4 +195,16 @@ extension UsageGenerationTests {
   func testSynopsisWithTooManyOptions() {
     _testSynopsis(M.self, expected: "example [<options>] --option <option> <input> [<output>]")
   }
+  
+  struct N: ParsableArguments {
+    @Flag var a: Bool = false
+    @Flag var b: Bool = false
+    var title = "defaulted value"
+    var decode = false
+  }
+  
+  func testNonwrappedValues() {
+    _testSynopsis(N.self, expected: "example [--a] [--b]")
+    _testSynopsis(N.self, visibility: .hidden, expected: "example [--a] [--b]")
+  }
 }


### PR DESCRIPTION
This includes arguments, options, and flags that have `.hidden` visibility when a user requests the extended version of help with `--help-hidden`. Previously, only hidden option groups were included.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
