### PR TITLE
Exclude XCTExpectFailure test on all non-Darwin platforms

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -72,7 +72,7 @@ extension HelpGenerationTests {
 
             """)
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android) && !os(Windows)
     XCTExpectFailure("""
             The following test fails to properly generate the help-hidden
             message properly because help-hidden is not fully supported yet.


### PR DESCRIPTION
as there is no `XCTExpectFailure` in the OSS XCTest, which all these non-Darwin platforms rely on. #405 just [broke my daily Android CI](https://github.com/buttaface/swift-android-sdk/runs/5197310606?check_suite_focus=true#step:9:71) because these other platforms weren't excluded alongside linux, showing this error:
```
Tests/ArgumentParserUnitTests/HelpGenerationTests.swift:76:5: error: cannot find 'XCTExpectFailure' in scope
```
Tried it locally on my Android phone and this addition gets it building again.

@compnerd, I figured this breaks on Windows too, so went ahead and added it also.