### PR TITLE
Hide optional flags when a command has too many options

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -209,7 +209,14 @@ extension Flag where Value == Optional<Bool> {
     help: ArgumentHelp? = nil
   ) {
     self.init(_parsedValue: .init { key in
-      .flag(key: key, name: name, default: nil, inversion: inversion, exclusivity: exclusivity, help: help)
+      .flag(
+        key: key,
+        name: name,
+        default: nil,
+        required: false,
+        inversion: inversion,
+        exclusivity: exclusivity,
+        help: help)
     })
   }
 }
@@ -257,7 +264,14 @@ extension Flag where Value == Bool {
     help: ArgumentHelp?
   ) {
     self.init(_parsedValue: .init { key in
-      .flag(key: key, name: name, default: initial, inversion: inversion, exclusivity: exclusivity, help: help)
+      .flag(
+        key: key,
+        name: name,
+        default: initial,
+        required: initial == nil,
+        inversion: inversion,
+        exclusivity: exclusivity,
+        help: help)
       })
   }
 

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -115,7 +115,6 @@ extension ArgumentSet {
     exclusivity: FlagExclusivity,
     help: ArgumentHelp?) -> ArgumentSet
   {
-    // The flag is required if initialValue is `nil`, otherwise it's optional
     let helpOptions: ArgumentDefinition.Help.Options = required ? [] : .isOptional
     
     let enableHelp = ArgumentDefinition.Help(options: helpOptions, help: help, defaultValue: initialValue.map(String.init), key: key, isComposite: true)

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -106,9 +106,17 @@ extension ArgumentSet {
   }
   
   /// Creates an argument set for a pair of inverted Boolean flags.
-  static func flag(key: InputKey, name: NameSpecification, default initialValue: Bool?, inversion: FlagInversion, exclusivity: FlagExclusivity, help: ArgumentHelp?) -> ArgumentSet {
+  static func flag(
+    key: InputKey,
+    name: NameSpecification,
+    default initialValue: Bool?,
+    required: Bool,
+    inversion: FlagInversion,
+    exclusivity: FlagExclusivity,
+    help: ArgumentHelp?) -> ArgumentSet
+  {
     // The flag is required if initialValue is `nil`, otherwise it's optional
-    let helpOptions: ArgumentDefinition.Help.Options = initialValue != nil ? .isOptional : []
+    let helpOptions: ArgumentDefinition.Help.Options = required ? [] : .isOptional
     
     let enableHelp = ArgumentDefinition.Help(options: helpOptions, help: help, defaultValue: initialValue.map(String.init), key: key, isComposite: true)
     let disableHelp = ArgumentDefinition.Help(options: [.isOptional], help: help, key: key)

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -175,6 +175,10 @@ extension UsageGenerationTests {
   }
 
   struct M: ParsableArguments {
+    enum Color: String, EnumerableFlag {
+      case green, blue, yellow
+    }
+    
     @Flag var a: Bool = false
     @Flag var b: Bool = false
     @Flag var c: Bool = false
@@ -189,7 +193,9 @@ extension UsageGenerationTests {
     @Flag var l: Bool = false
     
     @Flag(inversion: .prefixedEnableDisable)
-    var m: Bool?
+    var optionalBool: Bool?
+    
+    @Flag var optionalColor: Color?
     
     @Option var option: Bool
     @Argument var input: String

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -187,6 +187,10 @@ extension UsageGenerationTests {
     @Flag var j: Bool = false
     @Flag var k: Bool = false
     @Flag var l: Bool = false
+    
+    @Flag(inversion: .prefixedEnableDisable)
+    var m: Bool?
+    
     @Option var option: Bool
     @Argument var input: String
     @Argument var output: String?


### PR DESCRIPTION
The usage string feature that only shows positional args and required options/flags was incorrectly allowing through flags with type `Bool?`. For example, `--enable-foo` was incorrectly visible in the usage string for this type:

```swift
struct Example: ParsableCommand {
    // so many options
    // too many options

    @Flag(inversion: .prefixedEnableDisable)
    var foo: Bool?
}
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
