### PR TITLE
Don't trigger help for commands w/ unconditional remaining

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -73,9 +73,19 @@ extension CommandParser {
     return subcommandNode
   }
   
-  /// Throws a `HelpRequested` error if the user has specified either of the
-  /// built in help flags.
-  func checkForBuiltInFlags(_ split: SplitArguments) throws {
+  /// Throws a `HelpRequested` error if the user has specified any of the
+  /// built-in flags.
+  ///
+  /// - Parameters:
+  ///   - split: The remaining arguments to examine.
+  ///   - requireSoloArgument: `true` if the built-in flag must be the only
+  ///     one remaining for this to catch it.
+  func checkForBuiltInFlags(
+    _ split: SplitArguments,
+    requireSoloArgument: Bool = false
+  ) throws {
+    guard !requireSoloArgument || split.count == 1 else { return }
+    
     // Look for help flags
     guard !split.contains(anyOf: self.commandStack.getHelpNames(visibility: .default)) else {
       throw HelpRequested(visibility: .default)
@@ -187,7 +197,7 @@ extension CommandParser {
       }
       
       // Look for the help flag before falling back to a default command.
-      try checkForBuiltInFlags(split)
+      try checkForBuiltInFlags(split, requireSoloArgument: true)
       
       // No command was found, so fall back to the default subcommand.
       if let defaultSubcommand = currentNode.element.configuration.defaultSubcommand {

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -180,6 +180,10 @@ struct SplitArguments {
   var elements: ArraySlice<Element> {
     _elements[firstUnused...]
   }
+  
+  var count: Int {
+    elements.count
+  }
 }
 
 extension SplitArguments.Element: CustomDebugStringConvertible {

--- a/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
@@ -123,6 +123,11 @@ extension DefaultSubcommandEndToEndTests {
       XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
       XCTAssertEqual(plugin.options.verbose, true)
     }
+    AssertParseCommand(MyCommand.self, Plugin.self, ["my-plugin", "--help"]) { plugin in
+      XCTAssertEqual(plugin.pluginName, "my-plugin")
+      XCTAssertEqual(plugin.pluginArguments, ["--help"])
+      XCTAssertEqual(plugin.options.verbose, false)
+    }
   }
 
   func testRemainingDefaultExplicit() throws {
@@ -141,6 +146,11 @@ extension DefaultSubcommandEndToEndTests {
       XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
       XCTAssertEqual(plugin.options.verbose, true)
     }
+    AssertParseCommand(MyCommand.self, Plugin.self, ["--verbose", "plugin", "my-plugin", "--help"]) { plugin in
+      XCTAssertEqual(plugin.pluginName, "my-plugin")
+      XCTAssertEqual(plugin.pluginArguments, ["--help"])
+      XCTAssertEqual(plugin.options.verbose, true)
+    }
   }
 
   func testRemainingNonDefault() throws {
@@ -157,6 +167,11 @@ extension DefaultSubcommandEndToEndTests {
     AssertParseCommand(MyCommand.self, NonDefault.self, ["--verbose", "non-default", "my-plugin", "--verbose"]) { nondef in
       XCTAssertEqual(nondef.pluginName, "my-plugin")
       XCTAssertEqual(nondef.pluginArguments, ["--verbose"])
+      XCTAssertEqual(nondef.options.verbose, true)
+    }
+    AssertParseCommand(MyCommand.self, NonDefault.self, ["--verbose", "non-default", "my-plugin", "--help"]) { nondef in
+      XCTAssertEqual(nondef.pluginName, "my-plugin")
+      XCTAssertEqual(nondef.pluginArguments, ["--help"])
       XCTAssertEqual(nondef.options.verbose, true)
     }
   }


### PR DESCRIPTION
Previously, a `--help` flag could trigger the help screen when it should have been part of the parsed input for a command with an `.unconditionalRemaining` array parsing strategy.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary