### PR TITLE
Fix a typo and template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,5 @@ Replace this paragraph with a description of your changes and rationale. Provide
 ### Checklist
 - [ ] I've added at least one test that validates that my change is working, if appropriate
 - [ ] I've followed the code style of the rest of the project
-- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
 - [ ] I've updated the documentation if necessary

--- a/.github/PULL_REQUEST_TEMPLATE/NEW.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW.md
@@ -32,5 +32,5 @@ What is the impact of this change on existing users? Does it deprecate or remove
 ### Checklist
 - [ ] I've added at least one test that validates that my change is working, if appropriate
 - [ ] I've followed the code style of the rest of the project
-- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
+- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
 - [ ] I've updated the documentation if necessary

--- a/Sources/ArgumentParser/Parsable Properties/Errors.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Errors.swift
@@ -43,7 +43,7 @@ public struct ValidationError: Error, CustomStringConvertible {
 
 /// An error type that only includes an exit code.
 ///
-/// If you're printing custom errors messages yourself, you can throw this error
+/// If you're printing custom error messages yourself, you can throw this error
 /// to specify the exit code without adding any additional output to standard
 /// out or standard error.
 public struct ExitCode: Error, RawRepresentable, Hashable {


### PR DESCRIPTION
I found a typo and realized some links were not working in the PR template.

No real code was harmed during the production of this PR. 😅 

### Checklist
- ~~I've added at least one test that validates that my change is working, if appropriate~~
- ~~I've followed the code style of the rest of the project~~
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md) 👈
- [x] I've updated the documentation if necessary
