### PR TITLE
Make `@OptionGroup(visibility:)` a public API

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -61,11 +61,13 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
     }
   }
 
-  /// Creates a property that represents another parsable type.
-  public init() {
+  /// Creates a property that represents another parsable type, using the
+  /// specified visibility.
+  public init(visibility: ArgumentVisibility = .default) {
     self.init(_parsedValue: .init { _ in
       ArgumentSet(Value.self, visibility: .private)
     })
+    self._visibility = visibility
   }
 
   /// The value presented by this property wrapper.
@@ -97,14 +99,15 @@ extension OptionGroup: CustomStringConvertible {
 
 // Experimental use with caution
 extension OptionGroup {
-  @available(*, deprecated, message: "Use init(_visibility:) instead.")
+  @available(*, deprecated, renamed: "init(visibility:)")
   public init(_hiddenFromHelp: Bool) {
-    self.init()
-    self._visibility = .hidden
+    self.init(visibility: .hidden)
   }
-
-  public init(_visibility: ArgumentVisibility) {
-    self.init()
-    self._visibility = _visibility
+  
+  /// Creates a property that represents another parsable type.
+  @available(*, deprecated, renamed: "init(visibility:)")
+  @_disfavoredOverload
+  public init() {
+    self.init(visibility: .default)
   }
 }


### PR DESCRIPTION
### Description
This removes the underscore from the parameter in `@OptionGroup(visibility:)`, making it a fully public API. This allows users to set the visibility for an entire option group at once.

### Detailed Design
This adds a single initializer to the `OptionGroup` type.

```swift
extension OptionGroup {
    init(visibility: ArgumentVisibility)
}
```

### Documentation Plan
Symbol documentation included.

### Test Plan
Updated tests for generating help.

### Source Impact
This deprecates, but doesn't remove, the no argument `OptionGroup` initializer.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
