### PR TITLE
build: repair the build after #404

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(math
-  math/main.swift)
+  math/Math.swift)
 target_link_libraries(math PRIVATE
   ArgumentParser
   $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:m>)
 
 add_executable(repeat
-  repeat/main.swift)
+  repeat/Repeat.swift)
 target_link_libraries(repeat PRIVATE
   ArgumentParser)
 


### PR DESCRIPTION
This fixes the build with CMake after #404.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
