### PR TITLE
build: statically link ArgumentParserToolInfo always

### DIFF
--- a/Sources/ArgumentParserToolInfo/CMakeLists.txt
+++ b/Sources/ArgumentParserToolInfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(ArgumentParserToolInfo
+add_library(ArgumentParserToolInfo STATIC
   ToolInfo.swift)
 # NOTE: workaround for CMake not setting up include flags yet
 set_target_properties(ArgumentParserToolInfo PROPERTIES
@@ -7,5 +7,4 @@ target_compile_options(ArgumentParserToolInfo PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 
 
-_install_target(ArgumentParserToolInfo)
 set_property(GLOBAL APPEND PROPERTY ArgumentParser_EXPORTS ArgumentParserToolInfo)


### PR DESCRIPTION
Now that windows supports static linking as well (to a certain degree),
alter the build of swift-argument-parser in CMake to use static linking
for ArgumentParserToolInfo always irrespective of whether ArgumentParser
is being built as a static library or a dynamic library.  On Windows, in
release mode, this saves ~32KiB.  Additionally, because no tool directly
links against this library, no binaries are further expanded by static
linking, and we have one less file to distribute.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
