### PR TITLE
Remove platform requirement from Package.swift

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -13,6 +13,7 @@ import ArgumentParser
 import Foundation
 
 @main
+@available(macOS 10.15, *)
 struct CountLines: AsyncParsableCommand {
     @Argument(
         help: "A file to count lines in. If omitted, counts the lines of stdin.",
@@ -26,6 +27,7 @@ struct CountLines: AsyncParsableCommand {
     var verbose = false
 }
 
+@available(macOS 10.15, *)
 extension CountLines {
     var fileHandle: FileHandle {
         get throws {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,6 @@ import PackageDescription
 
 var package = Package(
     name: "swift-argument-parser",
-    platforms: [.macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(
             name: "ArgumentParser",

--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -11,6 +11,7 @@
 
 /// A type that can be executed asynchronously, as part of a nested tree of
 /// commands.
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncParsableCommand: ParsableCommand {
   /// The behavior or functionality of this command.
   ///
@@ -22,6 +23,7 @@ public protocol AsyncParsableCommand: ParsableCommand {
   mutating func run() async throws
 }
 
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncParsableCommand {
   /// Executes this command, or one of its subcommands, with the program's
   /// command-line arguments.
@@ -54,6 +56,7 @@ public protocol AsyncMainProtocol {
 }
 
 @available(swift, deprecated: 5.6)
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncMainProtocol {
   /// Executes the designated command type, or one of its subcommands, with
   /// the program's command-line arguments.


### PR DESCRIPTION
Adding the platform requirement is a source breaking change; this moves the requirement down to the `async` symbols instead.

Fixes #426.