### PR TITLE
Replace `AsyncParsableCommand.main` protocol extension

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -24,7 +24,7 @@ public protocol AsyncParsableCommand: ParsableCommand {
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-extension AsyncParsableCommand {
+extension ParsableCommand where Self : AsyncParsableCommand {
   /// Executes this command, or one of its subcommands, with the program's
   /// command-line arguments.
   ///


### PR DESCRIPTION
Building an executable project using `AsyncParsableCommand` with the Swift development branch toolchain broke some time after the 02-25-22a snapshot. No compile-time errors show, but an executable built with the 03-13-22 or 03-22-22 trunk toolchain ignores any provided arguments, prints the list of argument subcommands, and exits.

This seems to be a bug in the compiler, which now prefers the `ParsableCommand.main()` type method to the `AsyncParsableCommand.main()` override.

I've found replacing `AsyncParsableCommand.main()` with one defined on `ParsableCommand` with an `AsyncParsableCommand` self-requirement restores the original behavior without breaking source-compatibility for Swift 5.6 (and presumably earlier versions as well). I am unsure of any ABI implications arising from this change.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
