### PR TITLE
update README to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ let package = Package(
     // name, platforms, products, etc.
     dependencies: [
         // other dependencies
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.1"),
     ],
     targets: [
         .executableTarget(name: "<command-line-tool>", dependencies: [


### PR DESCRIPTION
Changed `1.0.0` to `1.1.1` in the "Adding `ArgumentParser` as a Dependency" section or the README


### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate // Not relevant
- [ ] I've followed the code style of the rest of the project // Not relevant
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
