### PR TITLE
Fix Repeat's endless printing

### DIFF
--- a/Examples/repeat/Repeat.swift
+++ b/Examples/repeat/Repeat.swift
@@ -23,7 +23,7 @@ struct Repeat: ParsableCommand {
     var phrase: String
 
     mutating func run() throws {
-        let repeatCount = count ?? .max
+        let repeatCount = count ?? 2
 
         for i in 1...repeatCount {
             if includeCounter {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ struct Repeat: ParsableCommand {
     var phrase: String
 
     mutating func run() throws {
-        let repeatCount = count ?? .max
+        let repeatCount = count ?? 2
 
         for i in 1...repeatCount {
             if includeCounter {

--- a/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
+++ b/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
@@ -24,7 +24,7 @@ struct Repeat: ParsableCommand {
     var count: Int?
 
     mutating func run() throws {
-        let repeatCount = count ?? .max
+        let repeatCount = count ?? 2
         for _ in 0..<repeatCount {
             print(phrase)
         }

--- a/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
@@ -25,7 +25,7 @@ struct Repeat: ParsableCommand {
     var count: Int?
 
     mutating func run() throws {
-        for _ in 0..<(count ?? Int.max) {
+        for _ in 0..<(count ?? 2) {
             print(phrase) 
         }
     }

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md
@@ -12,7 +12,7 @@ struct Repeat: ParsableCommand {
     var count: Int?
 
     mutating func run() throws {
-        let repeatCount = count ?? .max
+        let repeatCount = count ?? 2
         for _ in 0..<repeatCount {
             print(phrase)
         }

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -14,6 +14,20 @@ import ArgumentParserTestHelpers
 
 final class RepeatExampleTests: XCTestCase {
   func testRepeat() throws {
+    try AssertExecuteCommand(command: "repeat hello", expected: """
+        hello
+        hello
+        """)
+  }
+  
+  func testRepeat_include_counter() throws {
+    try AssertExecuteCommand(command: "repeat --include-counter hello", expected: """
+      1: hello
+      2: hello
+      """)
+  }
+  
+  func testRepeat_Count() throws {
     try AssertExecuteCommand(command: "repeat hello --count 6", expected: """
         hello
         hello


### PR DESCRIPTION
To prevent newbies from being scared off by endless printing in the terminal, I changed the default value of `Repeat.count` from `.max` to `2`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
