### PR TITLE
Remove extra newline

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -229,7 +229,7 @@ internal struct HelpGenerator {
       .joined(separator: "\n")
     let renderedAbstract = abstract.isEmpty
       ? ""
-      : "OVERVIEW: \(abstract)".wrapped(to: screenWidth) + "\n\n"
+      : "OVERVIEW: \(abstract)".wrapped(to: screenWidth) + "\n"
     
     var helpSubcommandMessage = ""
     if includesSubcommands {
@@ -247,7 +247,7 @@ internal struct HelpGenerator {
     
     let renderedUsage = usage.isEmpty
       ? ""
-      : "USAGE: \(usage.hangingIndentingEachLine(by: 7))\n\n"
+      : "USAGE: \(usage.hangingIndentingEachLine(by: 7))\n"
     
     return """
     \(renderedAbstract)\


### PR DESCRIPTION
I've replaced the double newline "\n\n" with only one newline "\n".
The CLI apps like the Terminal app are most of the time opened in a small window and do not take the full size of the screen, so each line is important to be inside the window frame and it's a better UX to view it without scrolling down. Removing these two new lines gives you extra two lines to view more information without scrolling.
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
