### PR TITLE
Hide hidden subcommands from completions

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -35,6 +35,7 @@ struct BashCompletionsGenerator {
   
     // Include 'help' in the list of subcommands for the root command.
     var subcommands = type.configuration.subcommands
+      .filter { $0.configuration.shouldDisplay }
     if !subcommands.isEmpty && isRootCommand {
       subcommands.append(HelpCommand.self)
     }

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -30,6 +30,7 @@ struct FishCompletionsGenerator {
     let isRootCommand = commands.count == 1
     let programName = commandChain[0]
     var subcommands = type.configuration.subcommands
+      .filter { $0.configuration.shouldDisplay }
 
     if !subcommands.isEmpty {
       if isRootCommand {

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -37,6 +37,7 @@ struct ZshCompletionsGenerator {
     
     var args = generateCompletionArguments(commands)    
     var subcommands = type.configuration.subcommands
+      .filter { $0.configuration.shouldDisplay }
     var subcommandHandler = ""
     if !subcommands.isEmpty {
       args.append("'(-): :->command'")


### PR DESCRIPTION
- Adds a filter to prevent hidden subcommands from appearing in shell
  completion scripts.

Fixes #442, rdar://92182881
