### PR TITLE
fix: 🐛 Declare `GenerateManualPlugin` as plugin product

### DIFF
--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -18,6 +18,9 @@ var package = Package(
         .library(
             name: "ArgumentParser",
             targets: ["ArgumentParser"]),
+        .plugin(
+            name: "GenerateManualPlugin",
+            targets: ["GenerateManualPlugin"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
✅ Closes: #455

`ArgumentParser` 1.1.3 includes a SwiftPM plugin for generating man pages. However, this plugin is not visible to packages that declare `ArgumentParser` as a package dependency.

Defining a product of type `plugin` in the package manifest will solve that. Running `swift package plugin --list` for a package, that declares `ArgumentParser` as a package dependency, will then list the `GenerateManualPlugin`

```
‘experimental-generate-manual’ (plugin ‘GenerateManualPlugin’ in package ‘swift-argument-parser’)
```

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
