### PR TITLE
Fix generate-manual plugin authors argument

### DIFF
--- a/Plugins/GenerateManualPlugin/GenerateManualPlugin.swift
+++ b/Plugins/GenerateManualPlugin/GenerateManualPlugin.swift
@@ -85,7 +85,7 @@ struct GenerateManualPlugin: CommandPlugin {
         outputDirectory.string
       ]
       generationToolArguments.append(
-        contentsOf: extractor.unextractedOptionsOrFlags)
+        contentsOf: extractor.remainingArguments)
 
       // Spawn generation tool.
       try generationToolFile.exec(arguments: generationToolArguments)

--- a/Plugins/GenerateManualPlugin/GenerateManualPluginError.swift
+++ b/Plugins/GenerateManualPlugin/GenerateManualPluginError.swift
@@ -46,5 +46,5 @@ extension GenerateManualPluginError: CustomStringConvertible {
 }
 
 extension GenerateManualPluginError: LocalizedError {
-  var localizedDescription: String { self.description }
+  var errorDescription: String? { self.description }
 }

--- a/Tests/ArgumentParserGenerateManualTests/CountLinesGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/CountLinesGenerateManualTests.swift
@@ -48,6 +48,7 @@ final class CountLinesGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -89,6 +90,7 @@ final class CountLinesGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao

--- a/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
@@ -110,6 +110,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -150,6 +151,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -186,6 +188,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -222,6 +225,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -257,6 +261,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -293,6 +298,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -326,6 +332,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -379,6 +386,7 @@ final class MathGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao

--- a/Tests/ArgumentParserGenerateManualTests/RepeatGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/RepeatGenerateManualTests.swift
@@ -45,6 +45,7 @@ final class RepeatGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -85,6 +86,7 @@ final class RepeatGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao

--- a/Tests/ArgumentParserGenerateManualTests/RollDiceGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/RollDiceGenerateManualTests.swift
@@ -50,6 +50,7 @@ final class RollDiceGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao
@@ -95,6 +96,7 @@ final class RollDiceGenerateManualTests: XCTestCase {
       .An -nosplit
       .An "Jane Appleseed" ,
       .Mt johnappleseed@apple.com ,
+      and
       .An -nosplit
       .An "The Appleseeds"
       .Ao

--- a/Tools/generate-manual/DSL/Authors.swift
+++ b/Tools/generate-manual/DSL/Authors.swift
@@ -21,8 +21,26 @@ struct Authors: MDocComponent {
         "The"
         MDocMacro.DocumentName()
         "reference was written by"
-        ForEach(authors) { author, last in
-          Author(author: author, trailing: last ? "." : ",")
+        ForEach(authors) { author, index in
+          switch index {
+          case authors.count - 2 where authors.count > 2:
+            Author(
+              author: author,
+              trailing: ",")
+            "and"
+          case authors.count - 2:
+            Author(
+              author: author,
+              trailing: "and")
+          case authors.count - 1:
+            Author(
+              author: author,
+              trailing: ".")
+          default:
+            Author(
+              author: author,
+              trailing: ",")
+          }
         }
       }
     }

--- a/Tools/generate-manual/DSL/Core/ForEach.swift
+++ b/Tools/generate-manual/DSL/Core/ForEach.swift
@@ -11,9 +11,9 @@
 
 struct ForEach<C>: MDocComponent where C: Collection {
   var items: C
-  var builder: (C.Element, Bool) -> MDocComponent
+  var builder: (C.Element, C.Index) -> MDocComponent
 
-  init(_ items: C, @MDocBuilder builder: @escaping (C.Element, Bool) -> MDocComponent) {
+  init(_ items: C, @MDocBuilder builder: @escaping (C.Element, C.Index) -> MDocComponent) {
     self.items = items
     self.builder = builder
   }
@@ -21,14 +21,12 @@ struct ForEach<C>: MDocComponent where C: Collection {
   var body: MDocComponent {
     guard !items.isEmpty else { return Empty() }
     var currentIndex = items.startIndex
-    var last = false
     var components = [MDocComponent]()
-    repeat {
+    while currentIndex < items.endIndex {
       let item = items[currentIndex]
+      components.append(builder(item, currentIndex))
       currentIndex = items.index(after: currentIndex)
-      last = currentIndex == items.endIndex
-      components.append(builder(item, last))
-    } while !last
+    }
     return Container(children: components)
   }
 }

--- a/Tools/generate-manual/DSL/SeeAlso.swift
+++ b/Tools/generate-manual/DSL/SeeAlso.swift
@@ -23,9 +23,10 @@ struct SeeAlso: MDocComponent {
 
   var body: MDocComponent {
     Section(title: "see also") {
-      ForEach(references) { reference, isLast in
+      ForEach(references) { reference, index in
         MDocMacro.CrossManualReference(title: reference, section: section)
-          .withUnsafeChildren(nodes: isLast ? [] : [","])
+          .withUnsafeChildren(
+            nodes: index == references.count - 1 ? [] : [","])
       }
     }
   }


### PR DESCRIPTION
- Fixes an issue where the --author option without its value  was passed
  by the generate-manual plugin to the generate-manual tool resulting in
  plugin invocation failures or incorrect author information.