### PR TITLE
Fix missing option value names in manuals

### DIFF
--- a/Tests/ArgumentParserGenerateManualTests/CountLinesGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/CountLinesGenerateManualTests.swift
@@ -27,9 +27,9 @@ final class CountLinesGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Ar input-file
-      .Op Fl -prefix
-      .Op Fl -verbose Ar verbose
-      .Fl -help Ar help
+      .Op Fl -prefix Ar prefix
+      .Op Fl -verbose
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Ar input-file
@@ -69,9 +69,9 @@ final class CountLinesGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Ar input-file
-      .Op Fl -prefix
-      .Op Fl -verbose Ar verbose
-      .Fl -help Ar help
+      .Op Fl -prefix Ar prefix
+      .Op Fl -verbose
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Ar input-file

--- a/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
@@ -26,8 +26,8 @@ final class MathGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Ar subcommand
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -version
@@ -131,8 +131,8 @@ final class MathGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Ar subcommand
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -version
@@ -166,10 +166,10 @@ final class MathGenerateManualTests: XCTestCase {
       .Nd "Print the sum of the values."
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -hex-output Ar hex-output
+      .Op Fl -hex-output
       .Op Ar values...
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl x , -hex-output
@@ -203,10 +203,10 @@ final class MathGenerateManualTests: XCTestCase {
       .Nd "Print the product of the values."
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -hex-output Ar hex-output
+      .Op Fl -hex-output
       .Op Ar values...
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl x , -hex-output
@@ -241,8 +241,8 @@ final class MathGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Ar subcommand
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -version
@@ -276,10 +276,10 @@ final class MathGenerateManualTests: XCTestCase {
       .Nd "Print the average of the values."
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -kind
+      .Op Fl -kind Ar kind
       .Op Ar values...
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -kind Ar kind
@@ -314,8 +314,8 @@ final class MathGenerateManualTests: XCTestCase {
       .Sh SYNOPSIS
       .Nm
       .Op Ar values...
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Ar values...
@@ -350,16 +350,16 @@ final class MathGenerateManualTests: XCTestCase {
       .Op Ar one-of-four
       .Op Ar custom-arg
       .Op Ar values...
-      .Op Fl -test-success-exit-code Ar test-success-exit-code
-      .Op Fl -test-failure-exit-code Ar test-failure-exit-code
-      .Op Fl -test-validation-exit-code Ar test-validation-exit-code
-      .Op Fl -test-custom-exit-code
-      .Op Fl -file
-      .Op Fl -directory
-      .Op Fl -shell
-      .Op Fl -custom
-      .Fl -version Ar version
-      .Fl -help Ar help
+      .Op Fl -test-success-exit-code
+      .Op Fl -test-failure-exit-code
+      .Op Fl -test-validation-exit-code
+      .Op Fl -test-custom-exit-code Ar test-custom-exit-code
+      .Op Fl -file Ar file
+      .Op Fl -directory Ar directory
+      .Op Fl -shell Ar shell
+      .Op Fl -custom Ar custom
+      .Fl -version
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Ar one-of-four

--- a/Tests/ArgumentParserGenerateManualTests/RepeatGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/RepeatGenerateManualTests.swift
@@ -23,10 +23,10 @@ final class RepeatGenerateManualTests: XCTestCase {
       .Nm repeat
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -count
-      .Op Fl -include-counter Ar include-counter
+      .Op Fl -count Ar count
+      .Op Fl -include-counter
       .Ar phrase
-      .Fl -help Ar help
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -count Ar count
@@ -64,10 +64,10 @@ final class RepeatGenerateManualTests: XCTestCase {
       .Nm repeat
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -count
-      .Op Fl -include-counter Ar include-counter
+      .Op Fl -count Ar count
+      .Op Fl -include-counter
       .Ar phrase
-      .Fl -help Ar help
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -count Ar count

--- a/Tests/ArgumentParserGenerateManualTests/RollDiceGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/RollDiceGenerateManualTests.swift
@@ -23,11 +23,11 @@ final class RollDiceGenerateManualTests: XCTestCase {
       .Nm roll
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -times
-      .Op Fl -sides
-      .Op Fl -seed
-      .Op Fl -verbose Ar verbose
-      .Fl -help Ar help
+      .Op Fl -times Ar n
+      .Op Fl -sides Ar m
+      .Op Fl -seed Ar seed
+      .Op Fl -verbose
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -times Ar n
@@ -69,11 +69,11 @@ final class RollDiceGenerateManualTests: XCTestCase {
       .Nm roll
       .Sh SYNOPSIS
       .Nm
-      .Op Fl -times
-      .Op Fl -sides
-      .Op Fl -seed
-      .Op Fl -verbose Ar verbose
-      .Fl -help Ar help
+      .Op Fl -times Ar n
+      .Op Fl -sides Ar m
+      .Op Fl -seed Ar seed
+      .Op Fl -verbose
+      .Fl -help
       .Sh DESCRIPTION
       .Bl -tag -width 6n
       .It Fl -times Ar n

--- a/Tools/generate-manual/DSL/ArgumentSynopsis.swift
+++ b/Tools/generate-manual/DSL/ArgumentSynopsis.swift
@@ -32,11 +32,11 @@ struct ArgumentSynopsis: MDocComponent {
       // preferredName cannot be nil
       let name = argument.preferredName!
       return MDocMacro.CommandOption(options: [name.manualPage])
+        .withUnsafeChildren(nodes: [argument.manualPageValueName])
     case .flag:
       // preferredName cannot be nil
       let name = argument.preferredName!
       return MDocMacro.CommandOption(options: [name.manualPage])
-        .withUnsafeChildren(nodes: [argument.manualPageValueName])
     }
   }
 }


### PR DESCRIPTION
- Fixes a manual generation bug where options in the synopsis were not
  given an option value name and flags were.
