### PR TITLE
IDEA: Supplemental discussion

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift
@@ -16,7 +16,11 @@ public struct ArgumentHelp {
   
   /// An expanded description of the argument, in plain text form.
   public var discussion: String = ""
-  
+
+  /// Additional description of the argument for supplemental content, in plain
+  /// text form.
+  public var supplementalDiscussion: String = ""
+
   /// An alternative name to use for the argument's value when showing usage
   /// information.
   ///
@@ -28,41 +32,17 @@ public struct ArgumentHelp {
   /// the extended help display.
   public var visibility: ArgumentVisibility = .default
 
-  /// A Boolean value indicating whether this argument should be shown in
-  /// the extended help display.
-  @available(*, deprecated, message: "Use visibility level instead.")
-  public var shouldDisplay: Bool {
-    get {
-      return visibility.base == .default
-    }
-    set {
-      visibility = newValue ? .default : .hidden
-    }
-  }
-  
-  /// Creates a new help instance.
-  @available(*, deprecated, message: "Use init(_:discussion:valueName:visibility:) instead.")
-  public init(
-    _ abstract: String = "",
-    discussion: String = "",
-    valueName: String? = nil,
-    shouldDisplay: Bool)
-  {
-    self.abstract = abstract
-    self.discussion = discussion
-    self.valueName = valueName
-    self.shouldDisplay = shouldDisplay
-  }
-
   /// Creates a new help instance.
   public init(
     _ abstract: String = "",
     discussion: String = "",
+    supplementalDiscussion: String = "",
     valueName: String? = nil,
     visibility: ArgumentVisibility = .default)
   {
     self.abstract = abstract
     self.discussion = discussion
+    self.supplementalDiscussion = supplementalDiscussion
     self.valueName = valueName
     self.visibility = visibility
   }
@@ -81,5 +61,36 @@ public struct ArgumentHelp {
 extension ArgumentHelp: ExpressibleByStringInterpolation {
   public init(stringLiteral value: String) {
     self.abstract = value
+  }
+}
+
+// MARK: - Deprecated API
+extension ArgumentHelp {
+  /// A Boolean value indicating whether this argument should be shown in
+  /// the extended help display.
+  @available(*, deprecated, message: "Use visibility level instead.")
+  public var shouldDisplay: Bool {
+    get {
+      return visibility.base == .default
+    }
+    set {
+      visibility = newValue ? .default : .hidden
+    }
+  }
+
+  /// Creates a new help instance.
+  @available(*, deprecated, message: "Use init(_:discussion:supplementalDiscussion:valueName:visibility:) instead.")
+  public init(
+    _ abstract: String = "",
+    discussion: String = "",
+    valueName: String? = nil,
+    shouldDisplay: Bool)
+  {
+    self.init(
+      abstract,
+      discussion: discussion,
+      supplementalDiscussion: "",
+      valueName: valueName,
+      visibility: shouldDisplay ? .default : .hidden)
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -38,6 +38,10 @@ public struct CommandConfiguration {
   /// A longer description of this command, to be shown in the extended help
   /// display.
   public var discussion: String
+
+  /// Additional description of this command to be shown in supplemental content
+  /// such as manuals.
+  public var supplementalDiscussion: String
   
   /// Version information for this command.
   public var version: String
@@ -67,6 +71,8 @@ public struct CommandConfiguration {
   ///     automatically generating a usage description. Passing an empty string
   ///     hides the usage string altogether.
   ///   - discussion: A longer description of the command.
+  ///   - supplementalDiscussion: Additional description of the command for
+  ///     supplemental content.
   ///   - version: The version number for this command. When you provide a
   ///     non-empty string, the argument parser prints it if the user provides
   ///     a `--version` flag.
@@ -85,6 +91,7 @@ public struct CommandConfiguration {
     abstract: String = "",
     usage: String? = nil,
     discussion: String = "",
+    supplementalDiscussion: String = "",
     version: String = "",
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
@@ -95,6 +102,7 @@ public struct CommandConfiguration {
     self.abstract = abstract
     self.usage = usage
     self.discussion = discussion
+    self.supplementalDiscussion = supplementalDiscussion
     self.version = version
     self.shouldDisplay = shouldDisplay
     self.subcommands = subcommands
@@ -110,6 +118,7 @@ public struct CommandConfiguration {
     abstract: String = "",
     usage: String? = nil,
     discussion: String = "",
+    supplementalDiscussion: String = "",
     version: String = "",
     shouldDisplay: Bool = true,
     subcommands: [ParsableCommand.Type] = [],
@@ -121,6 +130,7 @@ public struct CommandConfiguration {
     self.abstract = abstract
     self.usage = usage
     self.discussion = discussion
+    self.supplementalDiscussion = ""
     self.version = version
     self.shouldDisplay = shouldDisplay
     self.subcommands = subcommands
@@ -130,7 +140,7 @@ public struct CommandConfiguration {
 }
 
 extension CommandConfiguration {
-  @available(*, deprecated, message: "Use the memberwise initializer with the usage parameter.")
+  @available(*, deprecated, message: "Use the member-wise initializer with the usage parameter.")
   public init(
     commandName: String?,
     abstract: String,
@@ -146,6 +156,32 @@ extension CommandConfiguration {
       abstract: abstract,
       usage: "",
       discussion: discussion,
+      supplementalDiscussion: "",
+      version: version,
+      shouldDisplay: shouldDisplay,
+      subcommands: subcommands,
+      defaultSubcommand: defaultSubcommand,
+      helpNames: helpNames)
+  }
+
+  @available(*, deprecated, message: "Use the member-wise initializer with the extendedDiscussion parameter.")
+  public init(
+    commandName: String?,
+    abstract: String,
+    usage: String,
+    discussion: String,
+    version: String,
+    shouldDisplay: Bool,
+    subcommands: [ParsableCommand.Type],
+    defaultSubcommand: ParsableCommand.Type?,
+    helpNames: NameSpecification?
+  ) {
+    self.init(
+      commandName: commandName,
+      abstract: abstract,
+      usage: usage,
+      discussion: discussion,
+      supplementalDiscussion: "",
       version: version,
       shouldDisplay: shouldDisplay,
       subcommands: subcommands,

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -43,6 +43,7 @@ struct ArgumentDefinition {
     // `ArgumentHelp` members
     var abstract: String = ""
     var discussion: String = ""
+    var supplementalDiscussion: String = ""
     var valueName: String = ""
     var visibility: ArgumentVisibility = .default
 
@@ -78,6 +79,7 @@ struct ArgumentDefinition {
     mutating func updateArgumentHelp(help: ArgumentHelp?) {
       self.abstract = help?.abstract ?? ""
       self.discussion = help?.discussion ?? ""
+      self.supplementalDiscussion = help?.supplementalDiscussion ?? ""
       self.valueName = help?.valueName ?? ""
       self.visibility = help?.visibility ?? .default
     }

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -114,6 +114,7 @@ fileprivate extension CommandInfoV0 {
       commandName: command._commandName,
       abstract: command.configuration.abstract,
       discussion: command.configuration.discussion,
+      supplementalDiscussion: command.configuration.supplementalDiscussion,
       defaultSubcommand: defaultSubcommand,
       subcommands: subcommands,
       arguments: arguments)
@@ -134,7 +135,8 @@ fileprivate extension ArgumentInfoV0 {
       defaultValue: argument.help.defaultValue,
       allValues: argument.help.allValues,
       abstract: argument.help.abstract,
-      discussion: argument.help.discussion)
+      discussion: argument.help.discussion,
+      supplementalDiscussion: argument.help.supplementalDiscussion)
   }
 }
 

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -51,6 +51,9 @@ public struct CommandInfoV0: Codable, Hashable {
   public var abstract: String?
   /// Extended description of the command's functionality.
   public var discussion: String?
+  /// Additional description of the command's functionality for supplemental
+  /// content.
+  public var supplementalDiscussion: String?
 
   /// Optional name of the subcommand invoked when the command is invoked with
   /// no arguments.
@@ -65,6 +68,7 @@ public struct CommandInfoV0: Codable, Hashable {
     commandName: String,
     abstract: String,
     discussion: String,
+    supplementalDiscussion: String,
     defaultSubcommand: String?,
     subcommands: [CommandInfoV0],
     arguments: [ArgumentInfoV0]
@@ -74,6 +78,7 @@ public struct CommandInfoV0: Codable, Hashable {
     self.commandName = commandName
     self.abstract = abstract.nonEmpty
     self.discussion = discussion.nonEmpty
+    self.supplementalDiscussion = supplementalDiscussion.nonEmpty
 
     self.defaultSubcommand = defaultSubcommand?.nonEmpty
     self.subcommands = subcommands.nonEmpty
@@ -143,6 +148,9 @@ public struct ArgumentInfoV0: Codable, Hashable {
   public var abstract: String?
   /// Extended description of the argument's functionality.
   public var discussion: String?
+  /// Additional description of the argument's functionality for supplemental
+  /// content.
+  public var supplementalDiscussion: String?
 
   public init(
     kind: KindV0,
@@ -155,7 +163,8 @@ public struct ArgumentInfoV0: Codable, Hashable {
     defaultValue: String?,
     allValues: [String]?,
     abstract: String?,
-    discussion: String?
+    discussion: String?,
+    supplementalDiscussion: String?
   ) {
     self.kind = kind
 
@@ -172,5 +181,6 @@ public struct ArgumentInfoV0: Codable, Hashable {
 
     self.abstract = abstract?.nonEmpty
     self.discussion = discussion?.nonEmpty
+    self.supplementalDiscussion = supplementalDiscussion?.nonEmpty
   }
 }

--- a/Tools/generate-manual/DSL/Description.swift
+++ b/Tools/generate-manual/DSL/Description.swift
@@ -12,7 +12,8 @@
 import ArgumentParser
 import ArgumentParserToolInfo
 
-struct SinglePageDescription: MDocComponent {
+struct Description: MDocComponent {
+  var multipage: Bool
   var command: CommandInfoV0
 
   var body: MDocComponent {
@@ -25,6 +26,14 @@ struct SinglePageDescription: MDocComponent {
   var core: MDocComponent {
     if let discussion = command.discussion {
       discussion
+    }
+
+    if command.discussion != nil, command.supplementalDiscussion != nil {
+      MDocMacro.ParagraphBreak()
+    }
+
+    if let supplementalDiscussion = command.supplementalDiscussion {
+      supplementalDiscussion
     }
 
     List {
@@ -42,11 +51,23 @@ struct SinglePageDescription: MDocComponent {
         if let discussion = argument.discussion {
           discussion
         }
+
+        if argument.discussion != nil, argument.supplementalDiscussion != nil {
+          MDocMacro.ParagraphBreak()
+        }
+
+        if let supplementalDiscussion = argument.supplementalDiscussion {
+          supplementalDiscussion
+        }
       }
 
-      for subcommand in command.subcommands ?? [] {
-        MDocMacro.ListItem(title: MDocMacro.Emphasis(arguments: [subcommand.commandName]))
-        SinglePageDescription(command: subcommand).core
+      if !multipage {
+        for subcommand in command.subcommands ?? [] {
+          MDocMacro.ListItem(title: MDocMacro.Emphasis(arguments: [subcommand.commandName]))
+          Description(
+            multipage: multipage,
+            command: subcommand).core
+        }
       }
     }
   }

--- a/Tools/generate-manual/DSL/Document.swift
+++ b/Tools/generate-manual/DSL/Document.swift
@@ -24,11 +24,7 @@ struct Document: MDocComponent {
     Preamble(date: date, section: section, command: command)
     Name(command: command)
     Synopsis(command: command)
-    if multiPage {
-      MultiPageDescription(command: command)
-    } else {
-      SinglePageDescription(command: command)
-    }
+    Description(multipage: multiPage, command: command)
     Exit(section: section)
     if multiPage {
       SeeAlso(section: section, command: command)

--- a/Tools/generate-manual/GenerateManual.swift
+++ b/Tools/generate-manual/GenerateManual.swift
@@ -24,7 +24,22 @@ struct GenerateManual: ParsableCommand {
 
   static let configuration = CommandConfiguration(
     commandName: "generate-manual",
-    abstract: "Generate a manual for the provided tool.")
+    abstract: "Generate a manual for the provided tool.",
+    discussion: """
+      The generate-manual tool powers the generate-manual plugin and typically \
+      should not be directly invoked. Instead manuals should be generated \
+      using the plugin which can be invoked via \
+      `swift package generate-manual`.
+      """,
+    supplementalDiscussion: """
+      The generate-manual tool invokes provided executable with the \
+      `--experimental-dump-help` argument and decoding the output into a \
+      `ToolInfo` structure provided by the `ArgumentParserToolInfo` library. \
+      The executable's `ToolInfo` is then transformed into to an \
+      `MDocComponent` tree using a SwiftUI-esk resultBuilder DSL. Next, the \
+      `MDocComponent` tree is lowered into an `Array` of `MDocASTNode` trees. \
+      Lastly, the `MDocASTNode` trees are serialized to a manual page on disk.
+      """)
 
   @Argument(help: "Tool to generate manual for.")
   var tool: String
@@ -32,16 +47,41 @@ struct GenerateManual: ParsableCommand {
   @Flag(help: "Generate a separate manual for each subcommand.")
   var multiPage = false
 
-  @Option(name: .long, help: "Override the creation date of the manual. Format: 'yyyy-mm-dd'.")
+  @Option(
+    name: .long,
+    help: "Override the creation date of the manual. Format: 'yyyy-mm-dd'.")
   var date: Date = Date()
 
-  @Option(name: .long, help: "Section of the manual.")
+  @Option(
+    name: .long,
+    help: .init(
+      "The manual section.",
+      discussion: """
+        Manuals for executables are typically included in section 1, but may \
+        also be found in other sections such as section 8.
+        """,
+      supplementalDiscussion: """
+        A description of manual sections is included below:
+        1) General Commands
+        2) System Calls
+        3) Library Functions
+        4) Device Drivers
+        5) File Formats
+        6) Games
+        7) Miscellaneous Information
+        8) System Manager's Manual
+        9) Kernel Developer's Manual
+        """))
   var section: Int = 1
 
-  @Option(name: .long, help: "Names and/or emails of the tool's authors. Format: 'name<email>'.")
+  @Option(
+    name: .long,
+    help: "Names and/or emails of the tool's authors. Format: 'name<email>'.")
   var authors: [AuthorArgument] = []
 
-  @Option(name: .shortAndLong, help: "Directory to save generated manual. Use '-' for stdout.")
+  @Option(
+    name: .shortAndLong,
+    help: "Directory to save generated manual. Use '-' for stdout.")
   var outputDirectory: String
 
   func validate() throws {
@@ -51,14 +91,18 @@ struct GenerateManual: ParsableCommand {
     }
 
     if outputDirectory != "-" {
-      // outputDirectory must already exist, `GenerateManual` will not create it.
+      // `outputDirectory` must already exist, `GenerateManual` will not create
+      // it.
       var objcBool: ObjCBool = true
-      guard FileManager.default.fileExists(atPath: outputDirectory, isDirectory: &objcBool) else {
-        throw ValidationError("Output directory \(outputDirectory) does not exist")
+      guard FileManager.default.fileExists(
+        atPath: outputDirectory, isDirectory: &objcBool) else {
+        throw ValidationError(
+          "Output directory \(outputDirectory) does not exist")
       }
 
       guard objcBool.boolValue else {
-        throw ValidationError("Output directory \(outputDirectory) is not a directory")
+        throw ValidationError(
+          "Output directory \(outputDirectory) is not a directory")
       }
     }
   }
@@ -67,18 +111,20 @@ struct GenerateManual: ParsableCommand {
     let data: Data
     do {
       let tool = URL(fileURLWithPath: tool)
-      let output = try executeCommand(executable: tool, arguments: ["--experimental-dump-help"])
+      let output = try executeCommand(
+        executable: tool, arguments: ["--experimental-dump-help"])
       data = output.data(using: .utf8) ?? Data()
     } catch {
       throw Error.failedToRunSubprocess(error: error)
     }
 
     do {
-      let toolInfoThin = try JSONDecoder().decode(ToolInfoHeader.self, from: data)
-      guard toolInfoThin.serializationVersion == 0 else {
+      let decoder = JSONDecoder()
+      let toolInfoHeader = try decoder.decode(ToolInfoHeader.self, from: data)
+      guard toolInfoHeader.serializationVersion == 0 else {
         throw Error.unsupportedDumpHelpVersion(
           expected: 0,
-          found: toolInfoThin.serializationVersion)
+          found: toolInfoHeader.serializationVersion)
       }
     } catch {
       throw Error.unableToParseToolOutput(error: error)
@@ -104,7 +150,9 @@ struct GenerateManual: ParsableCommand {
     }
   }
 
-  func generatePages(from command: CommandInfoV0, savingTo directory: URL?) throws {
+  func generatePages(
+    from command: CommandInfoV0, savingTo directory: URL?
+  ) throws {
     let document = Document(
       multiPage: multiPage,
       date: date,


### PR DESCRIPTION
- IDEA: additional discussion for commands and arguments which is
  exported to dump-help and can be consumed by supplemental content
  generators to contains much more detailed information than you may want
  to include in a help screen.
  Maybe a better idea would be to have --help-detailed flag that would
  include this information in the help output. Suggestions are welcome.
