### PR TITLE
Declare Hashable conformance for ArgumentVisibility

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/ArgumentVisibility.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentVisibility.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Visibility level of an argument's help.
-public struct ArgumentVisibility {
+public struct ArgumentVisibility: Hashable {
   /// Internal implementation of `ArgumentVisibility` to allow for easier API
   /// evolution.
   internal enum Representation {

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import ArgumentParser
+import ArgumentParser
 import ArgumentParserToolInfo
 import XCTest
 
@@ -122,7 +122,7 @@ public func AssertHelp<T: ParsableArguments>(
   let flag: String
   let includeHidden: Bool
 
-  switch visibility.base {
+  switch visibility {
   case .default:
     flag = "--help"
     includeHidden = false
@@ -130,7 +130,10 @@ public func AssertHelp<T: ParsableArguments>(
     flag = "--help-hidden"
     includeHidden = true
   case .private:
-    XCTFail("Should not be called.")
+    XCTFail("Should not be called.", file: file, line: line)
+    return
+  default:
+    XCTFail("Unrecognized visibility.", file: file, line: line)
     return
   }
 
@@ -158,13 +161,16 @@ public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
 ) {
   let includeHidden: Bool
 
-  switch visibility.base {
+  switch visibility {
   case .default:
     includeHidden = false
   case .hidden:
     includeHidden = true
   case .private:
-    XCTFail("Should not be called.")
+    XCTFail("Should not be called.", file: file, line: line)
+    return
+  default:
+    XCTFail("Unrecognized visibility.", file: file, line: line)
     return
   }
 


### PR DESCRIPTION
In addition to being useful, this allows us to drop the `@testable` annotation for the ArgumentParser import in ArgumentParserTestHelpers, which resolves #463.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
