### PR TITLE
[GSoC] Interactive mode should only run in an interactive shell

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -15,8 +15,6 @@ import Foundation
 @main
 @available(macOS 10.15, *)
 struct CountLines: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(shouldPromptForMissing: false)
-
     @Argument(
         help: "A file to count lines in. If omitted, counts the lines of stdin.",
         completion: .file(), transform: URL.init(fileURLWithPath:))

--- a/Examples/math/Math.swift
+++ b/Examples/math/Math.swift
@@ -22,9 +22,6 @@ struct Math: ParsableCommand {
         // Commands can define a version for automatic '--version' support.
         version: "1.0.0",
 
-        // Throws an error when the required parameters are missing.
-        shouldPromptForMissing: false,
-
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be
         // provided by automatically finding nested `ParsableCommand` types.

--- a/Examples/repeat/Repeat.swift
+++ b/Examples/repeat/Repeat.swift
@@ -13,8 +13,6 @@ import ArgumentParser
 
 @main
 struct Repeat: ParsableCommand {
-    static var configuration = CommandConfiguration(shouldPromptForMissing: false)
-
     @Option(help: "The number of times to repeat 'phrase'.")
     var count: Int?
 

--- a/Examples/roll/main.swift
+++ b/Examples/roll/main.swift
@@ -12,8 +12,6 @@
 import ArgumentParser
 
 struct RollOptions: ParsableArguments {
-    static var configuration = CommandConfiguration(shouldPromptForMissing: false)
-
     @Option(help: ArgumentHelp("Rolls the dice <n> times.", valueName: "n"))
     var times = 1
 

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -22,6 +22,9 @@ struct CommandParser {
   let commandTree: Tree<ParsableCommand.Type>
   var currentNode: Tree<ParsableCommand.Type>
   var decodedArguments: [DecodedArguments] = []
+  /// Used to simulate user input to test interactive mode.
+  ///
+  /// When not optional, an interactive shell will be mocked for testing.
   var lineStack: [String]? = nil
   
   var rootCommand: ParsableCommand.Type {

--- a/Sources/ArgumentParser/Parsing/Interactive.swift
+++ b/Sources/ArgumentParser/Parsing/Interactive.swift
@@ -9,10 +9,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
-#else
+#elseif canImport(Darwin)
 import Darwin
+#elseif canImport(CRT)
+import CRT
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 extension CommandParser {

--- a/Sources/ArgumentParser/Parsing/Interactive.swift
+++ b/Sources/ArgumentParser/Parsing/Interactive.swift
@@ -9,6 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
 extension CommandParser {
   /// Get input from the user's typing or from the parameters of the test.
   fileprivate mutating func getInput() -> String? {
@@ -27,6 +33,10 @@ extension CommandParser {
   ///   - split: A collection of parsed arguments which needs to be modified.
   /// - Returns: Whether the dialog resolve the error.
   mutating func canInteract(error: Error, split: inout SplitArguments) -> Bool {
+    // Check if the command is executed in an interactive shell
+    guard
+      isatty(STDOUT_FILENO) == 1 && isatty(STDIN_FILENO) == 1
+    else { return false }
     guard rootCommand.configuration.shouldPromptForMissing else { return false }
     guard lineStack == nil || !lineStack!.isEmpty else { return false }
     guard let error = error as? ParserError else { return false }
@@ -56,6 +66,10 @@ extension CommandParser {
   ///   - values: The resulting values after parsing the arguments which needs to be modified.
   /// - Returns: Whether the dialog resolve the error.
   mutating func canInteract(error: Error, arguments: ArgumentSet, values: inout ParsedValues) -> Bool {
+    // Check if the command is executed in an interactive shell
+    guard
+      isatty(STDOUT_FILENO) == 1 && isatty(STDIN_FILENO) == 1
+    else { return false }
     guard rootCommand.configuration.shouldPromptForMissing else { return false }
     guard lineStack == nil || !lineStack!.isEmpty else { return false }
     guard let error = error as? ParserError else { return false }

--- a/Sources/ArgumentParser/Parsing/Interactive.swift
+++ b/Sources/ArgumentParser/Parsing/Interactive.swift
@@ -37,12 +37,14 @@ extension CommandParser {
   ///   - split: A collection of parsed arguments which needs to be modified.
   /// - Returns: Whether the dialog resolve the error.
   mutating func canInteract(error: Error, split: inout SplitArguments) -> Bool {
-    // Check if the command is executed in an interactive shell
-    guard
-      isatty(STDOUT_FILENO) == 1 && isatty(STDIN_FILENO) == 1
-    else { return false }
+    // Check if it's under test.
+    if lineStack == nil {
+      guard
+        // Check if the command is executed in an interactive shell.
+        isatty(STDOUT_FILENO) == 1, isatty(STDIN_FILENO) == 1
+      else { return false }
+    }
     guard rootCommand.configuration.shouldPromptForMissing else { return false }
-    guard lineStack == nil || !lineStack!.isEmpty else { return false }
     guard let error = error as? ParserError else { return false }
     guard case let .missingValueForOption(inputOrigin, name) = error else { return false }
 
@@ -70,12 +72,14 @@ extension CommandParser {
   ///   - values: The resulting values after parsing the arguments which needs to be modified.
   /// - Returns: Whether the dialog resolve the error.
   mutating func canInteract(error: Error, arguments: ArgumentSet, values: inout ParsedValues) -> Bool {
-    // Check if the command is executed in an interactive shell
-    guard
-      isatty(STDOUT_FILENO) == 1 && isatty(STDIN_FILENO) == 1
-    else { return false }
+    // Check if it's under test.
+    if lineStack == nil {
+      guard
+        // Check if the command is executed in an interactive shell.
+        isatty(STDOUT_FILENO) == 1, isatty(STDIN_FILENO) == 1
+      else { return false }
+    }
     guard rootCommand.configuration.shouldPromptForMissing else { return false }
-    guard lineStack == nil || !lineStack!.isEmpty else { return false }
     guard let error = error as? ParserError else { return false }
 
     switch error {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -197,6 +197,8 @@ extension HelpGenerationTests {
   }
 
   struct E: ParsableCommand {
+    static var configuration = CommandConfiguration(shouldPromptForMissing: false)
+
     enum OutputBehaviour: String, EnumerableFlag {
       case stats, count, list
 


### PR DESCRIPTION
Solution to the issue #461.

This PR is used to track progress and view differences to make discussions easier.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary