### PR TITLE
Add an explicit return type to `flatMap` closure.

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -395,7 +395,7 @@ extension Flag where Value: EnumerableFlag {
       // Create a string representation of the default value. Since this is a
       // flag, the default value to show to the user is the `--value-name`
       // flag that a user would provide on the command line, not a Swift value.
-      let defaultValueFlag = initial.flatMap { value in
+      let defaultValueFlag = initial.flatMap { value -> String? in
         let defaultKey = InputKey(rawValue: String(describing: value))
         let defaultNames = Value.name(for: value).makeNames(defaultKey)
         return defaultNames.first?.synopsisString


### PR DESCRIPTION
This restores the ability to build with versions of Swift prior to 5.7.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
