### PR TITLE
Fix help display for non-String RawRepresentables

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -54,15 +54,15 @@ extension ExpressibleByArgument where Self: CaseIterable {
   }
 }
 
-extension ExpressibleByArgument where Self: CaseIterable, Self: RawRepresentable, RawValue == String {
+extension ExpressibleByArgument where Self: CaseIterable, Self: RawRepresentable, RawValue: ExpressibleByArgument {
   public static var allValueStrings: [String] {
-    self.allCases.map { $0.rawValue }
+    self.allCases.map(\.rawValue.defaultValueDescription)
   }
 }
 
-extension ExpressibleByArgument where Self: RawRepresentable, RawValue == String {
+extension ExpressibleByArgument where Self: RawRepresentable, RawValue: ExpressibleByArgument {
   public var defaultValueDescription: String {
-    rawValue
+    rawValue.defaultValueDescription
   }
 }
 

--- a/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
+++ b/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
@@ -80,6 +80,11 @@ fileprivate enum Name: String, Equatable, Decodable, ExpressibleByArgument, Case
   case tony
 }
 
+fileprivate enum Counter: Int, ExpressibleByArgument, CaseIterable {
+  case one = 1
+  case two, three, four
+}
+
 fileprivate struct Foo: ParsableArguments {
   @Option(name: [.short, .long])
   var format: Format
@@ -95,6 +100,10 @@ fileprivate struct EnumWithFewCasesArrayArgument: ParsableArguments {
 fileprivate struct EnumWithManyCasesArrayArgument: ParsableArguments {
   @Argument
   var names: [Name]
+}
+
+fileprivate struct EnumWithIntRawValue: ParsableArguments {
+  @Option var counter: Counter
 }
 
 extension ErrorMessageTests {
@@ -134,6 +143,11 @@ extension ErrorMessageTests {
         - steve
         - thor
         - tony
+      """)
+    
+    AssertErrorMessage(EnumWithIntRawValue.self, ["--counter", "one"], """
+      The value 'one' is invalid for '--counter <counter>'. \
+      Please provide one of '1', '2', '3' or '4'.
       """)
   }
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -211,7 +211,7 @@ extension HelpGenerationTests {
         --degree <degree>       Your degree.
         --directory <directory> Directory. (default: current directory)
         --manual <manual>       Manual Option. (default: default-value)
-        --unspecial <unspecial> Unspecialized Synthesized (default: one)
+        --unspecial <unspecial> Unspecialized Synthesized (default: 0)
         --special <special>     Specialized Synthesized (default: Apple)
         -h, --help              Show help information.
 
@@ -633,7 +633,7 @@ extension HelpGenerationTests {
 
   func testAllValueStrings() throws {
     XCTAssertEqual(AllValues.Manual.allValueStrings, ["bar"])
-    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, ["one", "two"])
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, ["0", "1"])
     XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, ["Apple", "Banana"])
   }
 


### PR DESCRIPTION
RawRepresentable types that have a non-String raw value are having values displayed in the help screen by converting the RawRep value into a string. However, these values are by default parsed by their raw value, so we should use that for display instead.

This is accomplished by adding a defaultValueDescription implementation for all ExpressibleByArgument-conforming RawValue types, and then basing the allValues implementation on that. This generalizes the existing overloads for String-based RawRep types, while also allowing users who customize their ExpressibleByArgument implementation to provide the correct help value for clients.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
