### PR TITLE
Add new `shouldUseExecutableName` configuration property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/DerivedData
 /Packages
 /*.xcodeproj
 .swiftpm

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
@@ -4,7 +4,7 @@
 
 ### Creating a Configuration
 
-- ``init(commandName:abstract:usage:discussion:version:shouldDisplay:subcommands:defaultSubcommand:helpNames:)``
+- ``init(commandName:shouldUseExecutableName:abstract:usage:discussion:version:shouldDisplay:subcommands:defaultSubcommand:helpNames:)``
 
 ### Customizing the Help Screen
 
@@ -21,6 +21,7 @@
 ### Defining Command Properties
 
 - ``commandName``
+- ``shouldUseExecutableName``
 - ``version``
 - ``shouldDisplay``
 

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -17,6 +17,13 @@ public struct CommandConfiguration {
   /// the command type to hyphen-separated lowercase words.
   public var commandName: String?
 
+  /// A Boolean value indicating whether to use the executable's file name
+  /// for the command name.
+  ///
+  /// If `commandName` or `_superCommandName` are non-`nil`, this
+  /// value is ignored.
+  public var shouldUseExecutableName: Bool
+  
   /// The name of this command's "super-command". (experimental)
   ///
   /// Use this when a command is part of a group of commands that are installed
@@ -61,6 +68,9 @@ public struct CommandConfiguration {
   ///   - commandName: The name of the command to use on the command line. If
   ///     `commandName` is `nil`, the command name is derived by converting
   ///     the name of the command type to hyphen-separated lowercase words.
+  ///   - shouldUseExecutableName: A Boolean value indicating whether to
+  ///     use the executable's file name for the command name. If `commandName`
+  ///     is non-`nil`, this value is ignored.
   ///   - abstract: A one-line description of the command.
   ///   - usage: A custom usage description for the command. When you provide
   ///     a non-`nil` string, the argument parser uses `usage` instead of
@@ -82,6 +92,7 @@ public struct CommandConfiguration {
   ///     are `-h` and `--help`.
   public init(
     commandName: String? = nil,
+    shouldUseExecutableName: Bool = false,
     abstract: String = "",
     usage: String? = nil,
     discussion: String = "",
@@ -92,6 +103,7 @@ public struct CommandConfiguration {
     helpNames: NameSpecification? = nil
   ) {
     self.commandName = commandName
+    self.shouldUseExecutableName = shouldUseExecutableName
     self.abstract = abstract
     self.usage = usage
     self.discussion = discussion
@@ -106,6 +118,7 @@ public struct CommandConfiguration {
   /// (experimental)
   public init(
     commandName: String? = nil,
+    shouldUseExecutableName: Bool = false,
     _superCommandName: String,
     abstract: String = "",
     usage: String? = nil,
@@ -117,6 +130,7 @@ public struct CommandConfiguration {
     helpNames: NameSpecification? = nil
   ) {
     self.commandName = commandName
+    self.shouldUseExecutableName = shouldUseExecutableName
     self._superCommandName = _superCommandName
     self.abstract = abstract
     self.usage = usage

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -37,7 +37,9 @@ public protocol ParsableCommand: ParsableArguments {
 extension ParsableCommand {
   public static var _commandName: String {
     configuration.commandName ??
-      String(describing: Self.self).convertedToSnakeCase(separator: "-")
+      (configuration.shouldUseExecutableName && configuration._superCommandName == nil
+        ? UsageGenerator.executableName
+        : String(describing: Self.self).convertedToSnakeCase(separator: "-"))
   }
   
   public static var configuration: CommandConfiguration {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -37,7 +37,7 @@ extension UsageGenerator {
   ///
   /// If no tool name can be generated, `"<command>"` will be returned.
   static var executableName: String {
-    if let name = CommandLine.arguments[0].split(separator: "/").last.map(String.init) {
+    if let name = URL(fileURLWithPath: CommandLine.arguments[0]).pathComponents.last {
       // We quote the name if it contains whitespace to avoid confusion with
       // subcommands but otherwise leave properly quoting/escaping the command
       // up to the user running the tool

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -18,8 +18,7 @@ struct UsageGenerator {
 
 extension UsageGenerator {
   init(definition: ArgumentSet) {
-    let toolName = CommandLine.arguments[0].split(separator: "/").last.map(String.init) ?? "<command>"
-    self.init(toolName: toolName, definition: definition)
+    self.init(toolName: Self.executableName, definition: definition)
   }
   
   init(toolName: String, parsable: ParsableArguments, visibility: ArgumentVisibility, parent: InputKey.Parent) {
@@ -34,6 +33,20 @@ extension UsageGenerator {
 }
 
 extension UsageGenerator {
+  /// Will generate a tool name from the name of the executed file if possible.
+  ///
+  /// If no tool name can be generated, `"<command>"` will be returned.
+  static var executableName: String {
+    if let name = CommandLine.arguments[0].split(separator: "/").last.map(String.init) {
+      // We quote the name if it contains whitespace to avoid confusion with
+      // subcommands but otherwise leave properly quoting/escaping the command
+      // up to the user running the tool
+      return name.quotedIfContains(.whitespaces)
+    } else {
+      return "<command>"
+    }
+  }
+  
   /// The tool synopsis.
   ///
   /// In `roff`.

--- a/Sources/ArgumentParser/Utilities/StringExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/StringExtensions.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_implementationOnly import Foundation
+
 extension StringProtocol where SubSequence == Substring {
   func wrapped(to columns: Int, wrappingIndent: Int = 0) -> String {
     let columns = columns - wrappingIndent
@@ -118,6 +120,32 @@ extension StringProtocol where SubSequence == Substring {
       result += character.lowercased()
     }
     return result
+  }
+  
+  /// Returns a new single-quoted string if this string contains any characters
+  /// from the specified character set. Any existing occurrences of the `'`
+  /// character will be escaped.
+  ///
+  /// Examples:
+  ///
+  ///     "alone".quotedIfContains(.whitespaces)
+  ///     // alone
+  ///     "with space".quotedIfContains(.whitespaces)
+  ///     // 'with space'
+  ///     "with'quote".quotedIfContains(.whitespaces)
+  ///     // with'quote
+  ///     "with'quote and space".quotedIfContains(.whitespaces)
+  ///     // 'with\'quote and space'
+  func quotedIfContains(_ chars: CharacterSet) -> String {
+    guard !isEmpty else { return "" }
+    
+    if self.rangeOfCharacter(from: chars) != nil {
+      // Prepend and append a single quote to self, escaping any other occurrences of the character
+      let quote = "'"
+      return quote + self.replacingOccurrences(of: quote, with: "\\\(quote)") + quote
+    }
+    
+    return String(self)
   }
   
   /// Returns the edit distance between this string and the provided target string.

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(UnitTests
   HelpGenerationTests+GroupName.swift
   NameSpecificationTests.swift
   SplitArgumentTests.swift
+  StringQuoteTests.swift
   StringSnakeCaseTests.swift
   StringWrappingTests.swift
   TreeTests.swift

--- a/Tests/ArgumentParserUnitTests/StringQuoteTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringQuoteTests.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import ArgumentParser
+
+final class StringQuoteTests: XCTestCase {}
+
+extension StringQuoteTests {
+  func testStringQuoteWithCharacter() {
+    let charactersToQuote = CharacterSet.whitespaces.union(.symbols)
+    let quoteTests = [
+      ("noSpace", "noSpace"),
+      ("a space", "'a space'"),
+      (" startingSpace", "' startingSpace'"),
+      ("endingSpace ", "'endingSpace '"),
+      ("   ", "'   '"),
+      ("\t", "'\t'"),
+      ("with'quote", "with'quote"), // no need to quote, so don't escape quote character either
+      ("with'quote and space", "'with\\'quote and space'"), // quote the string and escape the quote character within
+      ("'\\\\'' '''", "'\\\'\\\\\\\'\\\' \\\'\\\'\\\''"),
+      ("\"\\\\\"\" \"\"\"", "'\"\\\\\"\" \"\"\"'"),
+      ("word+symbol", "'word+symbol'"),
+      ("@£$%'^*(", "'@£$%\\\'^*('")
+    ]
+    for test in quoteTests {
+      XCTAssertEqual(test.0.quotedIfContains(charactersToQuote), test.1)
+    }
+  }
+}


### PR DESCRIPTION
### Description
This adds the `shouldUseExecutableName` property to `CommandConfiguration`, allowing the command name to be derived from the executable's file name.

The property defaults to false, both because subcommands using it is probably undesirable and to preserve existing behaviour after updating the package.

This also adds `/DerivedData` to the git ignore list.

### Detailed Design
```swift
/// A Boolean value indicating whether to use the executable's file name for the command name.
public var shouldUseExecutableName: Bool
```

The `CommandConfiguration` initialisers use a default value of false, serving to allow existing code to compile and to avoid an unexpected change in behaviour. When the value is true, if both `commandName` and `_superCommandName` are nil, the command name will be derived from the first command line argument, i.e. the path to the running executable.

Change to associated code paths is minimal, specifically `ParsableCommand._commandName` has been expanded in a way that preserves the original outcome when the new property is false.

The thinking behind ignoring this value when either `commandName` or `_superCommandName` have been set is that if the command name has been explicitly set, this should be used. If the super command name has been set, this implies a relationship with another command where a dynamic command name may lead to inconsistent help texts.

Two new internal symbols - see diff for full API documentation.
```swift
/// Will generate a tool name from the name of the executed file if possible.
static var executableName: String {}

/// Returns a new single-quoted string if this string contains any characters
/// from the specified character set. Any existing occurrences of the `'`
/// character will be escaped.
func quotedIfContains(_ chars: CharacterSet) -> String {}
```

### Documentation Plan
Includes API documentation for the new symbols and minorly updates docs to expose the new property.

### Test Plan
Includes unit tests for the string quoting. I'm unaware of a guaranteed executable name when running tests and therefore this does not include tests for the command name generation.

### Source Impact
Existing users should not be impacted by this change.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
