### PR TITLE
build: repair the ArgumentParser build on main

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(ArgumentParser
   Parsing/ArgumentDefinition.swift
   Parsing/ArgumentSet.swift
   Parsing/CommandParser.swift
+  Parsing/InputKey.swift
   Parsing/InputOrigin.swift
   Parsing/Name.swift
   Parsing/Parsed.swift


### PR DESCRIPTION
The new source file was added to the tree but not the build.  Due to the snapshots using a tagged version, this escaped testing.