### PR TITLE
Change name of plugin target to readable form

### DIFF
--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -20,7 +20,7 @@ var package = Package(
             targets: ["ArgumentParser"]),
         .plugin(
             name: "GenerateManualPlugin",
-            targets: ["GenerateManualPlugin"]),
+            targets: ["Generate Manual"]),
     ],
     dependencies: [],
     targets: [
@@ -40,12 +40,13 @@ var package = Package(
 
         // Plugins
         .plugin(
-            name: "GenerateManualPlugin",
+            name: "Generate Manual",
             capability: .command(
                 intent: .custom(
                     verb: "generate-manual",
                     description: "Generate a manual entry for a specified target.")),
-            dependencies: ["generate-manual"]),
+            dependencies: ["generate-manual"],
+            path: "Plugins/GenerateManualPlugin"),
 
         // Examples
         .executableTarget(


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR updates the name of the "Generate Manual" plugin so that it appears in a more readable "command" form in the context menu in Xcode.

Before:
![image](https://user-images.githubusercontent.com/10712068/194952348-b2ee8325-0b21-4f62-a970-4d1bdc75338b.png)

After:
![image](https://user-images.githubusercontent.com/10712068/194952287-f4ab7c44-a51c-47b6-9524-e642fd0992cb.png)

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
