### PR TITLE
ArgumentParser: repair the build after #504

### DIFF
--- a/Sources/ArgumentParser/Utilities/Platform.swift
+++ b/Sources/ArgumentParser/Utilities/Platform.swift
@@ -41,7 +41,11 @@ extension Platform {
 // MARK: Exit codes
 
 #if os(Windows)
+import func WinSDK.GetStdHandle
+import func WinSDK.GetConsoleScreenBufferInfo
 import let WinSDK.ERROR_BAD_ARGUMENTS
+import let WinSDK.STD_OUTPUT_HANDLE
+import struct WinSDK.CONSOLE_SCREEN_BUFFER_INFO
 #endif
 
 extension Platform {


### PR DESCRIPTION
There are references to functions from the Windows SDK rather than the C library for the console handling.  Explicitly import the necessary types and functions from the WinSDK module so that Windows can build once more with the changes to sequester the platform specific code.