### PR TITLE
Update DocC curation for newest symbols

### DIFF
--- a/Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md
@@ -4,11 +4,20 @@
 
 ### Single Arguments
 
-- ``init(help:completion:)-6pqzn``
-- ``init(help:completion:transform:)``
+- ``init(help:completion:)-6mld0``
 - ``init(help:completion:)-4p94d``
-- ``init(wrappedValue:help:completion:)``
-- ``init(wrappedValue:help:completion:transform:)``
+- ``init(help:completion:transform:)-3fjtc``
+- ``init(help:completion:transform:)-7yn32``
+
+@Comment {
+  The following symbols are copied from the preview website, but give a warning
+  when built and don't show up in this section in the rendered navigation in
+  either Xcode or the preview website. Instead, these symbols end up in the 
+  default-generated Initializers section.
+}
+
+- ``init(wrappedvalue:help:completion:)``
+- ``init(wrappedvalue:help:completion:transform:)``
 
 ### Array Arguments
 
@@ -20,6 +29,5 @@
 
 ### Infrequently Used APIs
 
-- ``init()``
 - ``init(from:)``
 - ``wrappedValue``

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/ArgumentArrayParsingStrategy.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/ArgumentArrayParsingStrategy.md
@@ -1,0 +1,14 @@
+# ``ArgumentParser/ArgumentArrayParsingStrategy``
+
+## Topics
+
+### Parsing Strategies
+
+- ``remaining``
+- ``allUnrecognized``
+- ``postTerminator``
+- ``captureForPassthrough``
+
+### Deprecated
+
+- ``unconditionalRemaining``

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/Flag.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/Flag.md
@@ -33,7 +33,3 @@
 ### Supporting Types
 
 - ``FlagExclusivity``
-
-### Deprecated APIs
-
-- ``init()``

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/Option.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/Option.md
@@ -4,12 +4,27 @@
 
 ### Single Options
 
-- ``init(name:parsing:help:completion:)-4yske``
 - ``init(name:parsing:help:completion:)-7slrf``
+- ``init(name:parsing:help:completion:)-5k0ug``
 - ``init(name:parsing:help:completion:transform:)-2wf44``
-- ``init(wrappedValue:name:parsing:help:completion:)-7ilku``
+- ``init(name:parsing:help:completion:transform:)-25g7b``
 - ``init(wrappedValue:name:parsing:help:completion:transform:)-2llve``
 - ``SingleValueParsingStrategy``
+
+@Comment {
+  This gives a warning and doesn't show up here, but doesn't show up in the
+  Initializers section, either. If I omit it here, then it shows up in the
+  Initializers section.
+}
+
+- ``init(wrappedValue:name:parsing:help:completion:)-7ilku``
+
+@Comment {
+  This gives a warning and doesn't show up here, but is in the Initializers
+  section.
+}
+
+- ``init(wrappedvalue:name:parsing:help:completion:)-7xcum``
 
 ### Array Options
 
@@ -21,10 +36,17 @@
 
 ### Infrequently Used APIs
 
-- ``init()``
 - ``init(from:)``
 - ``wrappedValue``
 
 ### Deprecated APIs
 
 - ``init(wrappedValue:name:parsing:completion:help:)``
+
+@Comment {
+  These give a warning and don't show up here, but are in the Initializers
+  section.
+}
+
+- ``init(wrappedvalue:name:parsing:help:completion:)-4pl7h``
+- ``init(wrappedvalue:name:parsing:help:completion:transform:)-6rqji``

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/OptionGroup.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/OptionGroup.md
@@ -4,7 +4,11 @@
 
 ### Creating an Option Group
 
-- ``init(visibility:)``
+- ``init(title:visibility:)``
+
+### Option Group Properties
+
+- ``title``
 
 ### Infrequently Used APIs
 

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md
@@ -33,3 +33,4 @@
 ### Infrequently Used APIs
 
 - ``init()``
+- ``helpMessage(columns:)``

--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -460,7 +460,7 @@ extension Argument {
     Optional @Arguments with default values should be declared as non-Optional.
     """)
   public init<T>(
-    wrappedValue: Optional<T>,
+    wrappedValue _wrappedValue: Optional<T>,
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil
   ) where T: ExpressibleByArgument, Value == Optional<T> {
@@ -471,7 +471,7 @@ extension Argument {
         kind: .positional,
         help: help,
         parsingStrategy: .default,
-        initial: wrappedValue,
+        initial: _wrappedValue,
         completion: completion)
 
       return ArgumentSet(arg)
@@ -541,7 +541,7 @@ extension Argument {
     Optional @Arguments with default values should be declared as non-Optional.
     """)
   public init<T>(
-    wrappedValue: Optional<T>,
+    wrappedValue _wrappedValue: Optional<T>,
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil,
     transform: @escaping (String) throws -> T
@@ -554,7 +554,7 @@ extension Argument {
         help: help,
         parsingStrategy: .default,
         transform: transform,
-        initial: wrappedValue,
+        initial: _wrappedValue,
         completion: completion)
 
       return ArgumentSet(arg)

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -82,10 +82,10 @@ extension ParsableCommand {
   @_disfavoredOverload
   @available(*, deprecated, renamed: "helpMessage(for:includeHidden:columns:)")
   public static func helpMessage(
-    for subcommand: ParsableCommand.Type,
+    for _subcommand: ParsableCommand.Type,
     columns: Int? = nil
   ) -> String {
-    helpMessage(for: subcommand, includeHidden: false, columns: columns)
+    helpMessage(for: _subcommand, includeHidden: false, columns: columns)
   }
 
   /// Returns the text of the help screen for the given subcommand of this


### PR DESCRIPTION
Some of the symbol identifiers changed since the last release, and `OptionGroup` and `ArgumentArrayParsingStrategy` both received new API.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
