### PR TITLE
Fix unresolved symbol links in documentation

### DIFF
--- a/Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md
@@ -8,16 +8,8 @@
 - ``init(help:completion:)-4p94d``
 - ``init(help:completion:transform:)-3fjtc``
 - ``init(help:completion:transform:)-7yn32``
-
-@Comment {
-  The following symbols are copied from the preview website, but give a warning
-  when built and don't show up in this section in the rendered navigation in
-  either Xcode or the preview website. Instead, these symbols end up in the 
-  default-generated Initializers section.
-}
-
-- ``init(wrappedvalue:help:completion:)``
-- ``init(wrappedvalue:help:completion:transform:)``
+- ``init(wrappedValue:help:completion:)``
+- ``init(wrappedValue:help:completion:transform:)``
 
 ### Array Arguments
 

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/Option.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/Option.md
@@ -10,21 +10,7 @@
 - ``init(name:parsing:help:completion:transform:)-25g7b``
 - ``init(wrappedValue:name:parsing:help:completion:transform:)-2llve``
 - ``SingleValueParsingStrategy``
-
-@Comment {
-  This gives a warning and doesn't show up here, but doesn't show up in the
-  Initializers section, either. If I omit it here, then it shows up in the
-  Initializers section.
-}
-
-- ``init(wrappedValue:name:parsing:help:completion:)-7ilku``
-
-@Comment {
-  This gives a warning and doesn't show up here, but is in the Initializers
-  section.
-}
-
-- ``init(wrappedvalue:name:parsing:help:completion:)-7xcum``
+- ``init(wrappedValue:name:parsing:help:completion:)-7xcum``
 
 ### Array Options
 
@@ -42,11 +28,5 @@
 ### Deprecated APIs
 
 - ``init(wrappedValue:name:parsing:completion:help:)``
-
-@Comment {
-  These give a warning and don't show up here, but are in the Initializers
-  section.
-}
-
-- ``init(wrappedvalue:name:parsing:help:completion:)-4pl7h``
-- ``init(wrappedvalue:name:parsing:help:completion:transform:)-6rqji``
+- ``init(wrappedValue:name:parsing:help:completion:)-4pl7h``
+- ``init(wrappedValue:name:parsing:help:completion:transform:)-6rqji``


### PR DESCRIPTION
This fixes 6 unresolved symbol links in ArgumentParser documentation and removes the `@Comment` directives that used to describe these unresolved links. These unresolved links were brought up in https://github.com/apple/swift-docc/issues/407.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This is a documentation-only change.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
