### PR TITLE
Fix some Swift 5.6 compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vscode
 .*.sw?
 *.docc-build
+*.vs

--- a/Package.swift
+++ b/Package.swift
@@ -68,19 +68,3 @@ var package = Package(
             resources: [.copy("CountLinesTest.txt")]),
     ]
 )
-
-#if swift(>=5.6) && os(macOS)
-package.targets.append(contentsOf: [
-    // Examples
-    .executableTarget(
-        name: "count-lines",
-        dependencies: ["ArgumentParser"],
-        path: "Examples/count-lines"),
-
-    // Tools
-    .executableTarget(
-        name: "changelog-authors",
-        dependencies: ["ArgumentParser"],
-        path: "Tools/changelog-authors"),
-    ])
-#endif

--- a/Sources/ArgumentParser/Parsing/InputKey.swift
+++ b/Sources/ArgumentParser/Parsing/InputKey.swift
@@ -72,7 +72,7 @@ struct InputKey: Hashable {
   /// - Parameter codingKey: The base ``CodingKey``
   /// - Parameter path: The list of ``CodingKey`` values that lead to this one. May be empty.
   @inlinable
-  init<C: CodingKey>(codingKey: C, path: [CodingKey]) {
+  init(codingKey: CodingKey, path: [CodingKey]) {
     self.init(name: codingKey.stringValue, parent: Parent(InputKey(path: path)))
   }
   
@@ -113,7 +113,7 @@ extension InputKey {
   ///
   /// - Parameter codingKey: The key to clean.
   /// - Returns: The cleaned key.
-  static func clean<C: CodingKey>(codingKey: C) -> String {
+  static func clean(codingKey: CodingKey) -> String {
     clean(codingKey: codingKey.stringValue)
   }
 }

--- a/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) && swift(>=5.6)
+#if os(macOS) && swift(>=5.7)
 
 import XCTest
 import ArgumentParserTestHelpers


### PR DESCRIPTION
We've had some regressions under Swift 5.6 in the latest changes, particularly around using implicitly opened existentials, which is a 5.7 feature. I've tested these changes using Swift 5.6 on Linux and macOS 12.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
