### PR TITLE
Add .spi.yml for Swift Package Index doc support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [ArgumentParser]
+


### PR DESCRIPTION
This adds the `.spi.yml` file that SPI uses to know how to generate documentation, as described here: https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/
