### PR TITLE
WASI: Fix Platform.exit's infinite recursion

### DIFF
--- a/Sources/ArgumentParser/Utilities/Platform.swift
+++ b/Sources/ArgumentParser/Utilities/Platform.swift
@@ -83,7 +83,7 @@ extension Platform {
 #elseif canImport(CRT)
     ucrt._exit(code)
 #elseif canImport(WASILibc)
-    exit(code)
+    WASILibc.exit(code)
 #endif
   }
 }


### PR DESCRIPTION
This issue was introduced by #504.

When the target platform is WASI, `Platform.exit` causes infinite recursion because it calls itself.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
