### PR TITLE
Reword Enums to Remove "Master"

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -135,15 +135,15 @@ extension HelpGenerationTests {
 
   enum OptionFlags: String, EnumerableFlag { case optional, required }
   enum Degree {
-    case bachelor, master, doctor
+    case bachelor, graduate, doctorate
     static func degreeTransform(_ string: String) throws -> Degree {
       switch string {
       case "bachelor":
         return .bachelor
-      case "master":
-        return .master
-      case "doctor":
-        return .doctor
+      case "graduate":
+        return .graduate
+      case "doctorate":
+        return .doctorate
       default:
         throw ValidationError("Not a valid string for 'Degree'")
       }


### PR DESCRIPTION
Remove the word "master" from the project. An inclusive language filter was flagging this. As this word is only used in a test I opted to remove it completely to avoid this issue for myself and others.

Master is now "graduate" and doctor is now "doctorate" to be consistent.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
