### PR TITLE
Disfavor deprecated property wrapper inits

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -290,7 +290,7 @@ public struct ArgumentArrayParsingStrategy: Hashable {
 }
 
 // MARK: - @Argument T: ExpressibleByArgument Initializers
-extension Argument {
+extension Argument where Value: ExpressibleByArgument {
   /// Creates a property with a default value provided by standard Swift default
   /// value syntax.
   ///
@@ -309,7 +309,7 @@ extension Argument {
     wrappedValue: Value,
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil
-  ) where Value: ExpressibleByArgument {
+  ) {
     self.init(_parsedValue: .init { key in
       let arg = ArgumentDefinition(
         container: Bare<Value>.self,
@@ -338,7 +338,7 @@ extension Argument {
   public init(
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil
-  ) where Value: ExpressibleByArgument {
+  ) {
     self.init(_parsedValue: .init { key in
       let arg = ArgumentDefinition(
         container: Bare<Value>.self,
@@ -459,6 +459,7 @@ extension Argument {
   @available(*, deprecated, message: """
     Optional @Arguments with default values should be declared as non-Optional.
     """)
+  @_disfavoredOverload
   public init<T>(
     wrappedValue _wrappedValue: Optional<T>,
     help: ArgumentHelp? = nil,
@@ -540,6 +541,7 @@ extension Argument {
   @available(*, deprecated, message: """
     Optional @Arguments with default values should be declared as non-Optional.
     """)
+  @_disfavoredOverload
   public init<T>(
     wrappedValue _wrappedValue: Optional<T>,
     help: ArgumentHelp? = nil,

--- a/Sources/ArgumentParser/Parsable Properties/Option.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Option.swift
@@ -233,7 +233,7 @@ public struct ArrayParsingStrategy: Hashable {
 }
 
 // MARK: - @Option T: ExpressibleByArgument Initializers
-extension Option {
+extension Option where Value: ExpressibleByArgument {
   /// Creates a property with a default value provided by standard Swift default value syntax.
   ///
   /// This method is called to initialize an `Option` with a default value such as:
@@ -254,7 +254,7 @@ extension Option {
     parsing parsingStrategy: SingleValueParsingStrategy = .next,
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil
-  ) where Value: ExpressibleByArgument {
+  ) {
     self.init(_parsedValue: .init { key in
       let arg = ArgumentDefinition(
         container: Bare<Value>.self,
@@ -278,7 +278,7 @@ extension Option {
     parsing parsingStrategy: SingleValueParsingStrategy = .next,
     completion: CompletionKind?,
     help: ArgumentHelp?
-  ) where Value: ExpressibleByArgument {
+  ) {
     self.init(
       wrappedValue: wrappedValue,
       name: name,
@@ -304,7 +304,7 @@ extension Option {
     parsing parsingStrategy: SingleValueParsingStrategy = .next,
     help: ArgumentHelp? = nil,
     completion: CompletionKind? = nil
-  ) where Value: ExpressibleByArgument {
+  ) {
     self.init(_parsedValue: .init { key in
       let arg = ArgumentDefinition(
         container: Bare<Value>.self,
@@ -432,6 +432,7 @@ extension Option {
   @available(*, deprecated, message: """
     Optional @Options with default values should be declared as non-Optional.
     """)
+  @_disfavoredOverload
   public init<T>(
     wrappedValue: Optional<T>,
     name: NameSpecification = .long,
@@ -532,6 +533,7 @@ extension Option {
   @available(*, deprecated, message: """
     Optional @Options with default values should be declared as non-Optional.
     """)
+  @_disfavoredOverload
   public init<T>(
     wrappedValue: Optional<T>,
     name: NameSpecification = .long,

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -793,3 +793,38 @@ extension DefaultsEndToEndTests {
     }
   }
 }
+
+// MARK: Overload selection
+
+extension DefaultsEndToEndTests {
+  private struct AbsolutePath: ExpressibleByArgument {
+    init(_ value: String) {}
+    init?(argument: String) {}
+  }
+  
+  private struct TwoPaths: ParsableCommand {
+    @Argument(help: .init("The path"))
+    var path1 = AbsolutePath("abc")
+
+    @Argument(help: "The path")
+    var path2 = AbsolutePath("abc")
+
+    @Option(help: .init("The path"))
+    var path3 = AbsolutePath("abc")
+
+    @Option(help: "The path")
+    var path4 = AbsolutePath("abc")
+  }
+  
+  /// Tests that a non-optional `Value` type is inferred, regardless of how the
+  /// initializer parameters are spelled. Previously, string literals and
+  /// `.init` calls for the help parameter inferred different generic types.
+  func testHelpInitInferredType() throws {
+    AssertParse(TwoPaths.self, []) { cmd in
+      XCTAssert(type(of: cmd.path1) == AbsolutePath.self)
+      XCTAssert(type(of: cmd.path2) == AbsolutePath.self)
+      XCTAssert(type(of: cmd.path3) == AbsolutePath.self)
+      XCTAssert(type(of: cmd.path4) == AbsolutePath.self)
+    }
+  }
+}


### PR DESCRIPTION
This change is to make sure that the non-optional generic parameter type is chosen for `@Argument` and `@Option` properties that provide a default value. Previously, an optional type might be chosen depending on how the `help` parameter was spelled, due to strange overload resolution. In particular, using the `.init` caused selection of the deprecated optional overload:

```swift
// Unexpected:
// Infers `Value` as `Optional<AbsolutePath>`
@Argument(help: .init("The path"))
var path = AbsolutePath("/")

// Expected:
// Infers `Value` as `AbsolutePath`
@Argument(help: "The path")
var path = AbsolutePath("/")
```

This addresses the issue by marking the deprecated overloads as disfavored. rdar://102383455

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
