### PR TITLE
Fix deprecation warnings in unit tests

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtArgument.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtArgument.swift
@@ -221,6 +221,7 @@ extension HelpGenerationTests {
       var arg0: A? = nil
     }
 
+    @available(*, deprecated, message: "Included for test coverage")
     struct OptionalDefault: ParsableCommand {
       @Argument(help: "example")
       var arg0: A? = A()

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOption.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOption.swift
@@ -179,6 +179,7 @@ extension HelpGenerationTests {
       var arg0: A? = nil
     }
 
+    @available(*, deprecated, message: "Included for test coverage")
     struct OptionalDefault: ParsableCommand {
       @Option(help: "example")
       var arg0: A? = A()


### PR DESCRIPTION
- Fixes deprecation warnings in unit tests by marking tests which cover deprecated functionality as @available(*, deprecated) themselves.