### PR TITLE
Cleanup Foundation usage

### DIFF
--- a/Plugins/GenerateManualPlugin/GenerateManualPlugin.swift
+++ b/Plugins/GenerateManualPlugin/GenerateManualPlugin.swift
@@ -10,7 +10,6 @@
 //===----------------------------------------------------------------------===//
 
 import PackagePlugin
-import Foundation
 
 @main
 struct GenerateManualPlugin: CommandPlugin {

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
 @_implementationOnly import ArgumentParserToolInfo
+@_implementationOnly import class Foundation.JSONEncoder
 
 internal struct DumpHelpGenerator {
   var toolInfo: ToolInfoV0

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -9,12 +9,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
+@_implementationOnly import protocol Foundation.LocalizedError
+@_implementationOnly import class Foundation.NSError
 
 enum MessageInfo {
   case help(text: String)
   case validation(message: String, usage: String, help: String)
-  case other(message: String, exitCode: Int32)
+  case other(message: String, exitCode: ExitCode)
   
   init(error: Error, type: ParsableArguments.Type) {
     var commandStack: [ParsableCommand.Type]
@@ -105,15 +106,15 @@ enum MessageInfo {
         case .message(let message):
           self = .help(text: message)
         }
-      case let error as ExitCode:
-        self = .other(message: "", exitCode: error.rawValue)
+      case let exitCode as ExitCode:
+        self = .other(message: "", exitCode: exitCode)
       case let error as LocalizedError where error.errorDescription != nil:
-        self = .other(message: error.errorDescription!, exitCode: EXIT_FAILURE)
+        self = .other(message: error.errorDescription!, exitCode: .failure)
       default:
         if Swift.type(of: error) is NSError.Type {
-          self = .other(message: error.localizedDescription, exitCode: EXIT_FAILURE)
+          self = .other(message: error.localizedDescription, exitCode: .failure)
         } else {
-          self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
+          self = .other(message: String(describing: error), exitCode: .failure)
         }
       }
     } else if let parserError = parserError {
@@ -126,7 +127,7 @@ enum MessageInfo {
       let helpAbstract = argumentSet.helpDescription(error: parserError) ?? ""
       self = .validation(message: message, usage: usage, help: helpAbstract)
     } else {
-      self = .other(message: String(describing: error), exitCode: EXIT_FAILURE)
+      self = .other(message: String(describing: error), exitCode: .failure)
     }
   }
   
@@ -165,7 +166,7 @@ enum MessageInfo {
     switch self {
     case .help: return ExitCode.success
     case .validation: return ExitCode.validationFailure
-    case .other(_, let code): return ExitCode(code)
+    case .other(_, let exitCode): return exitCode
     }
   }
 }

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
+@_implementationOnly import protocol Foundation.LocalizedError
 
 struct UsageGenerator {
   var toolName: String


### PR DESCRIPTION
- Changes uses of import Foundation in ArgumentParser to only expose the symbols needed to avoid growing unintentional dependencies.
- Replaces direct usage of EXIT_FAILURE in MessageInfo with ExitCode, exposed as a result of the above change.