### PR TITLE
Redirect to Swift Package Index hosted docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <title>ArgumentParser Documentation</title>
-      <meta http-equiv = "refresh" content = "0; url = https://apple.github.io/swift-argument-parser/documentation/argumentparser/" />
+      <meta http-equiv = "refresh" content = "0; url = https://swiftpackageindex.com/apple/swift-argument-parser/documentation" />
    </head>
    <body>
       <p>Redirecting...</p>


### PR DESCRIPTION
This is part of the concerted effort to move to Swift Package Index hosted docs.