### PR TITLE
Change doc references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The 1.2.0 release includes contributions from [allevato], [clayellis],
 [compnerd], [d-ronnqvist], [natecook1000], [randomeizer], and [rauhul].
 Thank you!
 
-[arrayparse-docs]: https://apple.github.io/swift-argument-parser/documentation/argumentparser/argumentarrayparsingstrategy
+[arrayparse-docs]: https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/argumentarrayparsingstrategy
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The 1.2.0 release includes contributions from [allevato], [clayellis],
 [compnerd], [d-ronnqvist], [natecook1000], [randomeizer], and [rauhul].
 Thank you!
 
-[arrayparse-docs]: https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/argumentarrayparsingstrategy
+[arrayparse-docs]: https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/argumentarrayparsingstrategy
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ For guides, articles, and API documentation see the
 [library's documentation on the Web][docs] or in Xcode.
 
 - [ArgumentParser documentation][docs]
-- [Getting Started with ArgumentParser](https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/gettingstarted)
-- [`ParsableCommand` documentation](https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/parsablecommand)
+- [Getting Started with ArgumentParser](https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/gettingstarted)
+- [`ParsableCommand` documentation](https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/parsablecommand)
 
 [docs]: https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For guides, articles, and API documentation see the
 - [Getting Started with ArgumentParser](https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/gettingstarted)
 - [`ParsableCommand` documentation](https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/parsablecommand)
 
-[docs]: https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser
+[docs]: https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ For guides, articles, and API documentation see the
 [library's documentation on the Web][docs] or in Xcode.
 
 - [ArgumentParser documentation][docs]
-- [Getting Started with ArgumentParser](https://apple.github.io/swift-argument-parser/documentation/argumentparser/gettingstarted)
-- [`ParsableCommand` documentation](https://apple.github.io/swift-argument-parser/documentation/argumentparser/parsablecommand)
+- [Getting Started with ArgumentParser](https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/gettingstarted)
+- [`ParsableCommand` documentation](https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser/parsablecommand)
 
-[docs]: https://apple.github.io/swift-argument-parser/documentation/argumentparser/
+[docs]: https://swiftpackageindex.com/apple/swift-argument-parser/main/documentation/argumentparser
 
 #### Examples
 


### PR DESCRIPTION
Together with https://github.com/apple/swift-argument-parser/pull/531, updating GitHub pages references to those hosted by Swift Package Index.
