### PR TITLE
Revert "Redirect to Swift Package Index hosted docs"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <title>ArgumentParser Documentation</title>
-      <meta http-equiv = "refresh" content = "0; url = https://swiftpackageindex.com/apple/swift-argument-parser/documentation" />
+      <meta http-equiv = "refresh" content = "0; url = https://apple.github.io/swift-argument-parser/documentation/argumentparser/" />
    </head>
    <body>
       <p>Redirecting...</p>


### PR DESCRIPTION
Reverts apple/swift-argument-parser#531 — I mis-read which branch this was landing on. We need to wait until there's a release version of the docs hosted at SPI.