### PR TITLE
Improve fish completion (#376, #534)

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -63,8 +63,7 @@ extension ArgumentDefinition {
           !names.isEmpty
     else { return nil }
 
-    var results = names
-      .map{ $0.asFishSuggestion }
+    var results = names.map{ $0.asFishSuggestion }
 
     if !help.abstract.isEmpty {
       results += ["-d '\(help.abstract.fishEscape())'"]

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -2,8 +2,8 @@ struct FishCompletionsGenerator {
   static func generateCompletionScript(_ type: ParsableCommand.Type) -> String {
     let programName = type._commandName
     let helperFunctions = [
-      FishScriptBuilder.preprocessorFunction(commandName: programName),
-      FishScriptBuilder.helperFunction(commandName: programName)
+      preprocessorFunction(commandName: programName),
+      helperFunction(commandName: programName)
     ]
     let completions = generateCompletions(commandChain: [programName], [type])
 
@@ -25,11 +25,11 @@ extension FishCompletionsGenerator {
       subcommands.append(HelpCommand.self)
     }
 
-    let helperFunctionName = FishScriptBuilder.helperFunctionName(commandName: programName)
+    let helperFunctionName = helperFunctionName(commandName: programName)
 
-    var prefix = "complete -c \(programName) -n '\(helperFunctionName) \"\(commandChain.joined(separator: FishScriptBuilder.separator))\""
+    var prefix = "complete -c \(programName) -n '\(helperFunctionName) \"\(commandChain.joined(separator: separator))\""
     if !subcommands.isEmpty {
-      prefix += " \"\(subcommands.map { $0._commandName }.joined(separator: FishScriptBuilder.separator))\""
+      prefix += " \"\(subcommands.map { $0._commandName }.joined(separator: separator))\""
     }
     prefix += "'"
 
@@ -112,15 +112,15 @@ extension String {
   }
 }
 
-private enum FishScriptBuilder {
+extension FishCompletionsGenerator {
 
-  static var separator: String { " " }
+  private static var separator: String { " " }
 
   private static func preprocessorFunctionName(commandName: String) -> String {
     "_swift_\(commandName)_preprocessor"
   }
 
-  static func preprocessorFunction(commandName: String) -> String {
+  private static func preprocessorFunction(commandName: String) -> String {
     """
     # A function which filters options which starts with "-" from $argv.
     function \(preprocessorFunctionName(commandName: commandName))
@@ -136,11 +136,11 @@ private enum FishScriptBuilder {
     """
   }
 
-  static func helperFunctionName(commandName: String) -> String {
+  private static func helperFunctionName(commandName: String) -> String {
     "_swift_" + commandName + "_using_command"
   }
 
-  static func helperFunction(commandName: String) -> String {
+  private static func helperFunction(commandName: String) -> String {
     let functionName = helperFunctionName(commandName: commandName)
     let preprocessorFunctionName = preprocessorFunctionName(commandName: commandName)
     return """

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -545,45 +545,65 @@ _math
 """
 
 private let fishCompletionScriptText = """
+# A function which filters options which starts with \"-\" from $argv.
+function _swift_math_preprocessor
+    set -l results
+    for i in (seq (count $argv))
+        switch (echo $argv[$i] | string sub -l 1)
+            case '-'
+            case '*'
+                echo $argv[$i]
+        end
+    end
+end
+
 function _swift_math_using_command
-    set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq (count $argv) ]
-        for i in (seq (count $argv))
-            if [ $cmd[$i] != $argv[$i] ]
+    set -l currentCommands (_swift_math_preprocessor (commandline -opc))
+    set -l expectedCommands (string split \" \" $argv[1])
+    set -l subcommands (string split \" \" $argv[2])
+    if [ (count $currentCommands) -ge (count $expectedCommands) ]
+        for i in (seq (count $expectedCommands))
+            if [ $currentCommands[$i] != $expectedCommands[$i] ]
                 return 1
+            end
+        end
+        if [ (count $currentCommands) -eq (count $expectedCommands) ]
+            return 0
+        end
+        if [ (count $subcommands) -gt 1 ]
+            for i in (seq (count $subcommands))
+                if [ $currentCommands[(math (count $expectedCommands) + 1)] = $subcommands[$i] ]
+                    return 1
+                end
             end
         end
         return 0
     end
     return 1
 end
-complete -c math -n '_swift_math_using_command math' -f -l version -d 'Show the version.'
-complete -c math -n '_swift_math_using_command math' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math' -f -a 'add' -d 'Print the sum of the values.'
-complete -c math -n '_swift_math_using_command math' -f -a 'multiply' -d 'Print the product of the values.'
-complete -c math -n '_swift_math_using_command math' -f -a 'stats' -d 'Calculate descriptive statistics.'
-complete -c math -n '_swift_math_using_command math' -f -a 'help' -d 'Show subcommand help information.'
-complete -c math -n '_swift_math_using_command math add' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
-complete -c math -n '_swift_math_using_command math add' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math multiply' -f -l hex-output -s x -d 'Use hexadecimal notation for the result.'
-complete -c math -n '_swift_math_using_command math multiply' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math stats' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math stats' -f -a 'average' -d 'Print the average of the values.'
-complete -c math -n '_swift_math_using_command math stats' -f -a 'stdev' -d 'Print the standard deviation of the values.'
-complete -c math -n '_swift_math_using_command math stats' -f -a 'quantiles' -d 'Print the quantiles of the values (TBD).'
-complete -c math -n '_swift_math_using_command math stats' -f -a 'help' -d 'Show subcommand help information.'
-complete -c math -n '_swift_math_using_command math stats average' -f -r -l kind -d 'The kind of average to provide.'
-complete -c math -n '_swift_math_using_command math stats average --kind' -f -k -a 'mean median mode'
-complete -c math -n '_swift_math_using_command math stats average' -f -l version -d 'Show the version.'
-complete -c math -n '_swift_math_using_command math stats average' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math stats stdev' -f -s h -l help -d 'Show help information.'
-complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l file
-complete -c math -n '_swift_math_using_command math stats quantiles --file' -f -a '(for i in *.{txt,md}; echo $i;end)'
-complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l directory
-complete -c math -n '_swift_math_using_command math stats quantiles --directory' -f -a '(__fish_complete_directories)'
-complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l shell
-complete -c math -n '_swift_math_using_command math stats quantiles --shell' -f -a '(head -100 /usr/share/dict/words | tail -50)'
-complete -c math -n '_swift_math_using_command math stats quantiles' -f -r -l custom
-complete -c math -n '_swift_math_using_command math stats quantiles --custom' -f -a '(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])'
-complete -c math -n '_swift_math_using_command math stats quantiles' -f -s h -l help -d 'Show help information.'
+
+complete -c math -n \'_swift_math_using_command \"math add\"\' -l hex-output -s x -d \'Use hexadecimal notation for the result.\'
+complete -c math -n \'_swift_math_using_command \"math add\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math multiply\"\' -l hex-output -s x -d \'Use hexadecimal notation for the result.\'
+complete -c math -n \'_swift_math_using_command \"math multiply\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math stats average\"\' -l kind -d \'The kind of average to provide.\' -r -f -k -a \'mean median mode\'
+complete -c math -n \'_swift_math_using_command \"math stats average\"\' -l version -d \'Show the version.\'
+complete -c math -n \'_swift_math_using_command \"math stats average\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math stats stdev\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math stats quantiles\"\' -l file -r -f -a \'(for i in *.{txt,md}; echo $i;end)\'
+complete -c math -n \'_swift_math_using_command \"math stats quantiles\"\' -l directory -r -f -a \'(__fish_complete_directories)\'
+complete -c math -n \'_swift_math_using_command \"math stats quantiles\"\' -l shell -r -f -a \'(head -100 /usr/share/dict/words | tail -50)\'
+complete -c math -n \'_swift_math_using_command \"math stats quantiles\"\' -l custom -r -f -a \'(command math ---completion stats quantiles -- --custom (commandline -opc)[1..-1])\'
+complete -c math -n \'_swift_math_using_command \"math stats quantiles\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math stats\" \"average stdev quantiles help\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math stats\" \"average stdev quantiles help\"\' -f -a \'average\' -d \'Print the average of the values.\'
+complete -c math -n \'_swift_math_using_command \"math stats\" \"average stdev quantiles help\"\' -f -a \'stdev\' -d \'Print the standard deviation of the values.\'
+complete -c math -n \'_swift_math_using_command \"math stats\" \"average stdev quantiles help\"\' -f -a \'quantiles\' -d \'Print the quantiles of the values (TBD).\'
+complete -c math -n \'_swift_math_using_command \"math stats\" \"average stdev quantiles help\"\' -f -a \'help\' -d \'Show subcommand help information.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -l version -d \'Show the version.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -s h -l help -d \'Show help information.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -f -a \'add\' -d \'Print the sum of the values.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -f -a \'multiply\' -d \'Print the product of the values.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -f -a \'stats\' -d \'Calculate descriptive statistics.\'
+complete -c math -n \'_swift_math_using_command \"math\" \"add multiply stats help\"\' -f -a \'help\' -d \'Show subcommand help information.\'
 """

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -243,30 +243,50 @@ _escaped-command
 """
 
 private let fishBaseCompletions = """
+# A function which filters options which starts with "-" from $argv.
+function _swift_base_preprocessor
+    set -l results
+    for i in (seq (count $argv))
+        switch (echo $argv[$i] | string sub -l 1)
+            case '-'
+            case '*'
+                echo $argv[$i]
+        end
+    end
+end
+
 function _swift_base_using_command
-    set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq (count $argv) ]
-        for i in (seq (count $argv))
-            if [ $cmd[$i] != $argv[$i] ]
+    set -l currentCommands (_swift_base_preprocessor (commandline -opc))
+    set -l expectedCommands (string split " " $argv[1])
+    set -l subcommands (string split " " $argv[2])
+    if [ (count $currentCommands) -ge (count $expectedCommands) ]
+        for i in (seq (count $expectedCommands))
+            if [ $currentCommands[$i] != $expectedCommands[$i] ]
                 return 1
+            end
+        end
+        if [ (count $currentCommands) -eq (count $expectedCommands) ]
+            return 0
+        end
+        if [ (count $subcommands) -gt 1 ]
+            for i in (seq (count $subcommands))
+                if [ $currentCommands[(math (count $expectedCommands) + 1)] = $subcommands[$i] ]
+                    return 1
+                end
             end
         end
         return 0
     end
     return 1
 end
-complete -c base -n '_swift_base_using_command base' -f -r -l name -d 'The user\\'s name.'
-complete -c base -n '_swift_base_using_command base' -f -r -l kind
-complete -c base -n '_swift_base_using_command base --kind' -f -k -a 'one two custom-three'
-complete -c base -n '_swift_base_using_command base' -f -r -l other-kind
-complete -c base -n '_swift_base_using_command base --other-kind' -f -k -a '1 2 3'
-complete -c base -n '_swift_base_using_command base' -f -r -l path1
-complete -c base -n '_swift_base_using_command base --path1' -f -a '(for i in *.{}; echo $i;end)'
-complete -c base -n '_swift_base_using_command base' -f -r -l path2
-complete -c base -n '_swift_base_using_command base --path2' -f -a '(for i in *.{}; echo $i;end)'
-complete -c base -n '_swift_base_using_command base' -f -r -l path3
-complete -c base -n '_swift_base_using_command base --path3' -f -k -a 'a b c'
-complete -c base -n '_swift_base_using_command base' -f -s h -l help -d 'Show help information.'
+
+complete -c base -n '_swift_base_using_command \"base\"' -l name -d 'The user\\\'s name.'
+complete -c base -n '_swift_base_using_command \"base\"' -l kind -r -f -k -a 'one two custom-three'
+complete -c base -n '_swift_base_using_command \"base\"' -l other-kind -r -f -k -a '1 2 3'
+complete -c base -n '_swift_base_using_command \"base\"' -l path1 -r -f -a '(for i in *.{}; echo $i;end)'
+complete -c base -n '_swift_base_using_command \"base\"' -l path2 -r -f -a '(for i in *.{}; echo $i;end)'
+complete -c base -n '_swift_base_using_command \"base\"' -l path3 -r -f -k -a 'a b c'
+complete -c base -n '_swift_base_using_command \"base\"' -s h -l help -d 'Show help information.'
 """
 
 // MARK: - Test Hidden Subcommand
@@ -365,17 +385,42 @@ complete -F _parent parent
 """
 
 let fishHiddenCompletion = """
+# A function which filters options which starts with "-" from $argv.
+function _swift_parent_preprocessor
+    set -l results
+    for i in (seq (count $argv))
+        switch (echo $argv[$i] | string sub -l 1)
+            case '-'
+            case '*'
+                echo $argv[$i]
+        end
+    end
+end
+
 function _swift_parent_using_command
-    set -l cmd (commandline -opc)
-    if [ (count $cmd) -eq (count $argv) ]
-        for i in (seq (count $argv))
-            if [ $cmd[$i] != $argv[$i] ]
+    set -l currentCommands (_swift_parent_preprocessor (commandline -opc))
+    set -l expectedCommands (string split " " $argv[1])
+    set -l subcommands (string split " " $argv[2])
+    if [ (count $currentCommands) -ge (count $expectedCommands) ]
+        for i in (seq (count $expectedCommands))
+            if [ $currentCommands[$i] != $expectedCommands[$i] ]
                 return 1
+            end
+        end
+        if [ (count $currentCommands) -eq (count $expectedCommands) ]
+            return 0
+        end
+        if [ (count $subcommands) -gt 1 ]
+            for i in (seq (count $subcommands))
+                if [ $currentCommands[(math (count $expectedCommands) + 1)] = $subcommands[$i] ]
+                    return 1
+                end
             end
         end
         return 0
     end
     return 1
 end
-complete -c parent -n '_swift_parent_using_command parent' -f -s h -l help -d 'Show help information.'
+
+complete -c parent -n '_swift_parent_using_command \"parent\"' -s h -l help -d 'Show help information.'
 """


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->
A generated fish script didn't complete an option after an argument.

The cause is the generated fish script doesn't accept an input text which already has arguments. 
For example, when the input is `repeat -`, the script can complete `--count`, but when the text is `repeat foo -`, the script cannot complete `repeat foo --count`, because the input text already has the argument "foo".

To fix the issue, I implemented the following steps.
1. Preprocess for the subcommand.
To support options of the root command like `math --version add`, `--version` is removed by `_swift_{command name}_preprocessor`.

2. Decide a command.
In a case when a command has some subcommands like `math stats average 1 10 100 --kind mean`, we need to decide the target command.  (In the example  case, the target command is `average`.)
To decide it, the newly generated script receives `expected command` and `subcommands`.
(e,g,)
    1. A case checking whether the target command is `stats` or not.
        - `expected command` = `math stats`
        - `subcommands` = `average stdev quantiles help`
    2. A case checking whether the target command is `average` or not.
        - `expected command` = `math stats average`
        - `subcommands` is empty (`average` doesn't have any subcommands.)`

    When the input has the expected command, and a text after the expected command is not the subcommand, the newly generated script decide the command is a target command, and suggest options for the target command.

### Related issues
- #376
- #534

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
