### PR TITLE
Include more platforms in `count-lines` availability

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -58,7 +58,7 @@ extension CountLines {
     }
     
     mutating func run() async throws {
-        guard #available(macOS 12, *) else {
+        guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
           print("'count-lines' isn't supported on this platform.")
           return
         }


### PR DESCRIPTION
The `CountLines` executable is failing to build on non-macOS platforms, [as seen here](https://swiftpackageindex.com/apple/swift-argument-parser/builds), due to missing availability annotations before using `FileHandle.AsyncBytes.lines`. This change adds the missing availability to match.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
