### PR TITLE
Fix .postTerminator usage message

### DIFF
--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -116,6 +116,9 @@ extension ArgumentDefinition {
     if help.options.contains(.isOptional) {
       synopsis = "[\(synopsis)]"
     }
+    if parsingStrategy == .postTerminator {
+      synopsis = "-- \(synopsis)"
+    }
     return synopsis
   }
 }

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -217,4 +217,13 @@ extension UsageGenerationTests {
     _testSynopsis(N.self, expected: "example [--a] [--b]")
     _testSynopsis(N.self, visibility: .hidden, expected: "example [--a] [--b]")
   }
+  
+  struct O: ParsableArguments {
+    @Argument var a: String
+    @Argument(parsing: .postTerminator) var b: [String] = []
+  }
+  
+  func testSynopsisWithPostTerminatorParsingStrategy() {
+    _testSynopsis(O.self, expected: "example <a> -- [<b> ...]")
+  }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

The purpose of this PR is to fix issue https://github.com/apple/swift-argument-parser/issues/541. It fixes the `USAGE` text when generated with arguments using the `.postTerminator` parsing strategy.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
