### PR TITLE
Fix Swift 5.6 compatibility

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -37,7 +37,7 @@ extension FishCompletionsGenerator {
       "\(prefix) \(suggestion)"
     }
 
-    let subcommandCompletions = subcommands.map { subcommand in
+    let subcommandCompletions: [String] = subcommands.map { subcommand in
       let escapedAbstract = subcommand.configuration.abstract.fishEscape()
       let suggestion = "-f -a '\(subcommand._commandName)' -d '\(escapedAbstract)'"
       return complete(suggestion: suggestion)


### PR DESCRIPTION
This provide type annotation for a multi-line closure, which can only have an inferred return type in Swift 5.7.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
