### PR TITLE
Don't let .allUnrecognized consume built-in flags

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -165,17 +165,23 @@ extension ParsableCommand {
 extension ParsableCommand {
   /// `true` if this command contains any array arguments that are declared
   /// with `.unconditionalRemaining`.
-  internal static var includesUnconditionalArguments: Bool {
+  internal static var includesPassthroughArguments: Bool {
     ArgumentSet(self, visibility: .private, parent: nil).contains(where: {
       $0.isRepeatingPositional && $0.parsingStrategy == .allRemainingInput
+    })
+  }
+  
+  internal static var includesAllUnrecognizedArgument: Bool {
+    ArgumentSet(self, visibility: .private, parent: nil).contains(where: {
+      $0.isRepeatingPositional && $0.parsingStrategy == .allUnrecognized
     })
   }
   
   /// `true` if this command's default subcommand contains any array arguments
   /// that are declared with `.unconditionalRemaining`. This is `false` if
   /// there's no default subcommand.
-  internal static var defaultIncludesUnconditionalArguments: Bool {
-    configuration.defaultSubcommand?.includesUnconditionalArguments == true
+  internal static var defaultIncludesPassthroughArguments: Bool {
+    configuration.defaultSubcommand?.includesPassthroughArguments == true
   }
   
 #if DEBUG

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -160,256 +160,6 @@ extension ArgumentSet {
   }
 }
 
-// MARK: - Parsing from SplitArguments
-extension ArgumentSet {
-  /// Parse the given input for this set of defined arguments.
-  ///
-  /// This method will consume only the arguments that it understands. If any
-  /// arguments are declared to capture all remaining input, or a subcommand
-  /// is configured as such, parsing stops on the first positional argument or
-  /// unrecognized dash-prefixed argument.
-  ///
-  /// - Parameter input: The input that needs to be parsed.
-  /// - Parameter subcommands: Any subcommands of the current command.
-  /// - Parameter defaultCapturesAll: `true` if the default subcommand has an
-  ///   argument that captures all remaining input.
-  func lenientParse(
-    _ input: SplitArguments,
-    subcommands: [ParsableCommand.Type],
-    defaultCapturesAll: Bool
-  ) throws -> ParsedValues {
-    // Create a local, mutable copy of the arguments:
-    var inputArguments = input
-    
-    func parseValue(
-      _ argument: ArgumentDefinition,
-      _ parsed: ParsedArgument,
-      _ originElement: InputOrigin.Element,
-      _ update: ArgumentDefinition.Update.Unary,
-      _ result: inout ParsedValues,
-      _ usedOrigins: inout InputOrigin
-    ) throws {
-      let origin = InputOrigin(elements: [originElement])
-      switch argument.parsingStrategy {
-      case .default:
-        // We need a value for this option.
-        if let value = parsed.value {
-          // This was `--foo=bar` style:
-          try update(origin, parsed.name, value, &result)
-          usedOrigins.formUnion(origin)
-        } else if argument.allowsJoinedValue,
-           let (origin2, value) = inputArguments.extractJoinedElement(at: originElement)
-        {
-          // Found a joined argument
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, String(value), &result)
-          usedOrigins.formUnion(origins)
-        } else if let (origin2, value) = inputArguments.popNextElementIfValue(after: originElement) {
-          // Use `popNextElementIfValue(after:)` to handle cases where short option
-          // labels are combined
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, value, &result)
-          usedOrigins.formUnion(origins)
-        } else {
-          throw ParserError.missingValueForOption(origin, parsed.name)
-        }
-        
-      case .scanningForValue:
-        // We need a value for this option.
-        if let value = parsed.value {
-          // This was `--foo=bar` style:
-          try update(origin, parsed.name, value, &result)
-          usedOrigins.formUnion(origin)
-        } else if argument.allowsJoinedValue,
-            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
-          // Found a joined argument
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, String(value), &result)
-          usedOrigins.formUnion(origins)
-        } else if let (origin2, value) = inputArguments.popNextValue(after: originElement) {
-          // Use `popNext(after:)` to handle cases where short option
-          // labels are combined
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, value, &result)
-          usedOrigins.formUnion(origins)
-        } else {
-          throw ParserError.missingValueForOption(origin, parsed.name)
-        }
-        
-      case .unconditional:
-        // Use an attached value if it exists...
-        if let value = parsed.value {
-          // This was `--foo=bar` style:
-          try update(origin, parsed.name, value, &result)
-          usedOrigins.formUnion(origin)
-        } else if argument.allowsJoinedValue,
-            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
-          // Found a joined argument
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, String(value), &result)
-          usedOrigins.formUnion(origins)
-        } else {
-          guard let (origin2, value) = inputArguments.popNextElementAsValue(after: originElement) else {
-            throw ParserError.missingValueForOption(origin, parsed.name)
-          }
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, value, &result)
-          usedOrigins.formUnion(origins)
-        }
-        
-      case .allRemainingInput:
-        // Reset initial value with the found input origins:
-        try argument.initial(origin, &result)
-        
-        // Use an attached value if it exists...
-        if let value = parsed.value {
-          // This was `--foo=bar` style:
-          try update(origin, parsed.name, value, &result)
-          usedOrigins.formUnion(origin)
-        } else if argument.allowsJoinedValue,
-            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
-          // Found a joined argument
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, String(value), &result)
-          usedOrigins.formUnion(origins)
-          inputArguments.removeAll(in: usedOrigins)
-        }
-        
-        // ...and then consume the rest of the arguments
-        while let (origin2, value) = inputArguments.popNextElementAsValue(after: originElement) {
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, value, &result)
-          usedOrigins.formUnion(origins)
-        }
-        
-      case .upToNextOption:
-        // Use an attached value if it exists...
-        if let value = parsed.value {
-          // This was `--foo=bar` style:
-          try update(origin, parsed.name, value, &result)
-          usedOrigins.formUnion(origin)
-        } else if argument.allowsJoinedValue,
-            let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
-          // Found a joined argument
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, String(value), &result)
-          usedOrigins.formUnion(origins)
-          inputArguments.removeAll(in: usedOrigins)
-        }
-        
-        // Clear out the initial origin first, since it can include
-        // the exploded elements of an options group (see issue #327).
-        usedOrigins.formUnion(origin)
-        inputArguments.removeAll(in: origin)
-        
-        // Fix incorrect error message
-        // for @Option array without values (see issue #434).
-        guard let first = inputArguments.elements.first,
-              first.isValue
-        else {
-          throw ParserError.missingValueForOption(origin, parsed.name)
-        }
-        
-        // ...and then consume the arguments until hitting an option
-        while let (origin2, value) = inputArguments.popNextElementIfValue() {
-          let origins = origin.inserting(origin2)
-          try update(origins, parsed.name, value, &result)
-          usedOrigins.formUnion(origins)
-        }
-        
-      case .postTerminator, .allUnrecognized:
-        // These parsing kinds are for arguments only.
-        throw ParserError.invalidState
-      }
-    }
-    
-    // If this argument set includes a positional argument that unconditionally
-    // captures all remaining input, we use a different behavior, where we
-    // shortcut out at the first sign of a positional argument or unrecognized
-    // option/flag label.
-    let capturesAll = defaultCapturesAll || self.contains(where: { arg in
-      arg.isRepeatingPositional && arg.parsingStrategy == .allRemainingInput
-    })
-    
-    var result = ParsedValues(elements: [:], originalInput: input.originalInput)
-    var allUsedOrigins = InputOrigin()
-    
-    try setInitialValues(into: &result)
-    
-    // Loop over all arguments:
-    ArgumentLoop:
-    while let (origin, next) = inputArguments.popNext() {
-      var usedOrigins = InputOrigin()
-      defer {
-        inputArguments.removeAll(in: usedOrigins)
-        allUsedOrigins.formUnion(usedOrigins)
-      }
-      
-      switch next.value {
-      case .value(let argument):
-        // Special handling for matching subcommand names. We generally want
-        // parsing to skip over unrecognized input, but if the current
-        // command or the matched subcommand captures all remaining input,
-        // then we want to break out of parsing at this point.
-        if let matchedSubcommand = subcommands.first(where: { $0._commandName == argument }) {
-          if !matchedSubcommand.includesUnconditionalArguments && defaultCapturesAll {
-            continue ArgumentLoop
-          } else if matchedSubcommand.includesUnconditionalArguments {
-            break ArgumentLoop
-          }
-        }
-        
-        // If we're capturing all, the first positional value represents the
-        // start of positional input.
-        if capturesAll { break ArgumentLoop }
-        // We'll parse positional values later.
-        break
-      case let .option(parsed):
-        // Look for an argument that matches this `--option` or `-o`-style
-        // input. If we can't find one, just move on to the next input. We
-        // defer catching leftover arguments until we've fully extracted all
-        // the information for the selected command.
-        guard let argument = first(matching: parsed) else
-        {
-          // If we're capturing all, an unrecognized option/flag is the start
-          // of positional input. However, the first time we see an option
-          // pack (like `-fi`) it looks like a long name with a single-dash
-          // prefix, which may not match an argument even if its subcomponents
-          // will match.
-          if capturesAll && parsed.subarguments.isEmpty { break ArgumentLoop }
-          
-          // Otherwise, continue parsing. This option/flag may get picked up
-          // by a child command.
-          continue
-        }
-        
-        switch argument.update {
-        case let .nullary(update):
-          // We don’t expect a value for this option.
-          guard parsed.value == nil else {
-            throw ParserError.unexpectedValueForOption(origin, parsed.name, parsed.value!)
-          }
-          try update([origin], parsed.name, &result)
-          usedOrigins.insert(origin)
-        case let .unary(update):
-          try parseValue(argument, parsed, origin, update, &result, &usedOrigins)
-        }
-      case .terminator:
-        // Ignore the terminator, it might get picked up as a positional value later.
-        break
-      }
-    }
-    
-    // We have parsed all non-positional values at this point.
-    // Next: parse / consume the positional values.
-    var unusedArguments = input
-    unusedArguments.removeAll(in: allUsedOrigins)
-    try parsePositionalValues(from: unusedArguments, into: &result)
-
-    return result
-  }
-}
-
 extension ArgumentSet {
   /// Fills the given `ParsedValues` instance with initial values from this
   /// argument set.
@@ -441,8 +191,177 @@ extension ArgumentSet {
     let key = InputKey(name: name, parent: nil)
     return first(where: { $0.help.keys.contains(key) })
   }
+}
+
+/// A parser for a given input and set of arguments defined by the given
+/// command.
+///
+/// This parser will consume only the arguments that it understands. If any
+/// arguments are declared to capture all remaining input, or a subcommand
+/// is configured as such, parsing stops on the first positional argument or
+/// unrecognized dash-prefixed argument.
+struct LenientParser {
+  var command: ParsableCommand.Type
+  var argumentSet: ArgumentSet
+  var inputArguments: SplitArguments
   
-  func parsePositionalValues(
+  init(_ command: ParsableCommand.Type, _ split: SplitArguments) {
+    self.command = command
+    self.argumentSet = ArgumentSet(command, visibility: .private, parent: nil)
+    self.inputArguments = split
+  }
+  
+  var defaultCapturesForPassthrough: Bool {
+    command.defaultIncludesPassthroughArguments
+  }
+  
+  var subcommands: [ParsableCommand.Type] {
+    command.configuration.subcommands
+  }
+  
+  mutating func parseValue(
+    _ argument: ArgumentDefinition,
+    _ parsed: ParsedArgument,
+    _ originElement: InputOrigin.Element,
+    _ update: ArgumentDefinition.Update.Unary,
+    _ result: inout ParsedValues,
+    _ usedOrigins: inout InputOrigin
+  ) throws {
+    let origin = InputOrigin(elements: [originElement])
+    switch argument.parsingStrategy {
+    case .default:
+      // We need a value for this option.
+      if let value = parsed.value {
+        // This was `--foo=bar` style:
+        try update(origin, parsed.name, value, &result)
+        usedOrigins.formUnion(origin)
+      } else if argument.allowsJoinedValue,
+         let (origin2, value) = inputArguments.extractJoinedElement(at: originElement)
+      {
+        // Found a joined argument
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, String(value), &result)
+        usedOrigins.formUnion(origins)
+      } else if let (origin2, value) = inputArguments.popNextElementIfValue(after: originElement) {
+        // Use `popNextElementIfValue(after:)` to handle cases where short option
+        // labels are combined
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, value, &result)
+        usedOrigins.formUnion(origins)
+      } else {
+        throw ParserError.missingValueForOption(origin, parsed.name)
+      }
+      
+    case .scanningForValue:
+      // We need a value for this option.
+      if let value = parsed.value {
+        // This was `--foo=bar` style:
+        try update(origin, parsed.name, value, &result)
+        usedOrigins.formUnion(origin)
+      } else if argument.allowsJoinedValue,
+          let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+        // Found a joined argument
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, String(value), &result)
+        usedOrigins.formUnion(origins)
+      } else if let (origin2, value) = inputArguments.popNextValue(after: originElement) {
+        // Use `popNext(after:)` to handle cases where short option
+        // labels are combined
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, value, &result)
+        usedOrigins.formUnion(origins)
+      } else {
+        throw ParserError.missingValueForOption(origin, parsed.name)
+      }
+      
+    case .unconditional:
+      // Use an attached value if it exists...
+      if let value = parsed.value {
+        // This was `--foo=bar` style:
+        try update(origin, parsed.name, value, &result)
+        usedOrigins.formUnion(origin)
+      } else if argument.allowsJoinedValue,
+          let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+        // Found a joined argument
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, String(value), &result)
+        usedOrigins.formUnion(origins)
+      } else {
+        guard let (origin2, value) = inputArguments.popNextElementAsValue(after: originElement) else {
+          throw ParserError.missingValueForOption(origin, parsed.name)
+        }
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, value, &result)
+        usedOrigins.formUnion(origins)
+      }
+      
+    case .allRemainingInput:
+      // Reset initial value with the found input origins:
+      try argument.initial(origin, &result)
+      
+      // Use an attached value if it exists...
+      if let value = parsed.value {
+        // This was `--foo=bar` style:
+        try update(origin, parsed.name, value, &result)
+        usedOrigins.formUnion(origin)
+      } else if argument.allowsJoinedValue,
+          let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+        // Found a joined argument
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, String(value), &result)
+        usedOrigins.formUnion(origins)
+        inputArguments.removeAll(in: usedOrigins)
+      }
+      
+      // ...and then consume the rest of the arguments
+      while let (origin2, value) = inputArguments.popNextElementAsValue(after: originElement) {
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, value, &result)
+        usedOrigins.formUnion(origins)
+      }
+      
+    case .upToNextOption:
+      // Use an attached value if it exists...
+      if let value = parsed.value {
+        // This was `--foo=bar` style:
+        try update(origin, parsed.name, value, &result)
+        usedOrigins.formUnion(origin)
+      } else if argument.allowsJoinedValue,
+          let (origin2, value) = inputArguments.extractJoinedElement(at: originElement) {
+        // Found a joined argument
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, String(value), &result)
+        usedOrigins.formUnion(origins)
+        inputArguments.removeAll(in: usedOrigins)
+      }
+      
+      // Clear out the initial origin first, since it can include
+      // the exploded elements of an options group (see issue #327).
+      usedOrigins.formUnion(origin)
+      inputArguments.removeAll(in: origin)
+      
+      // Fix incorrect error message
+      // for @Option array without values (see issue #434).
+      guard let first = inputArguments.elements.first,
+            first.isValue
+      else {
+        throw ParserError.missingValueForOption(origin, parsed.name)
+      }
+      
+      // ...and then consume the arguments until hitting an option
+      while let (origin2, value) = inputArguments.popNextElementIfValue() {
+        let origins = origin.inserting(origin2)
+        try update(origins, parsed.name, value, &result)
+        usedOrigins.formUnion(origins)
+      }
+      
+    case .postTerminator, .allUnrecognized:
+      // These parsing kinds are for arguments only.
+      throw ParserError.invalidState
+    }
+  }
+  
+  mutating func parsePositionalValues(
     from unusedInput: SplitArguments,
     into result: inout ParsedValues
   ) throws {
@@ -451,7 +370,7 @@ extension ArgumentSet {
     // If this argument set includes a definition that should collect all the
     // post-terminator inputs, capture them before trying to fill other
     // `@Argument` definitions.
-    if let postTerminatorArg = self.first(where: { def in
+    if let postTerminatorArg = argumentSet.first(where: { def in
       def.isRepeatingPositional && def.parsingStrategy == .postTerminator
     }),
        case let .unary(update) = postTerminatorArg.update,
@@ -489,7 +408,7 @@ extension ArgumentSet {
     // For all positional arguments, consume one or more inputs.
     var usedOrigins = InputOrigin()
     ArgumentLoop:
-    for argumentDefinition in self {
+    for argumentDefinition in argumentSet {
       guard case .positional = argumentDefinition.kind else { continue }
       switch argumentDefinition.parsingStrategy {
       case .default, .allRemainingInput:
@@ -514,16 +433,109 @@ extension ArgumentSet {
     }
         
     // If there's an `.allUnrecognized` argument array, collect leftover args.
-    if let allUnrecognizedArg = self.first(where: { def in
+    if let allUnrecognizedArg = argumentSet.first(where: { def in
       def.isRepeatingPositional && def.parsingStrategy == .allUnrecognized
     }),
        case let .unary(update) = allUnrecognizedArg.update
     {
+      result.capturedUnrecognizedArguments = SplitArguments(
+        _elements: Array(argumentStack),
+        originalInput: [])
       while let arg = argumentStack.popFirst() {
         let origin: InputOrigin.Element = .argumentIndex(arg.index)
         let value = unusedInput.originalInput(at: origin)!
         try update([origin], nil, value, &result)
       }
     }
+  }
+
+  mutating func parse() throws -> ParsedValues {
+    let originalInput = inputArguments
+    defer { inputArguments = originalInput }
+    
+    // If this argument set includes a positional argument that unconditionally
+    // captures all remaining input, we use a different behavior, where we
+    // shortcut out at the first sign of a positional argument or unrecognized
+    // option/flag label.
+    let capturesForPassthrough = defaultCapturesForPassthrough || argumentSet.contains(where: { arg in
+      arg.isRepeatingPositional && arg.parsingStrategy == .allRemainingInput
+    })
+    
+    var result = ParsedValues(elements: [:], originalInput: inputArguments.originalInput)
+    var allUsedOrigins = InputOrigin()
+    
+    try argumentSet.setInitialValues(into: &result)
+    
+    // Loop over all arguments:
+    ArgumentLoop:
+    while let (origin, next) = inputArguments.popNext() {
+      var usedOrigins = InputOrigin()
+      defer {
+        inputArguments.removeAll(in: usedOrigins)
+        allUsedOrigins.formUnion(usedOrigins)
+      }
+      
+      switch next.value {
+      case .value(let argument):
+        // Special handling for matching subcommand names. We generally want
+        // parsing to skip over unrecognized input, but if the current
+        // command or the matched subcommand captures all remaining input,
+        // then we want to break out of parsing at this point.
+        if let matchedSubcommand = subcommands.first(where: { $0._commandName == argument }) {
+          if !matchedSubcommand.includesPassthroughArguments && defaultCapturesForPassthrough {
+            continue ArgumentLoop
+          } else if matchedSubcommand.includesPassthroughArguments {
+            break ArgumentLoop
+          }
+        }
+        
+        // If we're capturing all, the first positional value represents the
+        // start of positional input.
+        if capturesForPassthrough { break ArgumentLoop }
+        // We'll parse positional values later.
+        break
+      case let .option(parsed):
+        // Look for an argument that matches this `--option` or `-o`-style
+        // input. If we can't find one, just move on to the next input. We
+        // defer catching leftover arguments until we've fully extracted all
+        // the information for the selected command.
+        guard let argument = argumentSet.first(matching: parsed) else
+        {
+          // If we're capturing all, an unrecognized option/flag is the start
+          // of positional input. However, the first time we see an option
+          // pack (like `-fi`) it looks like a long name with a single-dash
+          // prefix, which may not match an argument even if its subcomponents
+          // will match.
+          if capturesForPassthrough && parsed.subarguments.isEmpty { break ArgumentLoop }
+          
+          // Otherwise, continue parsing. This option/flag may get picked up
+          // by a child command.
+          continue
+        }
+        
+        switch argument.update {
+        case let .nullary(update):
+          // We don’t expect a value for this option.
+          guard parsed.value == nil else {
+            throw ParserError.unexpectedValueForOption(origin, parsed.name, parsed.value!)
+          }
+          try update([origin], parsed.name, &result)
+          usedOrigins.insert(origin)
+        case let .unary(update):
+          try parseValue(argument, parsed, origin, update, &result, &usedOrigins)
+        }
+      case .terminator:
+        // Ignore the terminator, it might get picked up as a positional value later.
+        break
+      }
+    }
+    
+    // We have parsed all non-positional values at this point.
+    // Next: parse / consume the positional values.
+    var unusedArguments = originalInput
+    unusedArguments.removeAll(in: allUsedOrigins)
+    try parsePositionalValues(from: unusedArguments, into: &result)
+
+    return result
   }
 }

--- a/Sources/ArgumentParser/Parsing/ParsedValues.swift
+++ b/Sources/ArgumentParser/Parsing/ParsedValues.swift
@@ -28,6 +28,9 @@ struct ParsedValues {
   ///
   /// This is used for error output generation.
   var originalInput: [String]
+  
+  /// Any arguments that are captured into an `.allUnrecognized` argument.
+  var capturedUnrecognizedArguments = SplitArguments(originalInput: [])
 }
 
 extension ParsedValues {

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -186,6 +186,8 @@ struct SplitArguments {
   }
 }
 
+extension SplitArguments: Equatable {}
+
 extension SplitArguments.Element: CustomDebugStringConvertible {
   var debugDescription: String {
     switch value {
@@ -272,14 +274,14 @@ extension SplitArguments {
   }
   
   /// Returns the position in `elements` of the given input origin.
-  mutating func position(of origin: InputOrigin.Element) -> Int? {
+  func position(of origin: InputOrigin.Element) -> Int? {
     guard case let .argumentIndex(index) = origin else { return nil }
     return elements.firstIndex(where: { $0.index == index })
   }
   
   /// Returns the position in `elements` of the first element after the given
   /// input origin.
-  mutating func position(after origin: InputOrigin.Element) -> Int? {
+  func position(after origin: InputOrigin.Element) -> Int? {
     guard case let .argumentIndex(index) = origin else { return nil }
     return elements.firstIndex(where: { $0.index > index })
   }
@@ -295,7 +297,7 @@ extension SplitArguments {
     return (.argumentIndex(element.index), element)
   }
   
-  mutating func extractJoinedElement(at origin: InputOrigin.Element) -> (InputOrigin.Element, String)? {
+  func extractJoinedElement(at origin: InputOrigin.Element) -> (InputOrigin.Element, String)? {
     guard case let .argumentIndex(index) = origin else { return nil }
     
     // Joined arguments only apply when parsing the first sub-element of a


### PR DESCRIPTION
Arguments declared with the `.allUnrecognized` parsing strategy currently capture built-in flags, which isn't intended. This fixes that issue by looking for built-in flags in the captured portion of the input before decoding.

Fixes rdar://104990388

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
