### PR TITLE
Handle unparsed non-optional complex property types

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
@@ -95,8 +95,8 @@ final class ParsedArgumentsContainer<K>: KeyedDecodingContainerProtocol where K 
     ///
     /// This is, in essence, an iterative inverse of the `element(forKey:)` method.
     self.decoder.values.elements.keys
-        .filter { $0.path == self.codingPath.map(\.stringValue) }
-        .compactMap { K.init(stringValue: $0.name) }
+      .filter { $0.path == self.codingPath.map(\.stringValue) }
+      .compactMap { K.init(stringValue: $0.name) }
   }
   
   fileprivate func element(forKey key: K) -> ParsedValues.Element? {
@@ -115,10 +115,10 @@ final class ParsedArgumentsContainer<K>: KeyedDecodingContainerProtocol where K 
   func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
     let parsedElement = element(forKey: key)
     if parsedElement?.inputOrigin.isDefaultValue ?? false, let rawValue = parsedElement?.value {
-        guard let value = rawValue as? T else {
-            throw InternalParseError.wrongType(rawValue, forKey: parsedElement!.key)
-        }
-        return value
+      guard let value = rawValue as? T else {
+        throw InternalParseError.wrongType(rawValue, forKey: parsedElement!.key)
+      }
+      return value
     }
     let subDecoder = SingleValueDecoder(userInfo: decoder.userInfo, underlying: decoder, codingPath: codingPath + [key], key: InputKey(codingKey: key, path: codingPath), parsedElement: element(forKey: key))
     return try type.init(from: subDecoder)

--- a/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
@@ -86,17 +86,7 @@ final class ParsedArgumentsContainer<K>: KeyedDecodingContainerProtocol where K 
   }
   
   var allKeys: [K] {
-    /// This logic selects only those element keys which satisfy both of two conditions:
-    ///
-    /// 1. The input key's path is exactly equal to this container's coding path,
-    ///    neither shallower nor deeper.
-    /// 2. An instance of this container's coding key type can be instantiated using
-    ///    the input key's name.
-    ///
-    /// This is, in essence, an iterative inverse of the `element(forKey:)` method.
-    self.decoder.values.elements.keys
-      .filter { $0.path == self.codingPath.map(\.stringValue) }
-      .compactMap { K.init(stringValue: $0.name) }
+    fatalError()
   }
   
   fileprivate func element(forKey key: K) -> ParsedValues.Element? {

--- a/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
+++ b/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
@@ -260,68 +260,68 @@ extension UnparsedValuesEndToEndTests {
 // MARK: Value + unparsed dictionary
 
 fileprivate struct Bamf: ParsableCommand {
-    @Flag var bamph: Bool = false
-    var bop: [String: String] = [:]
-    var bopp: [String: [String]] = [:]
+  @Flag var bamph: Bool = false
+  var bop: [String: String] = [:]
+  var bopp: [String: [String]] = [:]
 }
 
 extension UnparsedValuesEndToEndTests {
-    func testUnparsedNestedDictionary() {
-        AssertParse(Bamf.self, []) { bamf in
-            XCTAssertFalse(bamf.bamph)
-            XCTAssertEqual(bamf.bop, [:])
-            XCTAssertEqual(bamf.bopp, [:])
-        }
+  func testUnparsedNestedDictionary() {
+    AssertParse(Bamf.self, []) { bamf in
+      XCTAssertFalse(bamf.bamph)
+      XCTAssertEqual(bamf.bop, [:])
+      XCTAssertEqual(bamf.bopp, [:])
     }
+  }
 }
 
 // MARK: Value + unparsed enum with associated values
 
 fileprivate struct Qiqi: ParsableCommand {
-    @Flag var qiqiqi: Bool = false
-    var qiqii: Qiqii = .q("")
+  @Flag var qiqiqi: Bool = false
+  var qiqii: Qiqii = .q("")
 }
 
 fileprivate enum Qiqii: Codable, Equatable {
-    // Enums with associated values generate a Codable conformance
-    // which calls `KeyedDecodingContainer.nestedContainer(keyedBy:)`.
-    //
-    // There is no known case of anything ever actually using the
-    // `.nestedUnkeyedContainer()` method.
-    case q(String)
-    case i(Int)
+  // Enums with associated values generate a Codable conformance
+  // which calls `KeyedDecodingContainer.nestedContainer(keyedBy:)`.
+  //
+  // There is no known case of anything ever actually using the
+  // `.nestedUnkeyedContainer()` method.
+  case q(String)
+  case i(Int)
 }
 
 extension UnparsedValuesEndToEndTests {
-    func testUnparsedEnumWithAssociatedValues() {
-        AssertParse(Qiqi.self, []) { qiqi in
-            XCTAssertFalse(qiqi.qiqiqi)
-            XCTAssertEqual(qiqi.qiqii, .q(""))
-        }
+  func testUnparsedEnumWithAssociatedValues() {
+    AssertParse(Qiqi.self, []) { qiqi in
+      XCTAssertFalse(qiqi.qiqiqi)
+      XCTAssertEqual(qiqi.qiqii, .q(""))
     }
+  }
 }
 
 // MARK: Value + nested decodable inheriting class type
 
 fileprivate struct Fry: ParsableCommand {
-    @Flag var c: Bool = false
-    var toksVig: Vig = .init()
+  @Flag var c: Bool = false
+  var toksVig: Vig = .init()
 }
 
 fileprivate class Toks: Codable {
-    var a = "hello"
+  var a = "hello"
 }
 
 fileprivate final class Vig: Toks {
-    var b = "world"
+  var b = "world"
 }
 
 extension UnparsedValuesEndToEndTests {
-    func testUnparsedNestedInheritingClassType() {
-        AssertParse(Fry.self, []) { fry in
-            XCTAssertFalse(fry.c)
-            XCTAssertEqual(fry.toksVig.a, "hello")
-            XCTAssertEqual(fry.toksVig.b, "world")
-        }
+  func testUnparsedNestedInheritingClassType() {
+    AssertParse(Fry.self, []) { fry in
+      XCTAssertFalse(fry.c)
+      XCTAssertEqual(fry.toksVig.a, "hello")
+      XCTAssertEqual(fry.toksVig.b, "world")
     }
+  }
 }

--- a/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
+++ b/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
@@ -256,3 +256,72 @@ extension UnparsedValuesEndToEndTests {
     XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "xyz", "--age", "None"]))
   }
 }
+
+// MARK: Value + unparsed dictionary
+
+fileprivate struct Bamf: ParsableCommand {
+    @Flag var bamph: Bool = false
+    var bop: [String: String] = [:]
+    var bopp: [String: [String]] = [:]
+}
+
+extension UnparsedValuesEndToEndTests {
+    func testUnparsedNestedDictionary() {
+        AssertParse(Bamf.self, []) { bamf in
+            XCTAssertFalse(bamf.bamph)
+            XCTAssertEqual(bamf.bop, [:])
+            XCTAssertEqual(bamf.bopp, [:])
+        }
+    }
+}
+
+// MARK: Value + unparsed enum with associated values
+
+fileprivate struct Qiqi: ParsableCommand {
+    @Flag var qiqiqi: Bool = false
+    var qiqii: Qiqii = .q("")
+}
+
+fileprivate enum Qiqii: Codable, Equatable {
+    // Enums with associated values generate a Codable conformance
+    // which calls `KeyedDecodingContainer.nestedContainer(keyedBy:)`.
+    //
+    // There is no known case of anything ever actually using the
+    // `.nestedUnkeyedContainer()` method.
+    case q(String)
+    case i(Int)
+}
+
+extension UnparsedValuesEndToEndTests {
+    func testUnparsedEnumWithAssociatedValues() {
+        AssertParse(Qiqi.self, []) { qiqi in
+            XCTAssertFalse(qiqi.qiqiqi)
+            XCTAssertEqual(qiqi.qiqii, .q(""))
+        }
+    }
+}
+
+// MARK: Value + nested decodable inheriting class type
+
+fileprivate struct Fry: ParsableCommand {
+    @Flag var c: Bool = false
+    var toksVig: Vig = .init()
+}
+
+fileprivate class Toks: Codable {
+    var a = "hello"
+}
+
+fileprivate final class Vig: Toks {
+    var b = "world"
+}
+
+extension UnparsedValuesEndToEndTests {
+    func testUnparsedNestedInheritingClassType() {
+        AssertParse(Fry.self, []) { fry in
+            XCTAssertFalse(fry.c)
+            XCTAssertEqual(fry.toksVig.a, "hello")
+            XCTAssertEqual(fry.toksVig.b, "world")
+        }
+    }
+}


### PR DESCRIPTION
As initially demonstrated in #553, the existing `ArgumentDecoder` logic fails when presented with a property which:

- Is unparsed
- Is not optional
- Has a default value, and
- Requests a keyed container during decoding

This occurs because while the actual property in question is properly assessed as having `.defaultValue` as an `InputOrigin`, the request for a keyed decoding container bypasses the logic which would otherwise return said default value, and since the `ArgumentDefinition` logic is (correctly) not recursive, the type fails to decode any keys it contains due to a "missing value".

The most straightforward solution I could find, one which covers all cases without negatively affecting handling of parsed properties (to the best of my ability to determine), was to apply the "default value" handling from the `decodeIfPresent<T>(_:forKey:)` method of the keyed decoding container (which ensured that _optional_ properties of this sort already worked correctly) to the more fundamental "bottleneck" `decode<T>(_:forKey:)` method as well, modified to throw a `wrongType` error instead of returning nil on type mismatch.

I additionally added a functioning `allKeys` property accessor for additional robustness against custom `Decodable.init(from:)` implementations. (The choice not to do the same for `nestedContainer(keyedBy:)`, `nestedUnkeyedContainer()`, `superDecoder()`, and `superDecoder(forKey:)` was simply pragmatic - it's not even close to worth the effort.)

Fixes #553 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
