### PR TITLE
Support passing arguments to async main

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -25,14 +25,18 @@ public protocol AsyncParsableCommand: ParsableCommand {
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncParsableCommand {
-  /// Executes this command, or one of its subcommands, with the program's
-  /// command-line arguments.
+  /// Executes this command, or one of its subcommands, with the given arguments.
   ///
-  /// Instead of calling this method directly, you can add `@main` to the root
-  /// command for your command-line tool.
-  public static func main() async {
+  /// This method parses an instance of this type, one of its subcommands, or
+  /// another built-in `AsyncParsableCommand` type, from command-line
+  /// (or provided) arguments, and then calls its `run()` method, exiting
+  /// with a relevant error message if necessary.
+  ///
+  /// - Parameter arguments: An array of arguments to use for parsing. If
+  ///   `arguments` is `nil`, this uses the program's command-line arguments.
+  public static func main(_ arguments: [String]?) async {
     do {
-      var command = try parseAsRoot()
+      var command = try parseAsRoot(arguments)
       if var asyncCommand = command as? AsyncParsableCommand {
         try await asyncCommand.run()
       } else {
@@ -41,6 +45,20 @@ extension AsyncParsableCommand {
     } catch {
       exit(withError: error)
     }
+  }
+
+  /// Executes this command, or one of its subcommands, with the program's
+  /// command-line arguments.
+  ///
+  /// Instead of calling this method directly, you can add `@main` to the root
+  /// command for your command-line tool.
+  ///
+  /// This method parses an instance of this type, one of its subcommands, or
+  /// another built-in `AsyncParsableCommand` type, from command-line arguments,
+  /// and then calls its `run()` method, exiting with a relevant error message
+  /// if necessary.
+  public static func main() async {
+    await self.main(nil)
   }
 }
 

--- a/Tests/ArgumentParserEndToEndTests/AsyncCommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/AsyncCommandEndToEndTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ArgumentParser
+
+final class AsyncCommandEndToEndTests: XCTestCase {
+}
+
+actor AsyncStatusCheck {
+  struct Status: OptionSet {
+    var rawValue: UInt8
+    
+    static var root: Self { .init(rawValue: 1 << 0) }
+    static var sub: Self  { .init(rawValue: 1 << 1) }
+  }
+  
+  @MainActor
+  var status: Status = []
+  
+  @MainActor
+  func update(_ status: Status) {
+    self.status.insert(status)
+  }
+}
+
+var statusCheck = AsyncStatusCheck()
+
+// MARK: AsyncParsableCommand.main() testing
+
+struct AsyncCommand: AsyncParsableCommand {
+  static var configuration: CommandConfiguration {
+    .init(subcommands: [SubCommand.self])
+  }
+  
+  func run() async throws {
+    await statusCheck.update(.root)
+  }
+  
+  struct SubCommand: AsyncParsableCommand {
+    func run() async throws {
+      await statusCheck.update(.sub)
+    }
+  }
+}
+
+extension AsyncCommandEndToEndTests {
+  @MainActor
+  func testAsyncMain_root() async throws {
+    XCTAssertFalse(statusCheck.status.contains(.root))
+    await AsyncCommand.main([])
+    XCTAssertTrue(statusCheck.status.contains(.root))
+  }
+  
+  @MainActor
+  func testAsyncMain_sub() async throws {
+    XCTAssertFalse(statusCheck.status.contains(.sub))
+    await AsyncCommand.main(["sub-command"])
+    XCTAssertTrue(statusCheck.status.contains(.sub))
+  }
+}

--- a/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
+++ b/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(EndToEndTests
+  AsyncCommandEndToEndTests.swift
   CustomParsingEndToEndTests.swift
   DefaultsEndToEndTests.swift
   EnumEndToEndTests.swift


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Adds a new static main function to `AsyncParsableCommand` to allow users to manually pass in arguments. The new functions behaves identically to the version found in `ParsableCommand` (see: https://github.com/apple/swift-argument-parser/blob/main/Sources/ArgumentParser/Parsable%20Types/ParsableCommand.swift#L126). This functionality is useful for manually building an argument list, e.g. when building a busybox~like binary.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
