### PR TITLE
Document ability to skip unknown parameters

### DIFF
--- a/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
@@ -468,3 +468,30 @@ Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
 % example -- --verbose file1.swift file2.swift --other
 Verbose: false, files: ["--", "--verbose", "file1.swift", "file2.swift", "--other"]
 ```
+
+### Ignoring unknown arguments/flags/options
+Different versions of CLI tool may have full or partial set of supported flags and options.
+
+By default, `ArgumentParser` throws the error if unknown arguments/flags/options are passed to command input.
+But in some cases that is convenient to just ignore unknowns and process supported ones.
+
+To achieve non-failable behaviour on unknown parameter, just collect unknowns in special `@Argument` with `.allUnrecognized` strategy.
+
+```swift
+struct Example: ParsableCommand {
+    @Flag var verbose = false
+    
+    @Argument(parsing: .allUnrecognized)
+    var unknowns: [String] = []
+
+    func run() throws {
+        print("Verbose: \(verbose)")
+    }
+}
+```
+
+This way any unknown parameters are just omitted.
+```
+% example --flag --verbose --option abc file1.swift
+Verbose: true
+```

--- a/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
@@ -469,13 +469,12 @@ Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
 Verbose: false, files: ["--", "--verbose", "file1.swift", "file2.swift", "--other"]
 ```
 
-### Ignoring unknown arguments/flags/options
-Different versions of CLI tool may have full or partial set of supported flags and options.
+### Ignoring unknown arguments
 
-By default, `ArgumentParser` throws the error if unknown arguments/flags/options are passed to command input.
-But in some cases that is convenient to just ignore unknowns and process supported ones.
+Different versions of a CLI tool may have full or partial sets of supported flags and options.
 
-To achieve non-failable behaviour on unknown parameter, just collect unknowns in special `@Argument` with `.allUnrecognized` strategy.
+By default, `ArgumentParser` throws an error if unknown arguments are passed as command input.
+When appropriate, you can process supported arguments and ignore unknown ones by collecting unknowns in special `@Argument` with the `.allUnrecognized` strategy.
 
 ```swift
 struct Example: ParsableCommand {
@@ -490,7 +489,8 @@ struct Example: ParsableCommand {
 }
 ```
 
-This way any unknown parameters are just omitted.
+This way any unknown parameters are silently captured in the `unknowns` array.
+
 ```
 % example --flag --verbose --option abc file1.swift
 Verbose: true


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Document ability to skip unknown parameters passed as command input
Fix #571 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
