### PR TITLE
Bash does not like '-' in function names

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -13,7 +13,7 @@ struct BashCompletionsGenerator {
   /// Generates a Bash completion script for the given command.
   static func generateCompletionScript(_ type: ParsableCommand.Type) -> String {
     // TODO: Add a check to see if the command is installed where we expect?
-    let initialFunctionName = [type].completionFunctionName()
+    let initialFunctionName = [type].completionFunctionName().makeSafeFunctionName
     return """
     #!/bin/bash
 
@@ -26,7 +26,7 @@ struct BashCompletionsGenerator {
   /// Generates a Bash completion function for the last command in the given list.
   fileprivate static func generateCompletionFunction(_ commands: [ParsableCommand.Type]) -> String {
     let type = commands.last!
-    let functionName = commands.completionFunctionName()
+    let functionName = commands.completionFunctionName().makeSafeFunctionName
     
     // The root command gets a different treatment for the parsing index.
     let isRootCommand = commands.count == 1
@@ -239,4 +239,10 @@ extension ArgumentDefinition {
       return #"COMPREPLY=( $(compgen -W "$("${COMP_WORDS[0]}" \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "$cur") )"#
     }
   }
+}
+
+extension String {
+    var makeSafeFunctionName: String {
+        self.replacingOccurrences(of: "-", with: "_")
+    }
 }


### PR DESCRIPTION
If a ParsableCommand has a `commandName` value with a hyphen, the bash completion generator will generate a function name with a hyphen which isn't valid in BASH, eg `_programName_command_sub-command': not a valid identifier`

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
