### PR TITLE
Skip count-lines tests in CI for now

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -13,7 +13,7 @@ import ArgumentParser
 import Foundation
 
 @main
-@available(macOS 10.15, *)
+@available(macOS 12, *)
 struct CountLines: AsyncParsableCommand {
     @Argument(
         help: "A file to count lines in. If omitted, counts the lines of stdin.",
@@ -27,7 +27,7 @@ struct CountLines: AsyncParsableCommand {
     var verbose = false
 }
 
-@available(macOS 10.15, *)
+@available(macOS 12, *)
 extension CountLines {
     var fileHandle: FileHandle {
         get throws {
@@ -58,11 +58,6 @@ extension CountLines {
     }
     
     mutating func run() async throws {
-        guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
-          print("'count-lines' isn't supported on this platform.")
-          return
-        }
-      
         let countAllLines = prefix == nil
         let lineCount = try await fileHandle.bytes.lines.reduce(0) { count, line in
             if countAllLines || line.starts(with: prefix!) {

--- a/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
@@ -17,10 +17,6 @@ import ArgumentParserTestHelpers
 final class CountLinesExampleTests: XCTestCase {
   func testCountLines() throws {
     guard #available(macOS 12, *) else { return }
-    // FIXME: CI is reporting macOS version 10.6 after passing this guard
-    try XCTSkipUnless(ProcessInfo.processInfo.isOperatingSystemAtLeast(
-      .init(majorVersion: 12, minorVersion: 0, patchVersion: 0)))
-    
     let testFile = try XCTUnwrap(Bundle.module.url(forResource: "CountLinesTest", withExtension: "txt"))
     try AssertExecuteCommand(command: "count-lines \(testFile.path)", expected: "20")
     try AssertExecuteCommand(command: "count-lines \(testFile.path) --prefix al", expected: "4")
@@ -28,10 +24,6 @@ final class CountLinesExampleTests: XCTestCase {
   
   func testCountLinesHelp() throws {
     guard #available(macOS 12, *) else { return }
-    // FIXME: CI is reporting macOS version 10.6 after passing this guard
-    try XCTSkipUnless(ProcessInfo.processInfo.isOperatingSystemAtLeast(
-      .init(majorVersion: 12, minorVersion: 0, patchVersion: 0)))
-
     let helpText = """
         USAGE: count-lines [<input-file>] [--prefix <prefix>] [--verbose]
 

--- a/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
@@ -17,6 +17,10 @@ import ArgumentParserTestHelpers
 final class CountLinesExampleTests: XCTestCase {
   func testCountLines() throws {
     guard #available(macOS 12, *) else { return }
+    // FIXME: CI is reporting macOS version 10.6 after passing this guard
+    try XCTSkipUnless(ProcessInfo.processInfo.isOperatingSystemAtLeast(
+      .init(majorVersion: 12, minorVersion: 0, patchVersion: 0)))
+    
     let testFile = try XCTUnwrap(Bundle.module.url(forResource: "CountLinesTest", withExtension: "txt"))
     try AssertExecuteCommand(command: "count-lines \(testFile.path)", expected: "20")
     try AssertExecuteCommand(command: "count-lines \(testFile.path) --prefix al", expected: "4")
@@ -24,6 +28,10 @@ final class CountLinesExampleTests: XCTestCase {
   
   func testCountLinesHelp() throws {
     guard #available(macOS 12, *) else { return }
+    // FIXME: CI is reporting macOS version 10.6 after passing this guard
+    try XCTSkipUnless(ProcessInfo.processInfo.isOperatingSystemAtLeast(
+      .init(majorVersion: 12, minorVersion: 0, patchVersion: 0)))
+
     let helpText = """
         USAGE: count-lines [<input-file>] [--prefix <prefix>] [--verbose]
 


### PR DESCRIPTION
CI is allowing a `guard #available(macOS 12)` in the tests to pass, but then reporting macOS version 10.16 both in ProcessInfo and in the guard in the actual `CountLines.run()` method, which results in an inconsistency. Skipping the test under these conditions until we can sort out the configuration issue.