### PR TITLE
build: add missing static link dependency

### DIFF
--- a/Sources/ArgumentParserTestHelpers/CMakeLists.txt
+++ b/Sources/ArgumentParserTestHelpers/CMakeLists.txt
@@ -5,5 +5,6 @@ set_target_properties(ArgumentParserTestHelpers PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(ArgumentParserTestHelpers PUBLIC
   ArgumentParser
+  ArgumentParserToolInfo
   XCTest
   Foundation)


### PR DESCRIPTION
The `ArgumentParserTestHelpers` module depends on
`ArgumentParserToolInfo` but fails to indicate that dependency.  This was exposed whilst improving static linking for Windows.