### PR TITLE
Update GH models in changelog-authors

### DIFF
--- a/Tools/changelog-authors/ChangelogAuthors.swift
+++ b/Tools/changelog-authors/ChangelogAuthors.swift
@@ -94,7 +94,7 @@ struct ChangelogAuthors: AsyncParsableCommand {
   mutating func run() async throws {
     let (data, _) = try await URLSession.shared.data(from: try comparisonURL())
     let comparison = try JSONDecoder().decode(Comparison.self, from: data)
-    let authors = comparison.commits.map({ $0.author })
+    let authors = comparison.commits.compactMap({ $0.author })
       .uniqued(by: { $0.login })
       .sorted(by: { $0.login.lowercased() < $1.login.lowercased() })
     

--- a/Tools/changelog-authors/Models.swift
+++ b/Tools/changelog-authors/Models.swift
@@ -17,7 +17,7 @@ struct Comparison: Codable {
 
 struct Commit: Codable {
   var sha: String
-  var author: Author
+  var author: Author?
 }
 
 struct Author: Codable {


### PR DESCRIPTION
Apparently the `commit.authors` field is optional - this fix skips commits without an author.