### PR TITLE
[Bash completion]: Respects .file() extensions, uses _filedir 

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -187,18 +187,44 @@ extension ArgumentDefinition {
   }
 
   /// Returns the bash completions that can follow this argument's `--name`.
+  ///
+  /// Uses bash-completion for file and directory values if available.
   fileprivate func bashValueCompletion(_ commands: [ParsableCommand.Type]) -> String {
     switch completion.kind {
     case .default:
       return ""
       
-    case .file(_):
-      // TODO: Use '_filedir' when available
-      // FIXME: Use the extensions array
-      return #"COMPREPLY=( $(compgen -f -- "$cur") )"#
+    case .file(let extensions) where extensions.isEmpty:
+      return """
+        if declare -F _filedir >/dev/null; then
+          _filedir
+        else
+          COMPREPLY=( $(compgen -f -- "$cur") )
+        fi
+        """
+
+    case .file(let extensions):
+      var safeExts = extensions.map { String($0.flatMap { $0 == "'" ? ["\\", "'"] : [$0] }) }
+      safeExts.append(contentsOf: safeExts.map { $0.uppercased() })
+      
+      return """
+        if declare -F _filedir >/dev/null; then
+          \(safeExts.map { "_filedir '\($0)'" }.joined(separator:"\n  "))
+        else
+          COMPREPLY=(
+            \(safeExts.map { "$(compgen -f -X '!*.\($0)' -- \"$cur\")" }.joined(separator: "\n    "))
+          )
+        fi
+        """
 
     case .directory:
-      return #"COMPREPLY=( $(compgen -d -- "$cur") )"#
+      return """
+        if declare -F _filedir >/dev/null; then
+          _filedir -d
+        else
+          COMPREPLY=( $(compgen -d -- "$cur") )
+        fi
+        """
       
     case .list(let list):
       return #"COMPREPLY=( $(compgen -W "\#(list.joined(separator: " "))" -- "$cur") )"#

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -210,9 +210,11 @@ extension ArgumentDefinition {
       return """
         if declare -F _filedir >/dev/null; then
           \(safeExts.map { "_filedir '\($0)'" }.joined(separator:"\n  "))
+          _filedir -d
         else
           COMPREPLY=(
             \(safeExts.map { "$(compgen -f -X '!*.\($0)' -- \"$cur\")" }.joined(separator: "\n    "))
+            $(compgen -d -- "$cur")
           )
         fi
         """

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -337,12 +337,14 @@ _math_stats_quantiles() {
               _filedir 'md'
               _filedir 'TXT'
               _filedir 'MD'
+              _filedir -d
             else
               COMPREPLY=(
                 $(compgen -f -X '!*.txt' -- "$cur")
                 $(compgen -f -X '!*.md' -- "$cur")
                 $(compgen -f -X '!*.TXT' -- "$cur")
                 $(compgen -f -X '!*.MD' -- "$cur")
+                $(compgen -d -- "$cur")
               )
             fi
             return

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -332,11 +332,27 @@ _math_stats_quantiles() {
     fi
     case $prev in
         --file)
-            COMPREPLY=( $(compgen -f -- "$cur") )
+            if declare -F _filedir >/dev/null; then
+              _filedir 'txt'
+              _filedir 'md'
+              _filedir 'TXT'
+              _filedir 'MD'
+            else
+              COMPREPLY=(
+                $(compgen -f -X '!*.txt' -- "$cur")
+                $(compgen -f -X '!*.md' -- "$cur")
+                $(compgen -f -X '!*.TXT' -- "$cur")
+                $(compgen -f -X '!*.MD' -- "$cur")
+              )
+            fi
             return
         ;;
         --directory)
-            COMPREPLY=( $(compgen -d -- "$cur") )
+            if declare -F _filedir >/dev/null; then
+              _filedir -d
+            else
+              COMPREPLY=( $(compgen -d -- "$cur") )
+            fi
             return
         ;;
         --shell)

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -195,11 +195,19 @@ _base() {
             return
         ;;
         --path1)
-            COMPREPLY=( $(compgen -f -- "$cur") )
+            if declare -F _filedir >/dev/null; then
+              _filedir
+            else
+              COMPREPLY=( $(compgen -f -- "$cur") )
+            fi
             return
         ;;
         --path2)
-            COMPREPLY=( $(compgen -f -- "$cur") )
+            if declare -F _filedir >/dev/null; then
+              _filedir
+            else
+              COMPREPLY=( $(compgen -f -- "$cur") )
+            fi
             return
         ;;
         --path3)


### PR DESCRIPTION
This PR implements two TODOs left over in the Bash completion script generator code:

1. `CompletionKind.file(extensions:)` did not actually honor the `extensions` array. It now does so.
2. `CompletionKind.file(extensions:)` and `.directory` now both preferentially invoke the `_filedir` shell function from `bash-completion` ([v1 for Bash 3.2](https://salsa.debian.org/debian/bash-completion) & [v2 for Bash 4.2+](https://github.com/scop/bash-completion)), if it is available in the shell environment at the time, falling back on `compgen` if it is not.

_Note: I could not find any open issues referring to these concerns._

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
