### PR TITLE
Don't remove nested option group titles

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -79,8 +79,10 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
   ) {
     self.init(_parsedValue: .init { parentKey in
       var args = ArgumentSet(Value.self, visibility: .private, parent: parentKey)
-      args.content.withEach {
-        $0.help.parentTitle = title
+      if !title.isEmpty {
+        args.content.withEach {
+          $0.help.parentTitle = title
+        }
       }
       return args
     })

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
@@ -339,9 +339,11 @@ extension HelpGenerationTests {
       ARGUMENTS:
         <name>                  example
 
-      OPTIONS:
+      FLAGS GROUP:
         --verbose               example
         --oversharing           example
+
+      OPTIONS:
         --existing-user         example
         -h, --help              Show help information.
       


### PR DESCRIPTION
When option groups are nested, any titles of the nested groups are removed, even when the containing group doesn't have a title. This change preserves the nested groups' titles when grouped in an untitled option group. Nesting within a titled option group continues to override any nested option groups.

Fixes #585.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
