### PR TITLE
Rename allValues to allValueStrings

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -419,7 +419,7 @@ extension Flag where Value: EnumerableFlag {
         }
         
         let help = ArgumentDefinition.Help(
-          allValues: [],
+          allValueStrings: [],
           options: initial != nil ? .isOptional : [],
           help: helpForCase,
           defaultValue: defaultValueString,
@@ -524,7 +524,7 @@ extension Flag {
         let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
 
         let help = ArgumentDefinition.Help(
-          allValues: [],
+          allValueStrings: [],
           options: [.isOptional],
           help: helpForCase,
           defaultValue: nil,
@@ -556,7 +556,7 @@ extension Flag {
         let name = Element.name(for: value)
         let helpForCase = hasCustomCaseHelp ? (caseHelps[i] ?? help) : help
         let help = ArgumentDefinition.Help(
-          allValues: [],
+          allValueStrings: [],
           options: [.isOptional],
           help: helpForCase,
           defaultValue: nil,

--- a/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDefinition.swift
@@ -48,7 +48,7 @@ struct ArgumentDefinition {
     var options: Options
     var defaultValue: String?
     var keys: [InputKey]
-    var allValues: [String]
+    var allValueStrings: [String]
     var isComposite: Bool
     var abstract: String
     var discussion: String
@@ -57,7 +57,7 @@ struct ArgumentDefinition {
     var parentTitle: String
 
     init(
-      allValues: [String],
+      allValueStrings: [String],
       options: Options,
       help: ArgumentHelp?,
       defaultValue: String?,
@@ -67,7 +67,7 @@ struct ArgumentDefinition {
       self.options = options
       self.defaultValue = defaultValue
       self.keys = [key]
-      self.allValues = allValues
+      self.allValueStrings = allValueStrings
       self.isComposite = isComposite
       self.abstract = help?.abstract ?? ""
       self.discussion = help?.discussion ?? ""
@@ -222,7 +222,7 @@ extension ArgumentDefinition {
       container: Bare<Any>.self,
       key: InputKey(name: unparsedKey, parent: parent),
       kind: .default,
-      allValues: [],
+      allValueStrings: [],
       help: .private,
       defaultValueDescription: nil,
       parsingStrategy: .default,
@@ -247,7 +247,7 @@ extension ArgumentDefinition {
       container: Container.self,
       key: key,
       kind: kind,
-      allValues: Container.Contained.allValueStrings,
+      allValueStrings: Container.Contained.allValueStrings,
       help: help,
       defaultValueDescription: Container.defaultValueDescription(initial),
       parsingStrategy: parsingStrategy,
@@ -276,7 +276,7 @@ extension ArgumentDefinition {
       container: Container.self,
       key: key,
       kind: kind,
-      allValues: [],
+      allValueStrings: [],
       help: help,
       defaultValueDescription: nil,
       parsingStrategy: parsingStrategy,
@@ -296,7 +296,7 @@ extension ArgumentDefinition {
     container: Container.Type,
     key: InputKey,
     kind: ArgumentDefinition.Kind,
-    allValues: [String],
+    allValueStrings: [String],
     help: ArgumentHelp?,
     defaultValueDescription: String?,
     parsingStrategy: ParsingStrategy,
@@ -307,7 +307,7 @@ extension ArgumentDefinition {
     self.init(
       kind: kind,
       help: .init(
-        allValues: allValues,
+        allValueStrings: allValueStrings,
         options: Container.helpOptions.union(initial != nil ? [.isOptional] : []),
         help: help,
         defaultValue: defaultValueDescription,

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -74,7 +74,7 @@ extension ArgumentSet {
     let defaultValueString = initialValue == true ? "true" : nil
     
     let help = ArgumentDefinition.Help(
-      allValues: [],
+      allValueStrings: [],
       options: helpOptions,
       help: help,
       defaultValue: defaultValueString,
@@ -128,8 +128,8 @@ extension ArgumentSet {
       $0 ? enableNames : disableNames
     }
     
-    let enableHelp = ArgumentDefinition.Help(allValues: [], options: helpOptions, help: help, defaultValue: initialValueNames?.first?.synopsisString, key: key, isComposite: true)
-    let disableHelp = ArgumentDefinition.Help(allValues: [], options: [.isOptional], help: help, defaultValue: nil, key: key, isComposite: false)
+    let enableHelp = ArgumentDefinition.Help(allValueStrings: [], options: helpOptions, help: help, defaultValue: initialValueNames?.first?.synopsisString, key: key, isComposite: true)
+    let disableHelp = ArgumentDefinition.Help(allValueStrings: [], options: [.isOptional], help: help, defaultValue: nil, key: key, isComposite: false)
 
     var hasUpdated = false
     let enableArg = ArgumentDefinition(kind: .named(enableNames), help: enableHelp, completion: .default, update: .nullary({ (origin, name, values) in
@@ -147,7 +147,7 @@ extension ArgumentSet {
   
   /// Creates an argument set for an incrementing integer flag.
   static func counter(key: InputKey, name: NameSpecification, help: ArgumentHelp?) -> ArgumentSet {
-    let help = ArgumentDefinition.Help(allValues: [], options: [.isOptional, .isRepeating], help: help, defaultValue: nil, key: key, isComposite: false)
+    let help = ArgumentDefinition.Help(allValueStrings: [], options: [.isOptional, .isRepeating], help: help, defaultValue: nil, key: key, isComposite: false)
     let arg = ArgumentDefinition(kind: .name(key: key, specification: name), help: help, completion: .default, update: .nullary({ (origin, name, values) in
       guard let a = values.element(forKey: key)?.value, let b = a as? Int else {
         throw ParserError.invalidState

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -133,7 +133,7 @@ fileprivate extension ArgumentInfoV0 {
       preferredName: argument.names.preferredName.map(ArgumentInfoV0.NameInfoV0.init),
       valueName: argument.valueName,
       defaultValue: argument.help.defaultValue,
-      allValues: argument.help.allValues,
+      allValues: argument.help.allValueStrings,
       abstract: argument.help.abstract,
       discussion: argument.help.discussion)
   }

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -329,7 +329,7 @@ internal extension BidirectionalCollection where Element == ParsableCommand.Type
     return ArgumentDefinition(
       kind: .named([.long("version")]),
       help: .init(
-        allValues: [],
+        allValueStrings: [],
         options: [.isOptional],
         help: "Show the version.",
         defaultValue: nil,
@@ -346,7 +346,7 @@ internal extension BidirectionalCollection where Element == ParsableCommand.Type
     return ArgumentDefinition(
       kind: .named(names),
       help: .init(
-        allValues: [],
+        allValueStrings: [],
         options: [.isOptional],
         help: "Show help information.",
         defaultValue: nil,
@@ -361,7 +361,7 @@ internal extension BidirectionalCollection where Element == ParsableCommand.Type
     return ArgumentDefinition(
       kind: .named([.long("experimental-dump-help")]),
       help: .init(
-        allValues: [],
+        allValueStrings: [],
         options: [.isOptional],
         help: ArgumentHelp("Dump help information as JSON."),
         defaultValue: nil,

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -430,12 +430,12 @@ extension ErrorMessageGenerator {
 
 private extension ArgumentDefinition {
   var formattedValueList: String {
-    if help.allValues.isEmpty {
+    if help.allValueStrings.isEmpty {
       return ""
     }
 
-    if help.allValues.count < 6 {
-      let quotedValues = help.allValues.map { "'\($0)'" }
+    if help.allValueStrings.count < 6 {
+      let quotedValues = help.allValueStrings.map { "'\($0)'" }
       let validList: String
       if quotedValues.count <= 2 {
         validList = quotedValues.joined(separator: " and ")
@@ -444,7 +444,7 @@ private extension ArgumentDefinition {
       }
       return ". Please provide one of \(validList)."
     } else {
-      let bulletValueList = help.allValues.map { "  - \($0)" }.joined(separator: "\n")
+      let bulletValueList = help.allValueStrings.map { "  - \($0)" }.joined(separator: "\n")
       return ". Please provide one of the following:\n\(bulletValueList)"
     }
   }

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -139,8 +139,15 @@ public struct ArgumentInfoV0: Codable, Hashable {
   public var valueName: String?
   /// Default value of the argument is none is specified on the command line.
   public var defaultValue: String?
+  // NOTE: this property will not be renamed to 'allValueStrings' to avoid
+  // breaking compatibility with the current serialized format.
   /// List of all valid values.
   public var allValues: [String]?
+  /// List of all valid values.
+  public var allValueStrings: [String]? {
+    get { self.allValues }
+    set { self.allValues = newValue }
+  }
 
   /// Short description of the argument's functionality.
   public var abstract: String?
@@ -174,9 +181,10 @@ public struct ArgumentInfoV0: Codable, Hashable {
 
     self.valueName = valueName?.nonEmpty
     self.defaultValue = defaultValue?.nonEmpty
-    self.allValues = allValues?.nonEmpty
+    self.allValueStrings = allValues?.nonEmpty
 
     self.abstract = abstract?.nonEmpty
     self.discussion = discussion?.nonEmpty
   }
 }
+

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -315,7 +315,7 @@ extension DumpHelpGenerationTests {
   "serializationVersion" : 0
 }
 """
-  
+
   static let mathDumpText: String = """
 {
   "command" : {
@@ -925,6 +925,7 @@ extension DumpHelpGenerationTests {
   },
   "serializationVersion" : 0
 }
+
 """
 
   static let mathAddDumpText: String = """
@@ -1010,6 +1011,7 @@ extension DumpHelpGenerationTests {
   },
   "serializationVersion" : 0
 }
+
 """
 
   static let mathMultiplyDumpText: String = """
@@ -1095,6 +1097,7 @@ extension DumpHelpGenerationTests {
   },
   "serializationVersion" : 0
 }
+
 """
 
   static let mathStatsDumpText: String = """
@@ -1500,5 +1503,6 @@ extension DumpHelpGenerationTests {
   },
   "serializationVersion" : 0
 }
+
 """
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -639,14 +639,14 @@ extension HelpGenerationTests {
 
   func testAllValues() {
     let opts = ArgumentSet(AllValues.self, visibility: .private, parent: nil)
-    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[0].help.allValues)
-    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[1].help.allValues)
+    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[0].help.allValueStrings)
+    XCTAssertEqual(AllValues.Manual.allValueStrings, opts[1].help.allValueStrings)
 
-    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[2].help.allValues)
-    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[3].help.allValues)
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[2].help.allValueStrings)
+    XCTAssertEqual(AllValues.UnspecializedSynthesized.allValueStrings, opts[3].help.allValueStrings)
 
-    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[4].help.allValues)
-    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[5].help.allValues)
+    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[4].help.allValueStrings)
+    XCTAssertEqual(AllValues.SpecializedSynthesized.allValueStrings, opts[5].help.allValueStrings)
   }
 
   struct Q: ParsableArguments {


### PR DESCRIPTION
Renames an internal property of argument parser to simplify tracking values through the code base. Should have no functional changes.
