### PR TITLE
Respect the COLUMNS and LINES environment variables when present

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -112,6 +112,23 @@ extension ParsableArguments {
     MessageInfo(error: error, type: self).fullText(for: self)
   }
 
+  /// Returns a full message for the given error, including usage information,
+  /// if appropriate.
+  ///
+  /// - Parameters:
+  ///   - error: An error to generate a message for.
+  ///   - columns: The column width to use when wrapping long line in the
+  ///     help screen. If `columns` is `nil`, uses the current terminal
+  ///     width, or a default value of `80` if the terminal width is not
+  ///     available.
+  /// - Returns: A message that can be displayed to the user.
+  public static func fullMessage(
+    for error: Error,
+    columns: Int?
+  ) -> String {
+    MessageInfo(error: error, type: self, columns: columns).fullText(for: self)
+  }
+
   /// Returns the text of the help screen for this type.
   ///
   /// - Parameters:

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -17,7 +17,7 @@ enum MessageInfo {
   case validation(message: String, usage: String, help: String)
   case other(message: String, exitCode: ExitCode)
   
-  init(error: Error, type: ParsableArguments.Type) {
+  init(error: Error, type: ParsableArguments.Type, columns: Int? = nil) {
     var commandStack: [ParsableCommand.Type]
     var parserError: ParserError? = nil
     
@@ -29,7 +29,7 @@ enum MessageInfo {
       // Exit early on built-in requests
       switch e.parserError {
       case .helpRequested(let visibility):
-        self = .help(text: HelpGenerator(commandStack: e.commandStack, visibility: visibility).rendered())
+        self = .help(text: HelpGenerator(commandStack: e.commandStack, visibility: visibility).rendered(screenWidth: columns))
         return
 
       case .dumpHelpRequested:
@@ -64,7 +64,7 @@ enum MessageInfo {
       
     case let e as ParserError:
       // Send ParserErrors back through the CommandError path
-      self.init(error: CommandError(commandStack: [type.asCommand], parserError: e), type: type)
+      self.init(error: CommandError(commandStack: [type.asCommand], parserError: e), type: type, columns: columns)
       return
 
     default:
@@ -97,7 +97,7 @@ enum MessageInfo {
           if let command = command {
             commandStack = CommandParser(type.asCommand).commandStack(for: command)
           }
-          self = .help(text: HelpGenerator(commandStack: commandStack, visibility: .default).rendered())
+          self = .help(text: HelpGenerator(commandStack: commandStack, visibility: .default).rendered(screenWidth: columns))
         case .dumpRequest(let command):
           if let command = command {
             commandStack = CommandParser(type.asCommand).commandStack(for: command)
@@ -120,7 +120,7 @@ enum MessageInfo {
     } else if let parserError = parserError {
       let usage: String = {
         guard case ParserError.noArguments = parserError else { return usage }
-        return "\n" + HelpGenerator(commandStack: [type.asCommand], visibility: .default).rendered()
+        return "\n" + HelpGenerator(commandStack: [type.asCommand], visibility: .default).rendered(screenWidth: columns)
       }()
       let argumentSet = ArgumentSet(commandStack.last!, visibility: .default, parent: nil)
       let message = argumentSet.errorDescription(error: parserError) ?? ""

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -203,6 +203,7 @@ public func AssertEqualStrings(
 public func AssertHelp<T: ParsableArguments>(
   _ visibility: ArgumentVisibility,
   for _: T.Type,
+  columns: Int? = 80,
   equals expected: String,
   file: StaticString = #file,
   line: UInt = #line
@@ -229,11 +230,11 @@ public func AssertHelp<T: ParsableArguments>(
     _ = try T.parse([flag])
     XCTFail(file: file, line: line)
   } catch {
-    let helpString = T.fullMessage(for: error)
+    let helpString = T.fullMessage(for: error, columns: columns)
     AssertEqualStrings(actual: helpString, expected: expected, file: file, line: line)
   }
 
-  let helpString = T.helpMessage(includeHidden: includeHidden, columns: nil)
+  let helpString = T.helpMessage(includeHidden: includeHidden, columns: columns)
   AssertEqualStrings(actual: helpString, expected: expected, file: file, line: line)
 }
 
@@ -241,6 +242,7 @@ public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
   _ visibility: ArgumentVisibility,
   for _: T.Type,
   root _: U.Type,
+  columns: Int? = 80,
   equals expected: String,
   file: StaticString = #file,
   line: UInt = #line
@@ -261,7 +263,7 @@ public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
   }
 
   let helpString = U.helpMessage(
-    for: T.self, includeHidden: includeHidden, columns: nil)
+    for: T.self, includeHidden: includeHidden, columns: columns)
   AssertEqualStrings(actual: helpString, expected: expected, file: file, line: line)
 }
 

--- a/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
+++ b/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
@@ -26,7 +26,8 @@ fileprivate struct Qux: ParsableArguments {
 fileprivate struct Quizzo: ParsableArguments {
   @Option() var name: String
   @Flag() var verbose = false
-  let count = 0
+  let count: Int
+  init() { self.count = 0 } // silence warning about count not being decoded
 }
 
 extension UnparsedValuesEndToEndTests {

--- a/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
@@ -15,6 +15,12 @@ import XCTest
 import ArgumentParserTestHelpers
 
 final class CountLinesExampleTests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
+  
   func testCountLines() throws {
     guard #available(macOS 12, *) else { return }
     let testFile = try XCTUnwrap(Bundle.module.url(forResource: "CountLinesTest", withExtension: "txt"))

--- a/Tests/ArgumentParserExampleTests/MathExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/MathExampleTests.swift
@@ -14,6 +14,12 @@ import ArgumentParser
 import ArgumentParserTestHelpers
 
 final class MathExampleTests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
+
   func testMath_Simple() throws {
     try AssertExecuteCommand(command: "math 1 2 3 4 5", expected: "15")
     try AssertExecuteCommand(command: "math multiply 1 2 3 4 5", expected: "120")

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -13,6 +13,12 @@ import XCTest
 import ArgumentParserTestHelpers
 
 final class RepeatExampleTests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
+
   func testRepeat() throws {
     try AssertExecuteCommand(command: "repeat hello", expected: """
         hello

--- a/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
@@ -13,6 +13,12 @@ import XCTest
 import ArgumentParserTestHelpers
 
 final class RollDiceExampleTests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
+
   func testRollDice() throws {
     try AssertExecuteCommand(command: "roll --times 6")
   }

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -14,6 +14,11 @@ import XCTest
 import ArgumentParserTestHelpers
 
 final class HelpTests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
 }
 
 func getErrorText<T: ParsableArguments>(_: T.Type, _ arguments: [String]) -> String {

--- a/Tests/ArgumentParserPackageManagerTests/Tests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/Tests.swift
@@ -14,6 +14,11 @@ import ArgumentParser
 import ArgumentParserTestHelpers
 
 final class Tests: XCTestCase {
+  override func setUp() {
+    #if !os(Windows) && !os(WASI)
+    unsetenv("COLUMNS")
+    #endif
+  }
 }
 
 extension Tests {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -810,6 +810,7 @@ extension HelpGenerationTests {
     throw XCTSkip("Unsupported on this platform")
     #endif
     
+    unsetenv("COLUMNS")
     AssertHelp(.default, for: WideHelp.self, equals: """
       USAGE: wide-help [<argument>]
       

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -809,27 +809,11 @@ extension HelpGenerationTests {
   func testColumnsEnvironmentOverride() throws {
     #if os(Windows) || os(WASI)
     throw XCTSkip("Unsupported on this platform")
-    #elseif Xcode
-    throw XCTSkip("Test cannot be run in Xcode (unable to detect if parallel tests are in effect)")
-    #else // N.B.: If #endif is used here, Xcode generates a spurious "code will never be executed" warning
-    
-    #if os(macOS)
-    if CommandLine.arguments.count >= 3,
-       CommandLine.arguments[1...2] == ["-XCTest", "ArgumentParserUnitTests.HelpGenerationTests/testColumnsEnvironmentOverride"]
-    {
-        throw XCTSkip("Test is not compatible with --parallel")
-    }
-    #elseif os(Linux)
-    if CommandLine.arguments.count >= 2,
-       CommandLine.arguments[1] == "ArgumentParserUnitTests.HelpGenerationTests/testColumnsEnvironmentOverride"
-    {
-        throw XCTSkip("Test is not compatible with --parallel")
-    }
     #endif
-    
+
     defer { unsetenv("COLUMNS") }
     unsetenv("COLUMNS")
-    AssertHelp(.default, for: WideHelp.self, equals: """
+    AssertHelp(.default, for: WideHelp.self, columns: nil, equals: """
       USAGE: wide-help [<argument>]
       
       ARGUMENTS:
@@ -841,7 +825,7 @@ extension HelpGenerationTests {
       """)
 
     setenv("COLUMNS", "60", 1)
-    AssertHelp(.default, for: WideHelp.self, equals: """
+    AssertHelp(.default, for: WideHelp.self, columns: nil, equals: """
       USAGE: wide-help [<argument>]
       
       ARGUMENTS:
@@ -854,7 +838,7 @@ extension HelpGenerationTests {
       """)
 
     setenv("COLUMNS", "79", 1)
-    AssertHelp(.default, for: WideHelp.self, equals: """
+    AssertHelp(.default, for: WideHelp.self, columns: nil, equals: """
       USAGE: wide-help [<argument>]
       
       ARGUMENTS:
@@ -865,6 +849,5 @@ extension HelpGenerationTests {
         -h, --help              Show help information.
       
       """)
-    #endif
   }
 }

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -798,3 +798,53 @@ extension HelpGenerationTests {
       """)
   }
 }
+
+extension HelpGenerationTests {
+  private struct WideHelp: ParsableCommand {
+    @Argument(help: "54 characters of help, so as to wrap when columns < 80")
+    var argument: String?
+  }
+  
+  func testColumnsEnvironmentOverride() throws {
+    #if os(Windows) || os(WASI)
+    throw XCTSkip("Unsupported on this platform")
+    #endif
+    
+    AssertHelp(.default, for: WideHelp.self, equals: """
+      USAGE: wide-help [<argument>]
+      
+      ARGUMENTS:
+        <argument>              54 characters of help, so as to wrap when columns < 80
+      
+      OPTIONS:
+        -h, --help              Show help information.
+      
+      """)
+
+    setenv("COLUMNS", "60", 1)
+    AssertHelp(.default, for: WideHelp.self, equals: """
+      USAGE: wide-help [<argument>]
+      
+      ARGUMENTS:
+        <argument>              54 characters of help, so as to
+                                wrap when columns < 80
+      
+      OPTIONS:
+        -h, --help              Show help information.
+      
+      """)
+
+    setenv("COLUMNS", "79", 1)
+    AssertHelp(.default, for: WideHelp.self, equals: """
+      USAGE: wide-help [<argument>]
+      
+      ARGUMENTS:
+        <argument>              54 characters of help, so as to wrap when columns <
+                                80
+      
+      OPTIONS:
+        -h, --help              Show help information.
+      
+      """)
+  }
+}

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -808,8 +808,25 @@ extension HelpGenerationTests {
   func testColumnsEnvironmentOverride() throws {
     #if os(Windows) || os(WASI)
     throw XCTSkip("Unsupported on this platform")
+    #elseif Xcode
+    throw XCTSkip("Test cannot be run in Xcode (unable to detect if parallel tests are in effect)")
+    #else // N.B.: If #endif is used here, Xcode generates a spurious "code will never be executed" warning
+    
+    #if os(macOS)
+    if CommandLine.arguments.count >= 3,
+       CommandLine.arguments[1...2] == ["-XCTest", "ArgumentParserUnitTests.HelpGenerationTests/testColumnsEnvironmentOverride"]
+    {
+        throw XCTSkip("Test is not compatible with --parallel")
+    }
+    #elseif os(Linux)
+    if CommandLine.arguments.count >= 2,
+       CommandLine.arguments[1] == "ArgumentParserUnitTests.HelpGenerationTests/testColumnsEnvironmentOverride"
+    {
+        throw XCTSkip("Test is not compatible with --parallel")
+    }
     #endif
     
+    defer { unsetenv("COLUMNS") }
     unsetenv("COLUMNS")
     AssertHelp(.default, for: WideHelp.self, equals: """
       USAGE: wide-help [<argument>]
@@ -847,5 +864,6 @@ extension HelpGenerationTests {
         -h, --help              Show help information.
       
       """)
+    #endif
   }
 }


### PR DESCRIPTION
As documented in both the [Linux](https://man7.org/linux/man-pages/man7/environ.7.html:~:text=COLUMNS) and [BSD](https://man.freebsd.org/cgi/man.cgi?environ(7)#:~:text=COLUMNS) versions of the `environ(7)` manpage, many console utilities respect the presence of the `COLUMNS` and `LINES` environment variables, treating them as overrides (or, less commonly, fallbacks) of the terminal's reported size (if any). This adds that same behavior to ArgumentParser's screen size logic, affecting the wrapping of the usage generator's output.

_Note: These changes follow the semantics of `ls(1)`, where `COLUMNS` and `LINES` individually override the values reported by a terminal when they are present. Setting only one of the two variables has no effect on the other. It is also worth noting that at the present time, overriding the screen height (i.e. `LINES`) has no impact whatsoever on ArgumentParser's behavior._

The new logic only takes effect on non-Windows/WASI platforms.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
