### PR TITLE
Enable shell detection for Windows

### DIFF
--- a/Sources/ArgumentParser/Utilities/Platform.swift
+++ b/Sources/ArgumentParser/Utilities/Platform.swift
@@ -29,14 +29,23 @@ extension Platform {
   /// The name of the user's preferred shell, if detectable from the
   /// environment.
   static var shellName: String? {
-#if os(Windows)
-    return nil
-#else
     // FIXME: This retrieves the user's preferred shell, not necessarily the one currently in use.
     guard let shellVar = getenv("SHELL") else { return nil }
-    let shellParts = String(cString: shellVar).split(separator: "/")
-    return shellParts.last.map(String.init)
+    let shellStr = String(cString: shellVar)
+#if os(Windows)
+    let shellParts = shellStr.split(whereSeparator: { $0 == "\\" || $0 == "/" })
+    let shellName = shellParts.last.map {
+      if $0.hasSuffix(".exe") {
+        return String($0.dropLast(4))
+      } else {
+        return String($0)
+      }
+    }
+#else
+    let shellParts = shellStr.split(separator: "/")
+    let shellName = shellParts.last.map(String.init)
 #endif
+    return shellName?.lowercased()
   }
 }
 


### PR DESCRIPTION
The conventional `SHELL` environment variable is set by OpenSSH server on Windows, but we need to normalize the path slightly differently. Some popular shell names on Windows are `cmd` (Command Prompt), `powershell` (Windows Powershell), `pwsh` (Powershell Core) and `bash` (Git Bash).

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
