### PR TITLE
Workarounds for remaining concurrency warnings

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -213,7 +213,8 @@ extension ParsableArguments {
       if messageInfo.shouldExitCleanly {
         print(fullText)
       } else {
-        print(fullText, to: &Platform.standardError)
+        var errorOut = Platform.standardError
+        print(fullText, to: &errorOut)
       }
     }
     Platform.exit(messageInfo.exitCode.rawValue)

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -63,7 +63,7 @@ extension ParsableCommand {
     _ arguments: [String]? = nil
   ) throws -> ParsableCommand {
     var parser = CommandParser(self)
-    let arguments = arguments ?? Array(CommandLine.arguments.dropFirst())
+    let arguments = arguments ?? Array(CommandLine._staticArguments.dropFirst())
     return try parser.parse(arguments: arguments).get()
   }
   

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -18,7 +18,8 @@ struct UsageGenerator {
 
 extension UsageGenerator {
   init(definition: ArgumentSet) {
-    let toolName = CommandLine.arguments[0].split(separator: "/").last.map(String.init) ?? "<command>"
+    let toolName = CommandLine._staticArguments[0]
+      .split(separator: "/").last.map(String.init) ?? "<command>"
     self.init(toolName: toolName, definition: definition)
   }
   

--- a/Sources/ArgumentParser/Utilities/Platform.swift
+++ b/Sources/ArgumentParser/Utilities/Platform.swift
@@ -9,6 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+extension CommandLine {
+  /// Accesses the command line arguments in a concurrency-safe way.
+  ///
+  /// Workaround for https://github.com/apple/swift/issues/66213
+  static let _staticArguments: [String] =
+    UnsafeBufferPointer(start: unsafeArgv, count: Int(argc))
+      .compactMap { String(validatingUTF8: $0!)
+  }
+}
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -103,7 +113,9 @@ extension Platform {
   }
 
   /// The `stderr` output stream.
-  static var standardError = StandardError()
+  static var standardError: StandardError {
+    StandardError()
+  }
 }
 
 // MARK: Terminal size


### PR DESCRIPTION
Resolves warnings around accessing `CommandLine.arguments` and the shared `Platform.standardError`.