### PR TITLE
[NFC] Suppress retroactive conformance errors

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -16,7 +16,7 @@ import ArgumentParserTestHelpers
 final class HelpGenerationTests: XCTestCase {
 }
 
-extension URL: ExpressibleByArgument {
+extension Foundation.URL: ArgumentParser.ExpressibleByArgument {
   public init?(argument: String) {
     guard let url = URL(string: argument) else {
       return nil

--- a/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable import ArgumentParser
 import ArgumentParserTestHelpers
 
-extension SplitArguments.InputIndex: ExpressibleByIntegerLiteral {
+extension ArgumentParser.SplitArguments.InputIndex: Swift.ExpressibleByIntegerLiteral {
   public init(integerLiteral value: Int) {
     self.init(rawValue: value)
   }

--- a/Tools/generate-manual/Extensions/Date+ExpressibleByArgument.swift
+++ b/Tools/generate-manual/Extensions/Date+ExpressibleByArgument.swift
@@ -12,7 +12,7 @@
 import ArgumentParser
 import Foundation
 
-extension Date: ExpressibleByArgument {
+extension Foundation.Date: ArgumentParser.ExpressibleByArgument {
   // parsed as `yyyy-mm-dd`
   public init?(argument: String) {
     // ensure the input argument is composed of exactly 3 components separated


### PR DESCRIPTION
These warnings are showing up in tests about types and protocols that are defined within this package, so they don't pose a problem for future library evolution. Instead of using the `@retroactive` attribute, which isn't supported by older compilers, this change fully qualifies the type and protocol in the relevant conformance declarations, which suppresses the issue.

Re: https://github.com/apple/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md