### PR TITLE
Tests: repair the build on Windows

### DIFF
--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -807,10 +807,7 @@ extension HelpGenerationTests {
   }
   
   func testColumnsEnvironmentOverride() throws {
-    #if os(Windows) || os(WASI)
-    throw XCTSkip("Unsupported on this platform")
-    #endif
-
+#if !(os(Windows) || os(WASI))
     defer { unsetenv("COLUMNS") }
     unsetenv("COLUMNS")
     AssertHelp(.default, for: WideHelp.self, columns: nil, equals: """
@@ -849,5 +846,6 @@ extension HelpGenerationTests {
         -h, --help              Show help information.
       
       """)
+#endif
   }
 }


### PR DESCRIPTION
These use APIs which are not available on Windows, so skipping the test is insufficient as it does not build.