### PR TITLE
build: correct ordering of `include`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,6 @@ project(swift-argument-parser
 option(BUILD_EXAMPLES "Build Example Programs" TRUE)
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
-include(CTest)
-include(SwiftSupport)
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -16,6 +13,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+include(CTest)
+include(SwiftSupport)
 
 find_package(dispatch CONFIG)
 find_package(Foundation CONFIG)


### PR DESCRIPTION
Correct the ordering that @bnbarham pointed out post-commit.  Ensure that we adjust the `CMAKE_MODULE_PATH` prior to the use of `include` which will reference local modules.