### PR TITLE
Allow single, attached value with .upToNextOption

### DIFF
--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -210,6 +210,24 @@ extension RepeatingEndToEndTests {
       XCTAssertEqual(qux.names, ["one", "two"])
       XCTAssertNil(qux.extra)
     }
+
+    AssertParse(Qux.self, ["--verbose", "--names=one"]) { qux in
+      XCTAssertTrue(qux.verbose)
+      XCTAssertEqual(qux.names, ["one"])
+      XCTAssertNil(qux.extra)
+    }
+
+    AssertParse(Qux.self, ["--verbose", "--names=one", "two"]) { qux in
+      XCTAssertTrue(qux.verbose)
+      XCTAssertEqual(qux.names, ["one", "two"])
+      XCTAssertNil(qux.extra)
+    }
+
+    AssertParse(Qux.self, ["--names=one", "--verbose", "two"]) { qux in
+      XCTAssertTrue(qux.verbose)
+      XCTAssertEqual(qux.names, ["one"])
+      XCTAssertEqual(qux.extra, "two")
+    }
   }
 
   func testParsing_repeatingStringUpToNext_Fails() throws {


### PR DESCRIPTION
Fixes an issue where a single attached value triggered an error on `.upToNextOption` options.

Fixes #609.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
