### PR TITLE
Fix unrecognized `-help` flag with default command

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -84,7 +84,7 @@ extension CommandParser {
     _ split: SplitArguments,
     requireSoloArgument: Bool = false
   ) throws {
-    guard !requireSoloArgument || split.count == 1 else { return }
+    guard !requireSoloArgument || split.originalInput.count == 1 else { return }
     
     // Look for help flags
     guard !split.contains(anyOf: self.commandStack.getHelpNames(visibility: .default)) else {


### PR DESCRIPTION
When there's a default subcommand that captures pass-through args, only a standalone help flag should trigger help (since the flag should otherwise go to the subcommand). This fix makes that true for single- dash help flag names, which were previously being skipped, due to single-dash flags being lexed as both one whole flag and as a group of individual short flags.

Re: https://github.com/apple/swift-package-manager/issues/7218
Re: rdar://120422808

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
