### PR TITLE
fix help message with @OptionGroup ParsableCommand

### DIFF
--- a/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
@@ -17,13 +17,16 @@
 struct DecodedArguments {
   var type: ParsableArguments.Type
   var value: ParsableArguments
+  var isOptionGroup: Bool = false
 
   var commandType: ParsableCommand.Type? {
-    type as? ParsableCommand.Type
+    if isOptionGroup { return nil }
+    return type as? ParsableCommand.Type
   }
 
   var command: ParsableCommand? {
-    value as? ParsableCommand
+    if isOptionGroup { return nil }
+    return value as? ParsableCommand
   }
 }
 
@@ -182,7 +185,7 @@ struct SingleValueDecoder: Decoder {
   }
 
   func saveValue<T: ParsableArguments>(_ value: T, type: T.Type = T.self) {
-    underlying.previouslyDecoded.append(DecodedArguments(type: type, value: value))
+    underlying.previouslyDecoded.append(DecodedArguments(type: type, value: value, isOptionGroup: true))
   }
   
   struct SingleValueContainer: SingleValueDecodingContainer {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -514,6 +514,31 @@ extension HelpGenerationTests {
     
     """)
   }
+
+  struct ParsableCommandOption : ParsableCommand {
+    struct Group: ParsableCommand {
+      @Option
+      var opt: Int = 0
+    }
+    @OptionGroup
+    var options: Group
+    @Argument
+    var arg: String = ""
+  }
+
+  func testHelpWithParsableCommandOption() {
+    AssertHelp(.default, for: ParsableCommandOption.self, equals: """
+    USAGE: parsable-command-option [--opt <opt>] [<arg>]
+
+    ARGUMENTS:
+      <arg>
+
+    OPTIONS:
+      --opt <opt>             (default: 0)
+      -h, --help              Show help information.
+
+    """)
+  }
 }
 
 extension HelpGenerationTests {


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Fixes #578.
This PR fixes usage text generated by command with `ParsableCommand` annotated `@OptionGroup`.
I have fixed it so that DecodedArguments created from OptionGroup are not recognized as ParsableCommand.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
