### PR TITLE
Mark `CommandConfiguration` as `Sendable`

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The configuration for a command.
-public struct CommandConfiguration {
+public struct CommandConfiguration: Sendable {
   /// The name of the command to use on the command line.
   ///
   /// If `nil`, the command name is derived by converting the name of


### PR DESCRIPTION
Lack of this marker protocol conformance causes warnings with strict concurrency checks, such as `Static property 'configuration' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6`

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
