### PR TITLE
Remove `@_implementationOnly` annotations

### DIFF
--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -9,11 +9,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.11)
+internal import ArgumentParserToolInfo
+internal import class Foundation.JSONEncoder
+#elseif swift(>=5.10)
+import ArgumentParserToolInfo
+import class Foundation.JSONEncoder
+#else
 @_implementationOnly import ArgumentParserToolInfo
 @_implementationOnly import class Foundation.JSONEncoder
+#endif
 
 internal struct DumpHelpGenerator {
-  var toolInfo: ToolInfoV0
+  private var toolInfo: ToolInfoV0
 
   init(_ type: ParsableArguments.Type) {
     self.init(commandStack: [type.asCommand])

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -9,8 +9,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.11)
+internal import protocol Foundation.LocalizedError
+internal import class Foundation.NSError
+#elseif swift(>=5.10)
+import protocol Foundation.LocalizedError
+import class Foundation.NSError
+#else
 @_implementationOnly import protocol Foundation.LocalizedError
 @_implementationOnly import class Foundation.NSError
+#endif
 
 enum MessageInfo {
   case help(text: String)

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,7 +9,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.11)
+internal import protocol Foundation.LocalizedError
+#elseif swift(>=5.10)
+import protocol Foundation.LocalizedError
+#else
 @_implementationOnly import protocol Foundation.LocalizedError
+#endif
 
 struct UsageGenerator {
   var toolName: String


### PR DESCRIPTION
These annotations produce warnings when compiling swift-syntax without library evolution using Swift ≥5.10.

Replace them by `private import` when compiling using Swift ≥5.11.

Mirrors https://github.com/apple/swift-syntax/pull/2429

### Checklist
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
