### PR TITLE
Prefer `let` for private configurations

### DIFF
--- a/Examples/math/Math.swift
+++ b/Examples/math/Math.swift
@@ -15,7 +15,7 @@ import ArgumentParser
 struct Math: ParsableCommand {
     // Customize your command's help and subcommands by implementing the
     // `configuration` property.
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         // Optional abstracts and discussions are used for help output.
         abstract: "A utility for performing maths.",
 
@@ -50,7 +50,7 @@ extension Math {
     }
 
     struct Add: ParsableCommand {
-        static var configuration =
+        static let configuration =
             CommandConfiguration(abstract: "Print the sum of the values.")
 
         // The `@OptionGroup` attribute includes the flags, options, and
@@ -64,7 +64,7 @@ extension Math {
     }
 
     struct Multiply: ParsableCommand {
-        static var configuration =
+        static let configuration =
             CommandConfiguration(abstract: "Print the product of the values.")
 
         @OptionGroup var options: Options
@@ -79,7 +79,7 @@ extension Math {
 // In practice, these nested types could be broken out into different files.
 extension Math {
     struct Statistics: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             // Command names are automatically generated from the type name
             // by default; you can specify an override here.
             commandName: "stats",
@@ -90,7 +90,7 @@ extension Math {
 
 extension Math.Statistics {
     struct Average: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             abstract: "Print the average of the values.",
             version: "1.5.0-alpha")
 
@@ -160,7 +160,7 @@ extension Math.Statistics {
     }
 
     struct StandardDeviation: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             commandName: "stdev",
             abstract: "Print the standard deviation of the values.")
 
@@ -184,7 +184,7 @@ extension Math.Statistics {
     }
 
     struct Quantiles: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             abstract: "Print the quantiles of the values (TBD).")
 
         @Argument(completion: .list(["alphabet", "alligator", "branch", "braggart"]))

--- a/Sources/ArgumentParser/Documentation.docc/Articles/CommandsAndSubcommands.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/CommandsAndSubcommands.md
@@ -39,7 +39,7 @@ Start by defining the root `Math` command. You can provide a static ``ParsableCo
 
 ```swift
 struct Math: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         abstract: "A utility for performing maths.",
         subcommands: [Add.self, Multiply.self, Statistics.self],
         defaultSubcommand: Add.self)
@@ -72,7 +72,7 @@ It's time to define our first two subcommands: `Add` and `Multiply`. Both of the
 ```swift
 extension Math {
     struct Add: ParsableCommand {
-        static var configuration
+        static let configuration
             = CommandConfiguration(abstract: "Print the sum of the values.")
 
         @OptionGroup var options: Math.Options
@@ -84,7 +84,7 @@ extension Math {
     }
 
     struct Multiply: ParsableCommand {
-        static var configuration
+        static let configuration
             = CommandConfiguration(abstract: "Print the product of the values.")
 
         @OptionGroup var options: Math.Options
@@ -102,7 +102,7 @@ Next, we'll define `Statistics`, the third subcommand of `Math`. The `Statistics
 ```swift
 extension Math {
     struct Statistics: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             commandName: "stats",
             abstract: "Calculate descriptive statistics.",
             subcommands: [Average.self, StandardDeviation.self])
@@ -115,7 +115,7 @@ Let's finish our subcommands with the `Average` and `StandardDeviation` types. E
 ```swift
 extension Math.Statistics {
     struct Average: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             abstract: "Print the average of the values.")
 
         enum Kind: String, ExpressibleByArgument {
@@ -148,7 +148,7 @@ extension Math.Statistics {
     }
 
     struct StandardDeviation: ParsableCommand {
-        static var configuration = CommandConfiguration(
+        static let configuration = CommandConfiguration(
             commandName: "stdev",
             abstract: "Print the standard deviation of the values.")
 

--- a/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
@@ -8,7 +8,7 @@ In addition to configuring the command name and subcommands, as described in <do
 
 ```swift
 struct Repeat: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         abstract: "Repeats your input phrase.",
         usage: """
             repeat <phrase>

--- a/Sources/ArgumentParser/Usage/HelpCommand.swift
+++ b/Sources/ArgumentParser/Usage/HelpCommand.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 struct HelpCommand: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     commandName: "help",
     abstract: "Show subcommand help information.",
     helpNames: [])

--- a/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
@@ -19,7 +19,7 @@ final class DefaultSubcommandEndToEndTests: XCTestCase {
 // MARK: -
 
 private struct Main: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     subcommands: [Default.self, Foo.self, Bar.self],
     defaultSubcommand: Default.self
   )
@@ -72,7 +72,7 @@ extension DefaultSubcommandEndToEndTests {
 
 extension DefaultSubcommandEndToEndTests {
   fileprivate struct MyCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       subcommands: [Plugin.self, NonDefault.self, Other.self],
       defaultSubcommand: Plugin.self
     )

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -613,7 +613,7 @@ extension DefaultsEndToEndTests {
 }
 
 fileprivate struct Main: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     subcommands: [Sub.self],
     defaultSubcommand: Sub.self
   )

--- a/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
@@ -19,7 +19,7 @@ final class NestedCommandEndToEndTests: XCTestCase {
 // MARK: Single value String
 
 fileprivate struct Foo: ParsableCommand {
-  static var configuration =
+  static let configuration =
     CommandConfiguration(subcommands: [Build.self, Package.self])
 
   @Flag(name: .short)
@@ -33,7 +33,7 @@ fileprivate struct Foo: ParsableCommand {
   }
 
   struct Package: ParsableCommand {
-    static var configuration =
+    static let configuration =
       CommandConfiguration(subcommands: [Clean.self, Config.self])
 
     @Flag(name: .short)

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -19,14 +19,14 @@ final class SubcommandEndToEndTests: XCTestCase {
 // MARK: Single value String
 
 fileprivate struct Foo: ParsableCommand {
-  static var configuration =
+  static let configuration =
     CommandConfiguration(subcommands: [CommandA.self, CommandB.self])
 
   @Option() var name: String
 }
 
 fileprivate struct CommandA: ParsableCommand {
-  static var configuration = CommandConfiguration(commandName: "a")
+  static let configuration = CommandConfiguration(commandName: "a")
 
   @OptionGroup() var foo: Foo
 
@@ -34,7 +34,7 @@ fileprivate struct CommandA: ParsableCommand {
 }
 
 fileprivate struct CommandB: ParsableCommand {
-  static var configuration = CommandConfiguration(commandName: "b")
+  static let configuration = CommandConfiguration(commandName: "b")
 
   @OptionGroup() var foo: Foo
 
@@ -154,7 +154,7 @@ struct BaseCommand: ParsableCommand {
 
   static let baseFlagValue = "base"
 
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     commandName: "base",
     subcommands: [SubCommand.self]
   )
@@ -173,7 +173,7 @@ extension BaseCommand {
   struct SubCommand : ParsableCommand {
     static let subFlagValue = "sub"
 
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       commandName: "sub",
       subcommands: [SubSubCommand.self]
     )
@@ -193,7 +193,7 @@ extension BaseCommand.SubCommand {
   struct SubSubCommand : ParsableCommand, TestableParsableArguments {
     let didValidateExpectation = XCTestExpectation(singleExpectation: "did validate subcommand")
 
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       commandName: "subsub"
     )
 
@@ -238,7 +238,7 @@ extension SubcommandEndToEndTests {
 // MARK: Version flags
 
 private struct A: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     version: "1.0.0",
     subcommands: [HasVersionFlag.self, NoVersionFlag.self])
 

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -248,7 +248,7 @@ extension HelpTests {
 }
 
 struct SubCommandCustomHelp: ParsableCommand {
-  static var configuration = CommandConfiguration (
+  static let configuration = CommandConfiguration (
     helpNames: [.customShort("p"), .customLong("parent-help")]
   )
 
@@ -257,7 +257,7 @@ struct SubCommandCustomHelp: ParsableCommand {
   }
 
   struct ModifiedHelp: ParsableCommand {
-    static var configuration = CommandConfiguration (
+    static let configuration = CommandConfiguration (
       helpNames: [.customShort("s"), .customLong("subcommand-help")]
     )
 

--- a/Tests/ArgumentParserPackageManagerTests/PackageManager/GenerateXcodeProject.swift
+++ b/Tests/ArgumentParserPackageManagerTests/PackageManager/GenerateXcodeProject.swift
@@ -14,7 +14,7 @@ import ArgumentParser
 extension Package {
   /// Generates an Xcode project
   struct GenerateXcodeProject: ParsableCommand {
-    static var configuration =
+    static let configuration =
       CommandConfiguration(commandName: "generate-xcodeproj")
 
     @OptionGroup()

--- a/Tests/ArgumentParserPackageManagerTests/PackageManager/Options.swift
+++ b/Tests/ArgumentParserPackageManagerTests/PackageManager/Options.swift
@@ -88,12 +88,12 @@ struct Options: ParsableArguments {
 }
 
 struct Package: ParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     subcommands: [Clean.self, Config.self, Describe.self, GenerateXcodeProject.self, Hidden.self])
 }
 
 extension Package {
   struct Hidden: ParsableCommand {
-    static var configuration = CommandConfiguration(shouldDisplay: false)
+    static let configuration = CommandConfiguration(shouldDisplay: false)
   }
 }

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -34,7 +34,7 @@ extension CompletionScriptTests {
   }
   
   struct Base: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       commandName: "base-test",
       subcommands: [SubCommand.self]
     )
@@ -55,7 +55,7 @@ extension CompletionScriptTests {
     @Option(name: [.short, .long]) var rep2: [String]
 
    struct SubCommand: ParsableCommand {
-     static var configuration = CommandConfiguration(
+     static let configuration = CommandConfiguration(
        commandName: "sub-command"
      )
    }
@@ -408,11 +408,11 @@ complete -c base-test -n '_swift_base-test_using_command "base-test" "sub-comman
 
 // MARK: - Test Hidden Subcommand
 struct Parent: ParsableCommand {
-    static var configuration = CommandConfiguration(subcommands: [HiddenChild.self])
+    static let configuration = CommandConfiguration(subcommands: [HiddenChild.self])
 }
 
 struct HiddenChild: ParsableCommand {
-    static var configuration = CommandConfiguration(shouldDisplay: false)
+    static let configuration = CommandConfiguration(shouldDisplay: false)
 }
 
 extension CompletionScriptTests {

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -21,7 +21,7 @@ extension ExitCodeTests {
   struct A: ParsableArguments {}
   struct E: Error {}
   struct C: ParsableCommand {
-    static var configuration = CommandConfiguration(version: "v1")
+    static let configuration = CommandConfiguration(version: "v1")
   }
   
   func testExitCodes() {

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -304,7 +304,7 @@ extension HelpGenerationTests {
       @Argument
       var argument: String = ""
     }
-    static var configuration = CommandConfiguration(subcommands: [CommandWithVeryLongName.self,ShortCommand.self,AnotherCommandWithVeryLongName.self,AnotherCommand.self])
+    static let configuration = CommandConfiguration(subcommands: [CommandWithVeryLongName.self,ShortCommand.self,AnotherCommandWithVeryLongName.self,AnotherCommand.self])
   }
 
   func testHelpWithSubcommands() {
@@ -342,7 +342,7 @@ extension HelpGenerationTests {
   }
 
   struct I: ParsableCommand {
-    static var configuration = CommandConfiguration(version: "1.0.0")
+    static let configuration = CommandConfiguration(version: "1.0.0")
   }
 
   func testHelpWithVersion() {
@@ -358,7 +358,7 @@ extension HelpGenerationTests {
   }
 
   struct J: ParsableCommand {
-    static var configuration = CommandConfiguration(discussion: "test")
+    static let configuration = CommandConfiguration(discussion: "test")
   }
 
   func testOverviewButNoAbstractSpacing() {
@@ -422,7 +422,7 @@ extension HelpGenerationTests {
   struct M: ParsableCommand {
   }
   struct N: ParsableCommand {
-    static var configuration = CommandConfiguration(subcommands: [M.self], defaultSubcommand: M.self)
+    static let configuration = CommandConfiguration(subcommands: [M.self], defaultSubcommand: M.self)
   }
 
   func testHelpWithDefaultCommand() {


### PR DESCRIPTION
Prefer `let` for private configurations.
Otherwise, we may think that the configuration is mutable, which is not really sendable friendly.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
