### PR TITLE
Clarify `postTerminator` parsing strategy behavior

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Argument.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Argument.swift
@@ -188,8 +188,8 @@ public struct ArgumentArrayParsingStrategy: Hashable {
     self.init(base: .allUnrecognized)
   }
   
-  /// Before parsing, capture all inputs that follow the `--` terminator in this
-  /// argument array.
+  /// Before parsing arguments, capture all inputs that follow the `--`
+  /// terminator in this argument array.
   ///
   /// For example, the `Example` command defined below has a `words` array that
   /// uses the `postTerminator` parsing strategy:
@@ -218,6 +218,14 @@ public struct ArgumentArrayParsingStrategy: Hashable {
   /// $ example Asa Extra -- one two --other
   /// Error: Unexpected argument 'Extra'
   /// ```
+  ///
+  /// Because options are parsed before arguments, an option that consumes or
+  /// suppresses the `--` terminator can prevent a `postTerminator` argument
+  /// array from capturing any input. In particular, the
+  /// ``SingleValueParsingStrategy/unconditional``,
+  /// ``ArrayParsingStrategy/unconditionalSingleValue``, and
+  /// ``ArrayParsingStrategy/remaining`` parsing strategies can all consume
+  /// the terminator as part of their values.
   ///
   /// - Note: This parsing strategy can be surprising for users, since it
   ///   changes the behavior of the `--` terminator. Prefer ``remaining``


### PR DESCRIPTION
Fixes #597.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
