### PR TITLE
Suppress needlessly alarming messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 include(CTest)
 include(SwiftSupport)
 
-find_package(dispatch CONFIG)
-find_package(Foundation CONFIG)
-find_package(XCTest CONFIG)
+find_package(dispatch QUIET CONFIG)
+find_package(Foundation QUIET CONFIG)
+find_package(XCTest QUIET CONFIG)
 
 add_subdirectory(Sources)
 if(BUILD_EXAMPLES)


### PR DESCRIPTION
These packages are not marked `REQUIRED` and when this project is used as a dependency of another CMake project they don't need to be findable when this CMakeLists.txt is read.  They may in fact be found later in the configuration process, so the messages when they actually _are_ needed, so the messages

```
-- Could NOT find dispatch (missing: dispatch_DIR)
-- Could NOT find Foundation (missing: Foundation_DIR)
-- Could NOT find XCTest (missing: XCTest_DIR)
```

are needlessly alarming.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
