### PR TITLE
Abort on ambiguous subcommand names

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -41,6 +41,8 @@ struct CommandParser {
       self.commandTree = try Tree(root: rootCommand)
     } catch Tree<ParsableCommand.Type>.InitializationError.recursiveSubcommand(let command) {
       fatalError("The ParsableCommand \"\(command)\" can't have itself as its own subcommand.")
+    } catch Tree<ParsableCommand.Type>.InitializationError.matchingCommandNames(let command, let commandName) {
+      fatalError("Ambiguous subcommand name \"\(commandName)\" encountered in ParsableCommand \"\(command)\"")
     } catch {
       fatalError("Unexpected error: \(error).")
     }

--- a/Sources/ArgumentParser/Utilities/Tree.swift
+++ b/Sources/ArgumentParser/Utilities/Tree.swift
@@ -90,7 +90,11 @@ extension Tree where Element == ParsableCommand.Type {
   
   convenience init(root command: ParsableCommand.Type) throws {
     self.init(command)
+    var subcommandNames = Set<String>()
     for subcommand in command.configuration.subcommands {
+      if !subcommandNames.insert(subcommand._commandName).inserted {
+        throw InitializationError.matchingCommandNames(command, subcommand._commandName)
+      }
       if subcommand == command {
         throw InitializationError.recursiveSubcommand(subcommand)
       }
@@ -100,5 +104,6 @@ extension Tree where Element == ParsableCommand.Type {
     
   enum InitializationError: Error {
     case recursiveSubcommand(ParsableCommand.Type)
+    case matchingCommandNames(ParsableCommand.Type, String)
   }
 }

--- a/Tests/ArgumentParserUnitTests/TreeTests.swift
+++ b/Tests/ArgumentParserUnitTests/TreeTests.swift
@@ -70,3 +70,35 @@ extension TreeTests {
     XCTAssertThrowsError(try Tree(root: Root.asCommand))
   }
 }
+
+extension TreeTests {
+  struct RootWithSubs: ParsableCommand {
+    static let configuration = CommandConfiguration(subcommands: [Sub.self, SubTwo.self])
+
+    struct Sub: ParsableCommand {
+    }
+
+    struct SubTwo: ParsableCommand {
+      static let configuration = CommandConfiguration(commandName: "sub")
+    }
+  }
+
+  struct RootWithNestedSubs: ParsableCommand {
+    static let configuration = CommandConfiguration(subcommands: [Sub.self])
+
+    struct Sub: ParsableCommand {
+      static let configuration = CommandConfiguration(subcommands: [Nested.self, NestedTwo.self])
+      struct Nested: ParsableCommand {
+      }
+
+      struct NestedTwo: ParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "nested")
+      }
+    }
+  }
+
+  func testInitializationWithMatchingCommandNames() {
+    XCTAssertThrowsError(try Tree(root: RootWithSubs.asCommand))
+    XCTAssertThrowsError(try Tree(root: RootWithNestedSubs.asCommand))
+  }
+}


### PR DESCRIPTION
Currently it's possible to have two commands with the same _commandName by mixing a combination of the automatic command name generation based on the type name, and explicit use of `CommandConfiguration`'s commandName parameter. For example, if we edit the math examples `Add` command to have a commandName of "multiply" this is allowed currently:

```
./.build/debug/math multiply 2 3
5
```

The behavior today is whatever subcommand is registered in the tree first is what will resolve for that command. So, `Multiply` in this example is permanently shadowed.

This change just makes sure there's no occurence of this happening in any level of the tree of potential subcommands, and if so we'll abort early. 

#### Note
I can't imagine this happens too often, but the detection logic will also be useful to verify clashing aliases+subcommands for this change as well https://github.com/apple/swift-argument-parser/pull/627.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
