### PR TITLE
Eliminate warnings re: CommandConfiguration init

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -146,18 +146,18 @@ public struct CommandConfiguration: Sendable {
 extension CommandConfiguration {
   @available(*, deprecated, message: "Use the memberwise initializer with the aliases parameter.")
   public init(
-    commandName: String? = nil,
-    abstract: String = "",
-    usage: String? = nil,
-    discussion: String = "",
-    version: String = "",
-    shouldDisplay: Bool = true,
-    subcommands: [ParsableCommand.Type] = [],
-    defaultSubcommand: ParsableCommand.Type? = nil,
-    helpNames: NameSpecification? = nil
+    commandName _commandName: String?,
+    abstract: String,
+    usage: String?,
+    discussion: String,
+    version: String,
+    shouldDisplay: Bool,
+    subcommands: [ParsableCommand.Type],
+    defaultSubcommand: ParsableCommand.Type?,
+    helpNames: NameSpecification?
   ) {
     self.init(
-      commandName: commandName,
+      commandName: _commandName,
       abstract: abstract,
       usage: usage,
       discussion: discussion,

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -26,7 +26,9 @@ extension CollectionDifference.Change {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension CollectionDifference.Change: Comparable where ChangeElement: Equatable {
+extension CollectionDifference.Change: Swift.Comparable 
+  where ChangeElement: Equatable
+{
   public static func < (lhs: Self, rhs: Self) -> Bool {
     guard lhs.offset == rhs.offset else {
       return lhs.offset < rhs.offset


### PR DESCRIPTION
When the old (pre-aliases) initializer has all its default parameter
values, it is selected as the overload because it has fewer parameters
overall. Removing the default parameters allows it to still satisfy
(very niche) source compat requirements without actually being
available as an overload.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
