### PR TITLE
Prefer if-let shorthand in `CountLines.swift`

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -31,7 +31,7 @@ struct CountLines: AsyncParsableCommand {
 extension CountLines {
     var fileHandle: FileHandle {
         get throws {
-            guard let inputFile = inputFile else {
+            guard let inputFile else {
                 return .standardInput
             }
             return try FileHandle(forReadingFrom: inputFile)
@@ -50,7 +50,7 @@ extension CountLines {
             print("Lines from stdin", terminator: "")
         }
         
-        if let prefix = prefix {
+        if let prefix {
             print(", prefixed by '\(prefix)'", terminator: "")
         }
         


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

`CountLines.swift` uses the mix of the normal if-let and the shorthand. This PR changes the normal version to the shorthand to stay consistent.

### Checklist
- N/A I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- N/A I've updated the documentation if necessary
