### PR TITLE
Add missing @Flag initializer in example

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -17,7 +17,7 @@
 /// ```swift
 /// struct GlobalOptions: ParsableArguments {
 ///     @Flag(name: .shortAndLong)
-///     var verbose: Bool
+///     var verbose: Bool = false
 ///
 ///     @Argument var values: [Int]
 /// }


### PR DESCRIPTION
The documentation as presented doesn't compile. An initializer is required for a boolean flag.

rdar://132579907

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
