### PR TITLE
Remove `@_implementationOnly` imports

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -11,10 +11,8 @@
 
 #if swift(>=5.11)
 internal import class Foundation.ProcessInfo
-#elseif swift(>=5.10)
-import class Foundation.ProcessInfo
 #else
-@_implementationOnly import class Foundation.ProcessInfo
+import class Foundation.ProcessInfo
 #endif
 
 struct CommandError: Error {

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -9,15 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
 internal import ArgumentParserToolInfo
 internal import class Foundation.JSONEncoder
-#elseif swift(>=5.10)
+#else
 import ArgumentParserToolInfo
 import class Foundation.JSONEncoder
-#else
-@_implementationOnly import ArgumentParserToolInfo
-@_implementationOnly import class Foundation.JSONEncoder
 #endif
 
 internal struct DumpHelpGenerator {

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -9,15 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
 internal import protocol Foundation.LocalizedError
 internal import class Foundation.NSError
-#elseif swift(>=5.10)
+#else
 import protocol Foundation.LocalizedError
 import class Foundation.NSError
-#else
-@_implementationOnly import protocol Foundation.LocalizedError
-@_implementationOnly import class Foundation.NSError
 #endif
 
 enum MessageInfo {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,12 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
 internal import protocol Foundation.LocalizedError
-#elseif swift(>=5.10)
-import protocol Foundation.LocalizedError
 #else
-@_implementationOnly import protocol Foundation.LocalizedError
+import protocol Foundation.LocalizedError
 #endif
 
 struct UsageGenerator {

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -9,12 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
 internal import Foundation
-#elseif swift(>=5.10)
-import Foundation
 #else
-@_implementationOnly import Foundation
+import Foundation
 #endif
 
 /// A synchronization primitive that protects shared mutable state via mutual


### PR DESCRIPTION
The `@_implementationOnly` attribute does not work correctly without library evolution enabled. The only possible client with this enabled is Apple, however they have updated to the Swift 6 compiler and can use `internal import` instead of this attribute. Therefore there is no need for this package to use the attribute anymore.
