### PR TITLE
Exclude hidden argument content from generate-manual output

### DIFF
--- a/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
@@ -94,10 +94,6 @@ final class MathGenerateManualTests: XCTestCase {
       .It Ar custom-arg
       .It Ar values...
       A group of floating-point values to operate on.
-      .It Fl -test-success-exit-code
-      .It Fl -test-failure-exit-code
-      .It Fl -test-validation-exit-code
-      .It Fl -test-custom-exit-code Ar test-custom-exit-code
       .It Fl -file Ar file
       .It Fl -directory Ar directory
       .It Fl -shell Ar shell
@@ -356,10 +352,6 @@ final class MathGenerateManualTests: XCTestCase {
       .Op Ar one-of-four
       .Op Ar custom-arg
       .Op Ar values...
-      .Op Fl -test-success-exit-code
-      .Op Fl -test-failure-exit-code
-      .Op Fl -test-validation-exit-code
-      .Op Fl -test-custom-exit-code Ar test-custom-exit-code
       .Op Fl -file Ar file
       .Op Fl -directory Ar directory
       .Op Fl -shell Ar shell
@@ -372,10 +364,6 @@ final class MathGenerateManualTests: XCTestCase {
       .It Ar custom-arg
       .It Ar values...
       A group of floating-point values to operate on.
-      .It Fl -test-success-exit-code
-      .It Fl -test-failure-exit-code
-      .It Fl -test-validation-exit-code
-      .It Fl -test-custom-exit-code Ar test-custom-exit-code
       .It Fl -file Ar file
       .It Fl -directory Ar directory
       .It Fl -shell Ar shell

--- a/Tools/generate-manual/DSL/ArgumentSynopsis.swift
+++ b/Tools/generate-manual/DSL/ArgumentSynopsis.swift
@@ -16,10 +16,12 @@ struct ArgumentSynopsis: MDocComponent {
   var argument: ArgumentInfoV0
 
   var body: MDocComponent {
-    if argument.isOptional {
-      MDocMacro.OptionalCommandLineComponent(arguments: [synopsis])
-    } else {
-      synopsis
+    if argument.shouldDisplay {
+      if argument.isOptional {
+        MDocMacro.OptionalCommandLineComponent(arguments: [synopsis])
+      } else {
+         synopsis
+      }
     }
   }
 

--- a/Tools/generate-manual/DSL/MultiPageDescription.swift
+++ b/Tools/generate-manual/DSL/MultiPageDescription.swift
@@ -23,18 +23,20 @@ struct MultiPageDescription: MDocComponent {
 
       List {
         for argument in command.arguments ?? [] {
-          MDocMacro.ListItem(title: argument.manualPageDescription)
-
-          if let abstract = argument.abstract {
-            abstract
-          }
-
-          if argument.abstract != nil, argument.discussion != nil {
-            MDocMacro.ParagraphBreak()
-          }
-
-          if let discussion = argument.discussion {
-            discussion
+          if argument.shouldDisplay {
+            MDocMacro.ListItem(title: argument.manualPageDescription)
+                  
+            if let abstract = argument.abstract {
+              abstract
+            }
+                  
+            if argument.abstract != nil, argument.discussion != nil {
+              MDocMacro.ParagraphBreak()
+            }
+                  
+            if let discussion = argument.discussion {
+              discussion
+            }
           }
         }
       }

--- a/Tools/generate-manual/DSL/SinglePageDescription.swift
+++ b/Tools/generate-manual/DSL/SinglePageDescription.swift
@@ -38,18 +38,20 @@ struct SinglePageDescription: MDocComponent {
 
     List {
       for argument in command.arguments ?? [] {
-        MDocMacro.ListItem(title: argument.manualPageDescription)
+        if argument.shouldDisplay {
+          MDocMacro.ListItem(title: argument.manualPageDescription)
 
-        if let abstract = argument.abstract {
-          abstract
-        }
+          if let abstract = argument.abstract {
+            abstract
+          }
 
-        if argument.abstract != nil, argument.discussion != nil {
-          MDocMacro.ParagraphBreak()
-        }
+          if argument.abstract != nil, argument.discussion != nil {
+            MDocMacro.ParagraphBreak()
+          }
 
-        if let discussion = argument.discussion {
-          discussion
+          if let discussion = argument.discussion {
+            discussion
+          }
         }
       }
 


### PR DESCRIPTION
Resolves issue #665, which suppresses the output for arguments that are marked as `hidden` - from synopsis, single page output, and multi-page output for generate-manual.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
