### PR TITLE
extend ToolInfoV0 with command visibility

### DIFF
--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -135,6 +135,7 @@ fileprivate extension CommandInfoV0 {
     self = CommandInfoV0(
       superCommands: superCommands,
       commandName: command._commandName,
+      shouldDisplay: command.configuration.shouldDisplay,
       abstract: command.configuration.abstract,
       discussion2: .init(command.configuration.discussion),
       defaultSubcommand: defaultSubcommand,

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -145,7 +145,7 @@ public struct CommandInfoV0: Codable, Hashable {
   public var discussion2: Discussion?
   
   /// Command should appear in help displays.
-  public var shouldDisplay: Bool
+  public var shouldDisplay: Bool = true
 
   /// Optional name of the subcommand invoked when the command is invoked with
   /// no arguments.
@@ -250,7 +250,7 @@ public struct ArgumentInfoV0: Codable, Hashable {
   public var shouldDisplay: Bool
   /// Custom name of argument's section.
   public var sectionTitle: String?
-  
+
   /// Argument can be omitted.
   public var isOptional: Bool
   /// Argument can be specified multiple times.
@@ -317,7 +317,7 @@ public struct ArgumentInfoV0: Codable, Hashable {
 
     self.shouldDisplay = shouldDisplay
     self.sectionTitle = sectionTitle
-    
+
     self.isOptional = isOptional
     self.isRepeating = isRepeating
 

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -111,7 +111,7 @@ public struct CommandInfoV0: Codable, Hashable {
   /// Custom CodingKeys names.
   enum CodingKeys: String, CodingKey {
     case discussion2 = "discussion"
-    case superCommands, commandName, abstract, defaultSubcommand, subcommands, arguments
+    case superCommands, commandName, abstract, defaultSubcommand, subcommands, arguments, shouldDisplay
   }
 
   /// Super commands and tools.
@@ -143,6 +143,9 @@ public struct CommandInfoV0: Codable, Hashable {
   /// for a custom `CaseIterable` type), or can describe
   /// a static block of text that extends the description of the argument.
   public var discussion2: Discussion?
+  
+  /// Command should appear in help displays.
+  public var shouldDisplay: Bool
 
   /// Optional name of the subcommand invoked when the command is invoked with
   /// no arguments.
@@ -155,6 +158,7 @@ public struct CommandInfoV0: Codable, Hashable {
   public init(
     superCommands: [String],
     commandName: String,
+    shouldDisplay: Bool,
     abstract: String,
     discussion2: Discussion?,
     defaultSubcommand: String?,
@@ -164,6 +168,7 @@ public struct CommandInfoV0: Codable, Hashable {
     self.superCommands = superCommands.nonEmpty
 
     self.commandName = commandName
+    self.shouldDisplay = shouldDisplay
     self.abstract = abstract.nonEmpty
     self.discussion2 = discussion2
     self.defaultSubcommand = defaultSubcommand?.nonEmpty
@@ -186,6 +191,7 @@ public struct CommandInfoV0: Codable, Hashable {
     self.init(
       superCommands: superCommands,
       commandName: commandName,
+      shouldDisplay: true,
       abstract: abstract,
       discussion2: discussion,
       defaultSubcommand: defaultSubcommand,

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -596,7 +596,8 @@ extension DumpHelpGenerationTests {
           "valueName" : "help"
         }
       ],
-      "commandName" : "c"
+      "commandName" : "c",
+      "shouldDisplay" : true
     },
     "serializationVersion" : 0
   }

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -90,6 +90,8 @@ extension DumpHelpGenerationTests {
 
     @Option(help: .init(discussion: "A discussion."))
     var discussion: String
+    
+    static var configuration = CommandConfiguration(shouldDisplay: false)
   }
 
   public func testDumpA() throws {
@@ -597,7 +599,7 @@ extension DumpHelpGenerationTests {
         }
       ],
       "commandName" : "c",
-      "shouldDisplay" : true
+      "shouldDisplay" : false
     },
     "serializationVersion" : 0
   }

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -277,7 +277,8 @@ extension DumpHelpGenerationTests {
         "valueName" : "help"
       }
     ],
-    "commandName" : "a"
+    "commandName" : "a",
+    "shouldDisplay" : true
   },
   "serializationVersion" : 0
 }
@@ -346,7 +347,8 @@ extension DumpHelpGenerationTests {
         "valueName" : "help"
       }
     ],
-    "commandName" : "b"
+    "commandName" : "b",
+    "shouldDisplay" : true
   },
   "serializationVersion" : 0
 }
@@ -647,6 +649,7 @@ extension DumpHelpGenerationTests {
       }
     ],
     "commandName" : "math",
+    "shouldDisplay" : true,
     "subcommands" : [
       {
         "abstract" : "Print the sum of the values.",
@@ -723,6 +726,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "add",
+        "shouldDisplay" : true,
         "superCommands" : [
           "math"
         ]
@@ -802,6 +806,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "multiply",
+        "shouldDisplay" : true,
         "superCommands" : [
           "math"
         ]
@@ -851,6 +856,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "stats",
+        "shouldDisplay" : true,
         "subcommands" : [
           {
             "abstract" : "Print the average of the values.",
@@ -929,6 +935,7 @@ extension DumpHelpGenerationTests {
               }
             ],
             "commandName" : "average",
+            "shouldDisplay" : true,
             "superCommands" : [
               "math",
               "stats"
@@ -987,6 +994,7 @@ extension DumpHelpGenerationTests {
               }
             ],
             "commandName" : "stdev",
+            "shouldDisplay" : true,
             "superCommands" : [
               "math",
               "stats"
@@ -1195,6 +1203,7 @@ extension DumpHelpGenerationTests {
               }
             ],
             "commandName" : "quantiles",
+            "shouldDisplay" : true,
             "superCommands" : [
               "math",
               "stats"
@@ -1289,6 +1298,7 @@ extension DumpHelpGenerationTests {
       }
     ],
     "commandName" : "add",
+    "shouldDisplay" : true,
     "superCommands" : [
       "math"
     ]
@@ -1375,6 +1385,7 @@ extension DumpHelpGenerationTests {
       }
     ],
     "commandName" : "multiply",
+    "shouldDisplay" : true,
     "superCommands" : [
       "math"
     ]
@@ -1431,6 +1442,7 @@ extension DumpHelpGenerationTests {
       }
     ],
     "commandName" : "stats",
+    "shouldDisplay" : true,
     "subcommands" : [
       {
         "abstract" : "Print the average of the values.",
@@ -1509,6 +1521,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "average",
+        "shouldDisplay" : true,
         "superCommands" : [
           "math",
           "stats"
@@ -1567,6 +1580,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "stdev",
+        "shouldDisplay" : true,
         "superCommands" : [
           "math",
           "stats"
@@ -1775,6 +1789,7 @@ extension DumpHelpGenerationTests {
           }
         ],
         "commandName" : "quantiles",
+        "shouldDisplay" : true,
         "superCommands" : [
           "math",
           "stats"


### PR DESCRIPTION
- resolves https://github.com/apple/swift-argument-parser/issues/668 by extending the ToolInfoV0 (help dump) struct to include visibility information for commands (already exists for arguments).
- updates test output to verify existing examples extend with the additional key.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
