### PR TITLE
Use FoundationEssentials if it's available

### DIFF
--- a/Examples/count-lines/CountLines.swift
+++ b/Examples/count-lines/CountLines.swift
@@ -10,7 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @main
 @available(macOS 12, *)

--- a/Plugins/GenerateManual/GenerateManualPluginError.swift
+++ b/Plugins/GenerateManual/GenerateManualPluginError.swift
@@ -8,8 +8,11 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
-
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import PackagePlugin
 
 enum GenerateManualPluginError: Error {

--- a/Plugins/GenerateManual/PackagePlugin+Helpers.swift
+++ b/Plugins/GenerateManual/PackagePlugin+Helpers.swift
@@ -9,7 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import PackagePlugin
 
 extension ArgumentExtractor {

--- a/Sources/ArgumentParser/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/GettingStarted.md
@@ -228,7 +228,11 @@ As promised, here's the complete `count` command, for your experimentation:
 
 ```swift
 import ArgumentParser
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @main
 struct Count: ParsableCommand {

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/AsyncParsableCommand.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/AsyncParsableCommand.md
@@ -9,7 +9,11 @@ To use `async`/`await` code in your commands' `run()` method implementations, fo
 The following example declares a `CountLines` command that uses Foundation's asynchronous `FileHandle.AsyncBytes` to read the lines from a file: 
 
 ```swift
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @main
 struct CountLines: AsyncParsableCommand {

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -9,9 +9,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import ArgumentParserToolInfo
+internal import class FoundationEssentials.JSONEncoder
+#else
 internal import ArgumentParserToolInfo
 internal import class Foundation.JSONEncoder
+#endif
 #elseif swift(>=5.10)
 import ArgumentParserToolInfo
 import class Foundation.JSONEncoder

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -9,9 +9,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import protocol FoundationEssentials.LocalizedError
+internal import class FoundationEssentials.NSError
+#else
 internal import protocol Foundation.LocalizedError
 internal import class Foundation.NSError
+#endif
 #elseif swift(>=5.10)
 import protocol Foundation.LocalizedError
 import class Foundation.NSError

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,8 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.11)
+#if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import protocol FoundationEssentials.LocalizedError
+#else
 internal import protocol Foundation.LocalizedError
+#endif
 #elseif swift(>=5.10)
 import protocol Foundation.LocalizedError
 #else

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -16,7 +16,7 @@ import ArgumentParserTestHelpers
 final class HelpGenerationTests: XCTestCase {
 }
 
-extension Foundation.URL: ArgumentParser.ExpressibleByArgument {
+extension URL: ArgumentParser.ExpressibleByArgument {
   public init?(argument: String) {
     guard let url = URL(string: argument) else {
       return nil

--- a/Tools/changelog-authors/ChangelogAuthors.swift
+++ b/Tools/changelog-authors/ChangelogAuthors.swift
@@ -12,7 +12,11 @@
 #if os(macOS)
 
 import ArgumentParser
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: Command
 

--- a/Tools/generate-manual/DSL/Document.swift
+++ b/Tools/generate-manual/DSL/Document.swift
@@ -11,7 +11,11 @@
 
 import ArgumentParser
 import ArgumentParserToolInfo
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct Document: MDocComponent {
   var multiPage: Bool

--- a/Tools/generate-manual/DSL/DocumentDate.swift
+++ b/Tools/generate-manual/DSL/DocumentDate.swift
@@ -11,7 +11,11 @@
 
 import ArgumentParser
 import ArgumentParserToolInfo
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct DocumentDate: MDocComponent {
   private var month: String

--- a/Tools/generate-manual/DSL/Preamble.swift
+++ b/Tools/generate-manual/DSL/Preamble.swift
@@ -11,7 +11,11 @@
 
 import ArgumentParser
 import ArgumentParserToolInfo
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 struct Preamble: MDocComponent {
   var date: Date

--- a/Tools/generate-manual/Extensions/Date+ExpressibleByArgument.swift
+++ b/Tools/generate-manual/Extensions/Date+ExpressibleByArgument.swift
@@ -10,9 +10,13 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
-extension Foundation.Date: ArgumentParser.ExpressibleByArgument {
+extension Date: ArgumentParser.ExpressibleByArgument {
   // parsed as `yyyy-mm-dd`
   public init?(argument: String) {
     // ensure the input argument is composed of exactly 3 components separated

--- a/Tools/generate-manual/Extensions/Process+SimpleAPI.swift
+++ b/Tools/generate-manual/Extensions/Process+SimpleAPI.swift
@@ -9,7 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 enum SubprocessError: Swift.Error, LocalizedError, CustomStringConvertible {
   case missingExecutable(url: URL)

--- a/Tools/generate-manual/GenerateManual.swift
+++ b/Tools/generate-manual/GenerateManual.swift
@@ -11,7 +11,11 @@
 
 import ArgumentParser
 import ArgumentParserToolInfo
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 enum GenerateManualError: Error {
   case failedToRunSubprocess(error: Error)


### PR DESCRIPTION
Use `FoundationEssentials` if it's available. This stops all of Foundation being linked when not needed and reduces binary sizes

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
