### PR TITLE
Fix Swift 5.7 build errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,9 +61,9 @@ var package = Package(
             dependencies: ["ArgumentParser"],
             path: "Examples/repeat"),
         .executableTarget(
-          name: "color",
-          dependencies: ["ArgumentParser"],
-          path: "Examples/color")
+            name: "color",
+            dependencies: ["ArgumentParser"],
+            path: "Examples/color"),
 
         // Tools
         .executableTarget(

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -186,14 +186,15 @@ public struct CommandInfoV0: Codable, Hashable {
     subcommands: [CommandInfoV0],
     arguments: [ArgumentInfoV0]
   ) {
-    let discussion: Discussion? = if let discussion { .init(discussion) } else { nil }
+    let discussion2: Discussion?
+    if let discussion { discussion2 = .init(discussion) } else { discussion2 = nil }
 
     self.init(
       superCommands: superCommands,
       commandName: commandName,
       shouldDisplay: true,
       abstract: abstract,
-      discussion2: discussion,
+      discussion2: discussion2,
       defaultSubcommand: defaultSubcommand,
       subcommands: subcommands,
       arguments: arguments
@@ -349,7 +350,8 @@ public struct ArgumentInfoV0: Codable, Hashable {
     abstract: String?,
     discussion: String?
   ) {
-    let discussion: Discussion? = if let discussion { .init(discussion) } else { nil }
+    let discussion2: Discussion?
+    if let discussion { discussion2 = .init(discussion) } else { discussion2 = nil }
 
     self.init(
       kind: kind,
@@ -363,8 +365,7 @@ public struct ArgumentInfoV0: Codable, Hashable {
       defaultValue: defaultValue,
       allValues: allValues,
       abstract: abstract,
-      discussion2: discussion
+      discussion2: discussion2
     )
   }
 }
-

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -64,11 +64,11 @@ extension DumpHelpGenerationTests {
       var defaultValueDescription: String {
         switch self {
         case .blue:
-          "A blue color, like the sky!"
+          return "A blue color, like the sky!"
         case .red:
-          "A red color, like a rose!"
+          return "A red color, like a rose!"
         case .yellow:
-          "A yellow color, like the sun!"
+          return "A yellow color, like the sun!"
         }
       }
     }

--- a/Tools/generate-manual/GenerateManual.swift
+++ b/Tools/generate-manual/GenerateManual.swift
@@ -24,13 +24,13 @@ extension GenerateManualError: CustomStringConvertible {
   var description: String {
     switch self {
     case let .failedToRunSubprocess(error):
-      "Failed to run subprocess: \(error)"
+      return "Failed to run subprocess: \(error)"
     case let .unableToParseToolOutput(error):
-      "Failed to parse tool output: \(error)"
+      return "Failed to parse tool output: \(error)"
     case let .unsupportedDumpHelpVersion(expected, found):
-      "Unsupported dump help version, expected '\(expected)' but found: '\(found)'"
+      return "Unsupported dump help version, expected '\(expected)' but found: '\(found)'"
     case let .failedToGenerateManualPages(error):
-      "Failed to generated manual pages: \(error)"
+      return "Failed to generated manual pages: \(error)"
     }
   }
 }


### PR DESCRIPTION
Fixed all Swift 5.7 build breaks in `main`, namely:

- `Package.swift`: `target` array missing a comma
- `ToolInfo.swift`: contains 2 if expressions, which are not supported by Swift 5.7
- `GenerateManual.swift`: contains switch expression, which is not supported by Swift 5.7
- `DumpHelpGenerationTests.swift`: contains switch expression, which is not supported by Swift 5.7

Resolve #675

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
