### PR TITLE
Fix incorrect or confusing documentation about Swift versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ let package = Package(
 
 ### Supported Versions
 
-The most recent versions of swift-argument-parser support Swift 5.5 and newer. The minimum Swift version supported by swift-argument-parser releases are detailed below:
+The minimum Swift version supported by swift-argument-parser releases are detailed below:
 
 swift-argument-parser | Minimum Swift Version
 ----------------------|----------------------

--- a/Sources/ArgumentParser/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/GettingStarted.md
@@ -15,7 +15,7 @@ and then include `"ArgumentParser"` as a dependency for our executable target.
 Our "Package.swift" file ends up looking like this:
 
 ```swift
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/AsyncParsableCommand.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/AsyncParsableCommand.md
@@ -29,13 +29,21 @@ struct CountLines: AsyncParsableCommand {
 
 ### Usage in Swift 5.5
 
-In Swift 5.5, you need to declare a separate, standalone type as your asynchronous `@main` entry point. Instead of designating your root command as `@main`, as described above, use the code snippet below, replacing the placeholder with the name of your own root command. Otherwise, follow the steps above to use `async`/`await` code within your commands' `run()` methods.
+Swift 5.5 is supported by the obsolete versions 1.1.x & 1.2.x versions of Swift Argument Parser.
+
+In Swift 5.5, an asynchronous `@main` entry point must be declared as a separate standalone type.
+
+Your root command cannot be designated as `@main`, unlike as described above.
+
+Instead, use the code snippet below, replacing the `<#RootCommand#>` placeholder with the name of your own root command.
 
 ```swift
 @main struct AsyncMain: AsyncMainProtocol {
     typealias Command = <#RootCommand#>
 }
 ```
+
+Continue to follow the other steps above to use `async`/`await` code within your commands' `run()` methods.
 
 ## Topics
 
@@ -47,4 +55,3 @@ In Swift 5.5, you need to declare a separate, standalone type as your asynchrono
 
 - ``main()``
 - ``AsyncMainProtocol``
-


### PR DESCRIPTION
Fix incorrect or confusing documentation about Swift versions

Rewrote Markdown to properly specify Swift 5.7 instead of 5.5, and to clarify other information related to Swift versions.

Resolve #677

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
