### PR TITLE
build: repair the CMake based build

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(ArgumentParser
   Completions/ZshCompletionsGenerator.swift
 
   "Parsable Properties/Argument.swift"
+  "Parsable Properties/ArgumentDiscussion.swift"
   "Parsable Properties/ArgumentHelp.swift"
   "Parsable Properties/ArgumentVisibility.swift"
   "Parsable Properties/CompletionKind.swift"


### PR DESCRIPTION
Add the missing source file to the package to allow building with CMake again.