### PR TITLE
Add tests parsing dump help output

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,10 @@ var package = Package(
             dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
             exclude: ["CMakeLists.txt"]),
         .testTarget(
+            name: "ArgumentParserToolInfoTests",
+            dependencies: ["ArgumentParserToolInfo"],
+            exclude: ["Examples"]),
+        .testTarget(
             name: "ArgumentParserUnitTests",
             dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
             exclude: ["CMakeLists.txt"]),

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -91,6 +91,10 @@ var package = Package(
             dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
             exclude: ["CMakeLists.txt"]),
         .testTarget(
+            name: "ArgumentParserToolInfoTests",
+            dependencies: ["ArgumentParserToolInfo"],
+            exclude: ["Examples"]),
+        .testTarget(
             name: "ArgumentParserUnitTests",
             dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
             exclude: ["CMakeLists.txt"]),

--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -145,7 +145,7 @@ public struct CommandInfoV0: Codable, Hashable {
   public var discussion2: Discussion?
   
   /// Command should appear in help displays.
-  public var shouldDisplay: Bool = true
+  public var shouldDisplay: Bool
 
   /// Optional name of the subcommand invoked when the command is invoked with
   /// no arguments.
@@ -199,6 +199,18 @@ public struct CommandInfoV0: Codable, Hashable {
       subcommands: subcommands,
       arguments: arguments
     )
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.superCommands = try container.decodeIfPresent([String].self, forKey: .superCommands)
+    self.commandName = try container.decode(String.self, forKey: .commandName)
+    self.abstract = try container.decodeIfPresent(String.self, forKey: .abstract)
+    self.discussion2 = try container.decodeIfPresent(Discussion.self, forKey: .discussion2)
+    self.shouldDisplay = try container.decodeIfPresent(Bool.self, forKey: .shouldDisplay) ?? true
+    self.defaultSubcommand = try container.decodeIfPresent(String.self, forKey: .defaultSubcommand)
+    self.subcommands = try container.decodeIfPresent([CommandInfoV0].self, forKey: .subcommands)
+    self.arguments = try container.decodeIfPresent([ArgumentInfoV0].self, forKey: .arguments)
   }
 }
 

--- a/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
+++ b/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+import ArgumentParserToolInfo
+
+extension DecodingError: @retroactive CustomStringConvertible {
+  public var description: String {
+    func pathDescription(_ path: [any CodingKey]) -> String {
+      var description = ""
+      for element in path {
+        if let intValue = element.intValue {
+          description += "[\(intValue)]"
+        } else {
+          if description.count > 0 { description += "." }
+          description += "\(element.stringValue)"
+        }
+      }
+      return description
+    }
+
+    switch self {
+    case let .dataCorrupted(context):
+      return "Data corrupted at '\(pathDescription(context.codingPath))'"
+    case let .keyNotFound(key, context):
+      return "Key not found at '\(pathDescription(context.codingPath + [key]))'"
+    case let .typeMismatch(_, context):
+      return "Type mismatch at '\(pathDescription(context.codingPath))'"
+    case let .valueNotFound(_, context):
+      return "Value not found at '\(pathDescription(context.codingPath))'"
+    @unknown default:
+      return "\(self)"
+    }
+  }
+}
+
+extension FileManager {
+  func files(
+    inDirectory directoryURL: URL,
+    withPathExtension pathExtension: String
+  ) -> [URL] {
+    let enumerator = self.enumerator(
+      at: directoryURL,
+      includingPropertiesForKeys: [])
+    guard let enumerator = enumerator else { return [] }
+
+    return enumerator
+      .lazy
+      .compactMap { $0 as? URL }
+      .filter { $0.pathExtension == pathExtension }
+      .sorted { $0.path < $1.path }
+  }
+}
+
+final class ArgumentParserToolInfoTests: XCTestCase {
+  func test_examples() {
+    let examplesDirectory = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Examples")
+    let examples = FileManager.default.files(
+      inDirectory: examplesDirectory,
+      withPathExtension: "json")
+
+    for example in examples {
+      do {
+        let data = try Data(contentsOf: example)
+        _ = try JSONDecoder().decode(ToolInfoV0.self, from: data)
+      } catch {
+        XCTFail("Failed to parse \(example.path): \(error)")
+      }
+    }
+  }
+}

--- a/Tests/ArgumentParserToolInfoTests/Examples/example0.json
+++ b/Tests/ArgumentParserToolInfoTests/Examples/example0.json
@@ -1,0 +1,6 @@
+{
+  "serializationVersion": 0,
+  "command": {
+    "commandName": "empty-example"
+  }
+}

--- a/Tests/ArgumentParserToolInfoTests/Examples/example1.json
+++ b/Tests/ArgumentParserToolInfoTests/Examples/example1.json
@@ -1,0 +1,65 @@
+{
+  "serializationVersion": 0,
+  "command": {
+    "superCommands": [
+      "parent2",
+      "parent1"
+    ],
+    "commandName": "full-example",
+    "abstract": "this command does everything",
+    "discussion": "like actually everything",
+    "defaultSubcommand": "do-thing",
+    "subcommands": [
+      {
+        "commandName": "sub"
+      }
+    ],
+    "arguments": [
+      {
+        "kind": "positional",
+        "shouldDisplay": true,
+        "isOptional": true,
+        "isRepeating": true,
+        "names": [
+          {
+            "kind": "long",
+            "name": "fruit"
+          },
+          {
+            "kind": "short",
+            "name": "f"
+          },
+          {
+            "kind": "longWithSingleDash",
+            "name": "frt"
+          },
+        ],
+        "preferredName": {
+          "kind": "long",
+          "name": "fruit"
+        },
+        "valueName": "fruit-type",
+        "defaultValue": "banana",
+        "allValues": [
+          "apple",
+          "banana",
+          "coconut"
+        ],
+        "abstract": "1234",
+        "discussion": "abcd",
+      },
+      {
+        "kind": "option",
+        "shouldDisplay": false,
+        "isOptional": false,
+        "isRepeating": false,
+      },
+      {
+        "kind": "flag",
+        "shouldDisplay": false,
+        "isOptional": false,
+        "isRepeating": false,
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a new test target called ArgumentParserToolInfoTests which contains example json output from dump-help. The test code attempts to parse all json files in the 'Examples' subdirectory. This will help us catch cases where ArgumentParser is unable to parse json generated by older versions.

We still need to add a test that asserts old ArgumentParser versions can parse the output of new versions.
