### PR TITLE
Refactor serialization of dump help descriptions

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/ArgumentDiscussion.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentDiscussion.swift
@@ -12,12 +12,13 @@
 
 /// A structure that contains an extended description of the argument.
 ///
-/// For `EnumerableOptionValue` types, the `.enumerated` case encapsulates the necessary information
-/// to list each of the possible values and their descriptions. Optionally, users can add a discussion preamble that
-/// will be appended to the beginning of the value list section.
+/// For `EnumerableOptionValue` types, the `.enumerated` case encapsulates the
+/// necessary information to list each of the possible values and their
+/// descriptions. Optionally, users can add a discussion preamble that will be
+/// appended to the beginning of the value list section.
 ///
-/// For example, the following `EnumerableOptionValue` type defined in a command could contain an
-/// additional discussion block defined in its `ArgumentHelp`:
+/// For example, the following `EnumerableOptionValue` type defined in a command
+/// could contain an additional discussion block defined in its `ArgumentHelp`:
 ///
 /// ```swift
 /// enum Color: String, EnumerableOptionValue {
@@ -77,8 +78,9 @@
 ///    -h, --help           Show help information
 /// ```
 ///
-/// In any case where the argument type is not `EnumerableOptionValue`, the default implementation
-/// will use the `.staticText` case and will print a block of discussion text.
+/// In any case where the argument type is not `EnumerableOptionValue`, the
+/// default implementation will use the `.staticText` case and will print a
+/// block of discussion text.
 enum ArgumentDiscussion {
   case staticText(String)
   case enumerated(preamble: String? = nil, any ExpressibleByArgument.Type)

--- a/Tests/ArgumentParserGenerateManualTests/ColorGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/ColorGenerateManualTests.swift
@@ -33,23 +33,24 @@ final class ColorGenerateManualTests: XCTestCase {
       Your favorite color.
       .Pp
       .Bl -tag -width 6n
-      .It red
+      .It Ar red
       A red color.
-      .It blue
+      .It Ar blue
       A blue color.
-      .It yellow
+      .It Ar yellow
       A yellow color.
       .El
       .It Fl -second Ar second
       Your second favorite color.
       .Pp
       This is optional.
+      .Pp
       .Bl -tag -width 6n
-      .It red
+      .It Ar red
       A red color.
-      .It blue
+      .It Ar blue
       A blue color.
-      .It yellow
+      .It Ar yellow
       A yellow color.
       .El
       .It Fl h , -help
@@ -90,23 +91,24 @@ final class ColorGenerateManualTests: XCTestCase {
       Your favorite color.
       .Pp
       .Bl -tag -width 6n
-      .It red
+      .It Ar red
       A red color.
-      .It blue
+      .It Ar blue
       A blue color.
-      .It yellow
+      .It Ar yellow
       A yellow color.
       .El
       .It Fl -second Ar second
       Your second favorite color.
       .Pp
       This is optional.
+      .Pp
       .Bl -tag -width 6n
-      .It red
+      .It Ar red
       A red color.
-      .It blue
+      .It Ar blue
       A blue color.
-      .It yellow
+      .It Ar yellow
       A yellow color.
       .El
       .It Fl h , -help

--- a/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
+++ b/Tests/ArgumentParserGenerateManualTests/MathGenerateManualTests.swift
@@ -70,6 +70,7 @@ final class MathGenerateManualTests: XCTestCase {
       .Bl -tag -width 6n
       .It Fl -kind Ar kind
       The kind of average to provide.
+      .Pp
       .It Ar values...
       A group of floating-point values to operate on.
       .It Fl -version
@@ -286,6 +287,7 @@ final class MathGenerateManualTests: XCTestCase {
       .Bl -tag -width 6n
       .It Fl -kind Ar kind
       The kind of average to provide.
+      .Pp
       .It Ar values...
       A group of floating-point values to operate on.
       .It Fl -version

--- a/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/DumpHelpGenerationTests.swift
@@ -82,9 +82,6 @@ extension DumpHelpGenerationTests {
     @Option(help: "An optional color.")
     var opt: Color?
 
-    @Option(help: "An optional color with a default value.")
-    var optWithDefault: Color? = .yellow
-
     @Option(help: .init(discussion: "A preamble for the list of values in the discussion section."))
     var extra: Color
 
@@ -362,27 +359,16 @@ extension DumpHelpGenerationTests {
       "arguments" : [
         {
           "abstract" : "A color to select.",
+          "allValueDescriptions" : {
+            "blue" : "A blue color, like the sky!",
+            "red" : "A red color, like a rose!",
+            "yellow" : "A yellow color, like the sun!"
+          },
           "allValues" : [
             "blue",
             "red",
             "yellow"
           ],
-          "discussion" : {
-            "values" : [
-              {
-                "description" : "A blue color, like the sky!",
-                "value" : "blue"
-              },
-              {
-                "description" : "A red color, like a rose!",
-                "value" : "red"
-              },
-              {
-                "description" : "A yellow color, like the sun!",
-                "value" : "yellow"
-              }
-            ]
-          },
           "isOptional" : false,
           "isRepeating" : false,
           "kind" : "option",
@@ -401,28 +387,17 @@ extension DumpHelpGenerationTests {
         },
         {
           "abstract" : "Another color to select!",
+          "allValueDescriptions" : {
+            "blue" : "A blue color, like the sky!",
+            "red" : "A red color, like a rose!",
+            "yellow" : "A yellow color, like the sun!"
+          },
           "allValues" : [
             "blue",
             "red",
             "yellow"
           ],
           "defaultValue" : "red",
-          "discussion" : {
-            "values" : [
-              {
-                "description" : "A blue color, like the sky!",
-                "value" : "blue"
-              },
-              {
-                "description" : "A red color, like a rose!",
-                "value" : "red"
-              },
-              {
-                "description" : "A yellow color, like the sun!",
-                "value" : "yellow"
-              }
-            ]
-          },
           "isOptional" : true,
           "isRepeating" : false,
           "kind" : "option",
@@ -441,27 +416,16 @@ extension DumpHelpGenerationTests {
         },
         {
           "abstract" : "An optional color.",
+          "allValueDescriptions" : {
+            "blue" : "A blue color, like the sky!",
+            "red" : "A red color, like a rose!",
+            "yellow" : "A yellow color, like the sun!"
+          },
           "allValues" : [
             "blue",
             "red",
             "yellow"
           ],
-          "discussion" : {
-            "values" : [
-              {
-                "description" : "A blue color, like the sky!",
-                "value" : "blue"
-              },
-              {
-                "description" : "A red color, like a rose!",
-                "value" : "red"
-              },
-              {
-                "description" : "A yellow color, like the sun!",
-                "value" : "yellow"
-              }
-            ]
-          },
           "isOptional" : true,
           "isRepeating" : false,
           "kind" : "option",
@@ -479,68 +443,17 @@ extension DumpHelpGenerationTests {
           "valueName" : "opt"
         },
         {
-          "abstract" : "An optional color with a default value.",
+          "allValueDescriptions" : {
+            "blue" : "A blue color, like the sky!",
+            "red" : "A red color, like a rose!",
+            "yellow" : "A yellow color, like the sun!"
+          },
           "allValues" : [
             "blue",
             "red",
             "yellow"
           ],
-          "defaultValue" : "yellow",
-          "discussion" : {
-            "values" : [
-              {
-                "description" : "A blue color, like the sky!",
-                "value" : "blue"
-              },
-              {
-                "description" : "A red color, like a rose!",
-                "value" : "red"
-              },
-              {
-                "description" : "A yellow color, like the sun!",
-                "value" : "yellow"
-              }
-            ]
-          },
-          "isOptional" : true,
-          "isRepeating" : false,
-          "kind" : "option",
-          "names" : [
-            {
-              "kind" : "long",
-              "name" : "opt-with-default"
-            }
-          ],
-          "preferredName" : {
-            "kind" : "long",
-            "name" : "opt-with-default"
-          },
-          "shouldDisplay" : true,
-          "valueName" : "opt-with-default"
-        },
-        {
-          "allValues" : [
-            "blue",
-            "red",
-            "yellow"
-          ],
-          "discussion" : {
-            "preamble" : "A preamble for the list of values in the discussion section.",
-            "values" : [
-              {
-                "description" : "A blue color, like the sky!",
-                "value" : "blue"
-              },
-              {
-                "description" : "A red color, like a rose!",
-                "value" : "red"
-              },
-              {
-                "description" : "A yellow color, like the sun!",
-                "value" : "yellow"
-              }
-            ]
-          },
+          "discussion" : "A preamble for the list of values in the discussion section.",
           "isOptional" : false,
           "isRepeating" : false,
           "kind" : "option",

--- a/Tools/generate-manual/DSL/Discussion.swift
+++ b/Tools/generate-manual/DSL/Discussion.swift
@@ -13,19 +13,40 @@
 import ArgumentParserToolInfo
 
 struct DiscussionText: MDocComponent {
-  var discussion: Discussion
+  var discussion: String?
+  var allValueStrings: [String]?
+  var allValueDescriptions: [String: String]?
+
+  init?(
+    discussion: String?,
+    allValueStrings: [String]?,
+    allValueDescriptions: [String: String]?
+  ) {
+    if discussion == nil, allValueStrings == nil {
+      return nil
+    }
+    self.discussion = discussion
+    self.allValueStrings = allValueStrings
+    self.allValueDescriptions = allValueDescriptions
+  }
 
   var body: MDocComponent {
-    if case let .staticText(text) = discussion {
-      text
-    } else if case let .enumerated(preamble, values) = discussion {
-      if let preamble {
-        preamble
-      }
+    if let discussion {
+      discussion
+    }
+
+    if discussion != nil, allValueStrings != nil {
+      MDocMacro.ParagraphBreak()
+    }
+
+    if let allValueStrings, let allValueDescriptions {
       List {
-        for value in values {
-          MDocMacro.ListItem(title: value.value)
-          value.description
+        for value in allValueStrings {
+//          MDocMacro.ListItem(title: MDocMacro.CommandArgument(arguments: [value]))
+          MDocMacro.ListItem(title: MDocMacro.CommandArgument(arguments: [value]))
+          if let description = allValueDescriptions[value] {
+            description
+          }
         }
       }
     }

--- a/Tools/generate-manual/DSL/MultiPageDescription.swift
+++ b/Tools/generate-manual/DSL/MultiPageDescription.swift
@@ -17,25 +17,35 @@ struct MultiPageDescription: MDocComponent {
 
   var body: MDocComponent {
     Section(title: "description") {
-      if let discussion = command.discussion2 {
-        DiscussionText(discussion: discussion)
+      let discussion = DiscussionText(
+        discussion: command.discussion,
+        allValueStrings: nil,
+        allValueDescriptions: nil)
+
+      if let discussion = discussion {
+        discussion
       }
 
       List {
         for argument in command.arguments ?? [] {
           if argument.shouldDisplay {
             MDocMacro.ListItem(title: argument.manualPageDescription)
-                  
+
+            let discussion = DiscussionText(
+              discussion: argument.discussion,
+              allValueStrings: argument.allValueStrings,
+              allValueDescriptions: argument.allValueDescriptions)
+
             if let abstract = argument.abstract {
               abstract
             }
-                  
-            if argument.abstract != nil, argument.discussion2 != nil {
+
+            if argument.abstract != nil, discussion != nil {
               MDocMacro.ParagraphBreak()
             }
                   
-            if let discussion = argument.discussion2 {
-              DiscussionText(discussion: discussion)
+            if let discussion = discussion {
+              discussion
             }
           }
         }

--- a/Tools/generate-manual/DSL/SinglePageDescription.swift
+++ b/Tools/generate-manual/DSL/SinglePageDescription.swift
@@ -28,12 +28,17 @@ struct SinglePageDescription: MDocComponent {
       abstract
     }
 
-    if !root, command.abstract != nil, command.discussion2 != nil {
+    if !root, command.abstract != nil, command.discussion != nil {
       MDocMacro.ParagraphBreak()
     }
 
-    if let discussion = command.discussion2 {
-      DiscussionText(discussion: discussion)
+    let discussion = DiscussionText(
+      discussion: command.discussion,
+      allValueStrings: nil,
+      allValueDescriptions: nil)
+
+    if let discussion = discussion {
+      discussion
     }
 
     List {
@@ -41,16 +46,21 @@ struct SinglePageDescription: MDocComponent {
         if argument.shouldDisplay {
           MDocMacro.ListItem(title: argument.manualPageDescription)
 
+          let discussion = DiscussionText(
+            discussion: argument.discussion,
+            allValueStrings: argument.allValueStrings,
+            allValueDescriptions: argument.allValueDescriptions)
+
           if let abstract = argument.abstract {
             abstract
           }
 
-          if argument.abstract != nil, argument.discussion2 != nil {
+          if argument.abstract != nil, discussion != nil {
             MDocMacro.ParagraphBreak()
           }
 
-          if let discussion = argument.discussion2 {
-            DiscussionText(discussion: discussion)
+          if let discussion = discussion {
+            discussion
           }
         }
       }


### PR DESCRIPTION
Cleans up some lingering odds and ends from #647. Specifically switches
CommandInfoV0 to use the old style description and updates
ArgumentInfoV0 to emit value descriptions as a separate dictionary.