### PR TITLE
Refactor Bash completions to use ToolInfo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,7 @@ var package = Package(
         .testTarget(
             name: "ArgumentParserExampleTests",
             dependencies: ["ArgumentParserTestHelpers"],
+            exclude: ["Snapshots"],
             resources: [.copy("CountLinesTest.txt")]),
         .testTarget(
             name: "ArgumentParserGenerateDoccReferenceTests",

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -96,6 +96,7 @@ var package = Package(
         .testTarget(
             name: "ArgumentParserExampleTests",
             dependencies: ["ArgumentParserTestHelpers"],
+            exclude: ["Snapshots"],
             resources: [.copy("CountLinesTest.txt")]),
         .testTarget(
             name: "ArgumentParserGenerateDoccReferenceTests",

--- a/Sources/ArgumentParser/Parsing/ArgumentSet.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentSet.swift
@@ -191,9 +191,17 @@ extension ArgumentSet {
   }
   
   func firstPositional(
-    withKey key: InputKey
+    withKey key: InputKey,
   ) -> ArgumentDefinition? {
-    first(where: { $0.help.keys.contains(key) })
+    return first(where: { $0.help.keys.contains(key) })
+  }
+
+  func positional(
+    at index: Int
+  ) -> ArgumentDefinition? {
+    let arguments = self.content.filter { $0.isPositional }
+    guard arguments.count > index else { return nil }
+    return arguments[index]
   }
 }
 

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -86,7 +86,7 @@ fileprivate extension ArgumentSet {
   }
 }
 
-fileprivate extension ToolInfoV0 {
+extension ToolInfoV0 {
   init(commandStack: [ParsableCommand.Type]) {
     self.init(command: CommandInfoV0(commandStack: commandStack))
     // FIXME: This is a hack to inject the help command into the tool info

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -95,7 +95,7 @@ _math_stats_stdev() {
 _math_stats_quantiles() {
     opts="--file --directory --shell --custom --version -h --help"
     opts="$opts alphabet alligator branch braggart"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
+    opts="$opts $("${COMP_WORDS[0]}" ---completion stats quantiles -- positional@1 "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
@@ -139,7 +139,7 @@ _math_stats_quantiles() {
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _math_help() {
-    opts="--version"
+    opts=""
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -8,17 +8,13 @@ _base_test() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     COMPREPLY=()
     opts="--name --kind --other-kind --path1 --path2 --path3 --one --two --three --kind-counter --rep1 -r --rep2 -h --help sub-command escaped-command help"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
+    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- positional@0 "${COMP_WORDS[@]}")"
+    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- positional@1 "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     fi
     case $prev in
-        --name)
-
-            return
-        ;;
         --kind)
             COMPREPLY=( $(compgen -W "one two custom-three" -- "$cur") )
             return
@@ -45,14 +41,6 @@ _base_test() {
         ;;
         --path3)
             COMPREPLY=( $(compgen -W "c1_bash c2_bash c3_bash" -- "$cur") )
-            return
-        ;;
-        --rep1)
-
-            return
-        ;;
-        -r|--rep2)
-
             return
         ;;
     esac
@@ -82,17 +70,11 @@ _base_test_sub_command() {
 }
 _base_test_escaped_command() {
     opts="--one -h --help"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
+    opts="$opts $("${COMP_WORDS[0]}" ---completion escaped-command -- positional@0 "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "$1" ]]; then
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
         return
     fi
-    case $prev in
-        --one)
-
-            return
-        ;;
-    esac
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 _base_test_help() {


### PR DESCRIPTION
Rebases the implementation of the BashCompletionGenerator to use
ToolInfo from ArgumentParserToolInfo instead of digging through the
command structure. This helps us decouple the implementation of Argument
parsing from the generation of supplemental content such as docs,
man-pages, completion scripts, help menus and more.