### PR TITLE
Fix Swift 5.7 build errors

### DIFF
--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -48,9 +48,9 @@ class Mutex<T>: @unchecked Sendable {
   /// - Throws: Re-throws any error thrown by `body`.
   ///
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  func withLock<U, E>(
-    _ body: (inout T) throws(E) -> U
-  ) throws(E) -> U where E: Error {
+  func withLock<U>(
+    _ body: (inout T) throws -> U
+  ) rethrows -> U {
     self.lock.lock()
     defer { self.lock.unlock() }
     return try body(&self.value)

--- a/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
+++ b/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
@@ -13,7 +13,7 @@ import Foundation
 import XCTest
 import ArgumentParserToolInfo
 
-extension DecodingError: @retroactive CustomStringConvertible {
+extension DecodingError: Swift.CustomStringConvertible {
   public var description: String {
     func pathDescription(_ path: [any CodingKey]) -> String {
       var description = ""

--- a/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
+++ b/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
@@ -108,15 +108,15 @@ extension ArgumentInfoV0 {
 
     // TODO: default values, short, etc.
 
-    var inner =
-      switch self.kind {
-      case .positional:
-        "<\(names.joined(separator: "|"))>"
-      case .option:
-        "--\(names.joined(separator: "|"))=<\(self.valueName ?? "")>"
-      case .flag:
-        "--\(names.joined(separator: "|"))"
-      }
+    var inner: String
+    switch self.kind {
+    case .positional:
+      inner = "<\(names.joined(separator: "|"))>"
+    case .option:
+      inner = "--\(names.joined(separator: "|"))=<\(self.valueName ?? "")>"
+    case .flag:
+      inner = "--\(names.joined(separator: "|"))"
+    }
 
     if self.isRepeating {
       inner += "..."


### PR DESCRIPTION
Fix Swift 5.7 build errors.

I used `Swift.CustomStringConvertible` instead of `CustomStringConvertible` because of a [recommendation in the `@retroactive` Swift Proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility).

I know that you might want to move off of Swift 5.7 sometime, but can you please delay doing so until after a PR for #679 has been merged & released? Dropping support for 5.7 should require a major version bump.

Resolve #706

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
