### PR TITLE
Prevent implementation-only import build warnings on older Swift

### DIFF
--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -9,7 +9,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.11)
+internal import Foundation
+#elseif swift(>=5.10)
 import Foundation
+#else
+@_implementationOnly import Foundation
+#endif
 
 /// A synchronization primitive that protects shared mutable state via mutual
 /// exclusion.


### PR DESCRIPTION
Prevent implementation-only import build warnings on older Swift.

Resolve #719

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
