### PR TITLE
Fix confusing error message w/ single-dash option

### DIFF
--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -63,7 +63,11 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
     Array(_elements).sorted()
   }
 
-  init() {
+  var firstElement: Element {
+    guard !elements.isEmpty else {
+      fatalError("Invalid 'InputOrigin' with no positions")
+    }
+    return elements[0]
   }
 
   init(elements: [Element]) {

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -26,6 +26,7 @@ enum ParserError: Error {
   case nonAlphanumericShortOption(Character)
   /// The option was there, but its value is missing, e.g. `--name` but no value for the `name`.
   case missingValueForOption(InputOrigin, Name)
+  case missingValueOrUnknownCompositeOption(InputOrigin, Name, Name)
   case unexpectedValueForOption(InputOrigin.Element, Name, String)
   case unexpectedExtraValues([(InputOrigin, String)])
   case duplicateExclusiveValues(

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -198,6 +198,10 @@ extension ErrorMessageGenerator {
       return unknownOptionMessage(origin: o, name: n)
     case .missingValueForOption(let o, let n):
       return missingValueForOptionMessage(origin: o, name: n)
+    case .missingValueOrUnknownCompositeOption(
+      let o, let shortName, let compositeName):
+      return missingValueOrUnknownCompositeOptionMessage(
+        origin: o, shortName: shortName, compositeName: compositeName)
     case .unexpectedValueForOption(let o, let n, let v):
       return unexpectedValueForOptionMessage(origin: o, name: n, value: v)
     case .unexpectedExtraValues(let v):
@@ -338,6 +342,23 @@ extension ErrorMessageGenerator {
     } else {
       return "Missing value for '\(name.synopsisString)'"
     }
+  }
+
+  func missingValueOrUnknownCompositeOptionMessage(
+    origin: InputOrigin,
+    shortName: Name,
+    compositeName: Name
+  ) -> String {
+    let unknownOptionMessage = unknownOptionMessage(
+      origin: origin.firstElement,
+      name: compositeName)
+    let missingValueMessage = missingValueForOptionMessage(
+      origin: origin,
+      name: shortName)
+    return """
+      \(unknownOptionMessage)
+         or: \(missingValueMessage) in '\(compositeName.synopsisString)'
+      """
   }
 
   func unexpectedValueForOptionMessage(

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -535,3 +535,44 @@ final class ParsableArgumentsValidationTests: XCTestCase {
     }
   }
 }
+
+extension ParsableArgumentsValidationTests {
+  func testMissingValueForShortNameOptions() throws {
+    struct SomeArgs: ParsableArguments {
+      @Option(name: .shortAndLong)
+      var xArg: Int
+      @Option(name: .shortAndLong)
+      var zArg: Int
+      @Option(name: .customLong("long-with-x-or-y", withSingleDash: true))
+      var other: Int?
+    }
+
+    AssertErrorMessage(
+      SomeArgs.self,
+      ["-long_option_with_x_or_z"],
+      """
+      Unknown option '-long_option_with_x_or_z'
+         or: Missing value for '-x <x-arg>' in '-long_option_with_x_or_z'
+      """
+    )
+    // Including near-miss checking.
+    AssertErrorMessage(
+      SomeArgs.self,
+      ["-long-with-x-or-z"],
+      """
+      Unknown option '-long-with-x-or-z'. Did you mean '-long-with-x-or-y'?
+         or: Missing value for '-x <x-arg>' in '-long-with-x-or-z'
+      """
+    )
+    // Missing value for whole option.
+    AssertErrorMessage(
+      SomeArgs.self, ["-x", "-z", "2"],
+      "Missing value for '-x <x-arg>'"
+    )
+    // Standalone unexpected option.
+    AssertErrorMessage(
+      SomeArgs.self, ["-x", "1", "-z", "2", "-q"],
+      "Unknown option '-q'"
+    )
+  }
+}


### PR DESCRIPTION
When a required option has a short name, longer single-dash arguments can end up incorrectly colliding and causing confusing error messages. This changes the error handling when a short-name option is missing a value to show both the missing-value error _and_ a message about the unrecognized longer/composite option.

Fixes #709.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
