### PR TITLE
Drop availability checks for macOS 10.13

### DIFF
--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -31,9 +31,7 @@ internal struct DumpHelpGenerator {
   func rendered() -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
-    if #available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
-      encoder.outputFormatting.insert(.sortedKeys)
-    }
+    encoder.outputFormatting.insert(.sortedKeys)
     guard let encoded = try? encoder.encode(self.toolInfo) else { return "" }
     return String(data: encoded, encoding: .utf8) ?? ""
   }

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -350,11 +350,7 @@ extension XCTest {
 
     #if !canImport(Darwin) || os(macOS)
     let process = Process()
-    if #available(macOS 10.13, *) {
-      process.executableURL = commandURL
-    } else {
-      process.launchPath = commandURL.path
-    }
+    process.executableURL = commandURL
     process.arguments = arguments
 
     let output = Pipe()
@@ -362,13 +358,9 @@ extension XCTest {
     let error = Pipe()
     process.standardError = error
 
-    if #available(macOS 10.13, *) {
-      guard (try? process.run()) != nil else {
-        XCTFail("Couldn't run command process.", file: file, line: line)
-        return ""
-      }
-    } else {
-      process.launch()
+    guard (try? process.run()) != nil else {
+      XCTFail("Couldn't run command process.", file: file, line: line)
+      return ""
     }
     process.waitUntilExit()
 
@@ -401,13 +393,11 @@ extension XCTest {
     actual: String, expected: String, for type: T.Type,
     file: StaticString = #filePath, line: UInt = #line
   ) throws {
-    if #available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
-      AssertEqualStrings(
-        actual: actual.trimmingCharacters(in: .whitespacesAndNewlines),
-        expected: expected.trimmingCharacters(in: .whitespacesAndNewlines),
-        file: file,
-        line: line)
-    }
+    AssertEqualStrings(
+      actual: actual.trimmingCharacters(in: .whitespacesAndNewlines),
+      expected: expected.trimmingCharacters(in: .whitespacesAndNewlines),
+      file: file,
+      line: line)
 
     let actualJSONData = try XCTUnwrap(
       actual.data(using: .utf8), file: file, line: line)

--- a/Tools/generate-docc-reference/Extensions/Process+SimpleAPI.swift
+++ b/Tools/generate-docc-reference/Extensions/Process+SimpleAPI.swift
@@ -50,14 +50,10 @@ func executeCommand(
   process.standardOutput = output
   process.standardError = FileHandle.nullDevice
 
-  if #available(macOS 10.13, *) {
-    do {
-      try process.run()
-    } catch {
-      throw SubprocessError.failedToLaunch(error: error)
-    }
-  } else {
-    process.launch()
+  do {
+    try process.run()
+  } catch {
+    throw SubprocessError.failedToLaunch(error: error)
   }
   let outputData = output.fileHandleForReading.readDataToEndOfFile()
   process.waitUntilExit()

--- a/Tools/generate-manual/Extensions/Process+SimpleAPI.swift
+++ b/Tools/generate-manual/Extensions/Process+SimpleAPI.swift
@@ -47,11 +47,7 @@ func executeCommand(
   }
 
   let process = Process()
-  if #available(macOS 10.13, *) {
-    process.executableURL = executable
-  } else {
-    process.launchPath = executable.path
-  }
+  process.executableURL = executable
   process.arguments = arguments
 
   let output = Pipe()
@@ -59,14 +55,10 @@ func executeCommand(
   let error = Pipe()
   process.standardError = error
 
-  if #available(macOS 10.13, *) {
-    do {
-      try process.run()
-    } catch {
-      throw SubprocessError.failedToLaunch(error: error)
-    }
-  } else {
-    process.launch()
+  do {
+    try process.run()
+  } catch {
+    throw SubprocessError.failedToLaunch(error: error)
   }
   let outputData = output.fileHandleForReading.readDataToEndOfFile()
   let errorData = error.fileHandleForReading.readDataToEndOfFile()


### PR DESCRIPTION
As @rgoldberg points out, the bump to Swift 5.7 makes these availability checks unnecessary.

Fixes #725.