### PR TITLE
Update ArgumentParser CMakeLists.txt: add Mutex.swift

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(ArgumentParser
   Usage/UsageGenerator.swift
 
   Utilities/CollectionExtensions.swift
+  Utilities/Mutex.swift
   Utilities/Platform.swift
   Utilities/SequenceExtensions.swift
   Utilities/StringExtensions.swift


### PR DESCRIPTION
Recently, `Sources/ArgumentParser/Utilities/Mutex.swift` was created but omitted in `CMakeLists.txt`

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
