### PR TITLE
Improve bash completion script generation

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -365,7 +365,8 @@ extension [ParsableCommand.Type] {
     case .custom:
       // Generate a call back into the command to retrieve a completions list
       return """
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" \(arg.customCompletionCall(self)) "${COMP_WORDS[@]}")" -- "${cur}"))
+        \(addCompletionsFunctionName) -W\
+         "$("${COMP_WORDS[0]}" \(arg.customCompletionCall(self)) "${COMP_WORDS[@]}")"
 
         """
     }

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -335,9 +335,9 @@ extension [ParsableCommand.Type] {
         """
 
     case .file(let extensions):
-      let exts = extensions.map { $0.shellEscapeForSingleQuotedString() }
-        .flatMap { [$0, $0.uppercased()] }
-        .joined(separator: "|")
+      let exts =
+        extensions
+        .map { $0.shellEscapeForSingleQuotedString() }.joined(separator: "|")
       return """
         \(addCompletionsFunctionName) -o plusdirs -fX '!*.@(\(exts))'
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -71,16 +71,12 @@ extension [ParsableCommand.Type] {
                   -*)
                       # ${word} is a flag or an option
                       # If ${word} is an option, mark that the next word to be parsed is an option value
-                      # TODO: handle joined-value options (-o=file.ext), stacked flags (-aBc), legacy long (-long), combos
-                      # TODO: if multi-valued options can exist, support them
                       local option
                       for option in "${options[@]}"; do
                           [[ "${word}" = "${option}" ]] && is_parsing_option_value=true && break
                       done
 
                       # Remove ${word} from ${flags} or ${options} so it isn't offered again
-                      # TODO: handle repeatable flags & options
-                      # TODO: remove equivalent options (-h/--help) & exclusive options (--yes/--no)
                       local not_found=true
                       local -i index
                       for index in "${!flags[@]}"; do
@@ -107,7 +103,6 @@ extension [ParsableCommand.Type] {
               fi
 
               # ${word} is neither a flag, nor an option, nor an option value
-              # TODO: can SAP be configured to require options before positionals?
               if [[ "${positional_number}" -lt "${positional_count}" ]]; then
                   # ${word} is a positional
                   ((positional_number++))
@@ -126,7 +121,6 @@ extension [ParsableCommand.Type] {
 
           unparsed_words=("${unparsed_words[@]}")
 
-          # TODO: offer flags & options after all positionals iff they're allowed after positionals
           if\\
               ! "${was_flag_option_terminator_seen}"\\
               && ! "${is_parsing_option_value}"\\
@@ -237,7 +231,6 @@ extension [ParsableCommand.Type] {
       result += """
 
             # Offer option value completions
-            # TODO: only if ${prev} matches -* & is not an option value
             case "${prev}" in
         \(optionHandlers)
             esac

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -245,26 +245,27 @@ extension [ParsableCommand.Type] {
         """
     }
 
-    if !positionalArguments.allSatisfy({ bashValueCompletion($0).isEmpty }) {
+    let positionalCases =
+      zip(1..., positionalArguments)
+      .compactMap { position, arg in
+        let completion = bashValueCompletion(arg)
+        return completion.isEmpty
+          ? nil
+          : """
+              \(position))
+          \(completion.indentingEachLine(by: 8))\
+                  return
+                  ;;
+
+          """
+      }
+
+    if !positionalCases.isEmpty {
       result += """
 
             # Offer positional completions
             case "${positional_number}" in
-        \(zip(1..., positionalArguments)
-          .compactMap { position, arg in
-            let completion = bashValueCompletion(arg)
-            return completion.isEmpty
-              ? nil
-              : """
-                  \(position))
-              \(completion.indentingEachLine(by: 8))\
-                      return
-                      ;;
-
-              """
-          }
-          .joined()
-        )\
+        \(positionalCases.joined())\
             esac
 
         """

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -63,14 +63,14 @@ struct BashCompletionsGenerator {
     // that other command functions don't need.
     if isRootCommand {
       result += """
-        export \(CompletionShell.shellEnvironmentVariableName)=bash
-        \(CompletionShell.shellVersionEnvironmentVariableName)="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
-        export \(CompletionShell.shellVersionEnvironmentVariableName)
-        cur="${COMP_WORDS[COMP_CWORD]}"
-        prev="${COMP_WORDS[COMP_CWORD-1]}"
-        COMPREPLY=()
+            export \(CompletionShell.shellEnvironmentVariableName)=bash
+            \(CompletionShell.shellVersionEnvironmentVariableName)="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
+            export \(CompletionShell.shellVersionEnvironmentVariableName)
+            cur="${COMP_WORDS[COMP_CWORD]}"
+            prev="${COMP_WORDS[COMP_CWORD-1]}"
+            COMPREPLY=()
 
-        """.indentingEachLine(by: 4)
+        """
     }
 
     // Start by declaring a local var for the top-level completions.
@@ -93,10 +93,11 @@ struct BashCompletionsGenerator {
     let optionHandlers = generateOptionHandlers(commands)
     if !optionHandlers.isEmpty {
       result += """
-        case $prev in
-        \(optionHandlers.indentingEachLine(by: 4))
-        esac
-        """.indentingEachLine(by: 4) + "\n"
+            case $prev in
+        \(optionHandlers)
+            esac
+
+        """
     }
 
     // Build out completions for the subcommands.
@@ -106,13 +107,12 @@ struct BashCompletionsGenerator {
       result += "    case ${COMP_WORDS[\(dollarOne)]} in\n"
       for subcommand in subcommands {
         result += """
-          (\(subcommand._commandName))
-              \(functionName)_\(subcommand._commandName) \(subcommandArgument)
-              return
-              ;;
+              (\(subcommand._commandName))
+                  \(functionName)_\(subcommand._commandName) \(subcommandArgument)
+                  return
+                  ;;
 
           """
-          .indentingEachLine(by: 8)
       }
       result += "    esac\n"
     }
@@ -179,10 +179,10 @@ struct BashCompletionsGenerator {
         if arg.isNullary { return nil }
 
         return """
-          \(arg.bashCompletionWords().joined(separator: "|")))
-          \(arg.bashValueCompletion(commands).indentingEachLine(by: 4))
-              return
-          ;;
+              \(arg.bashCompletionWords().joined(separator: "|")))
+          \(arg.bashValueCompletion(commands).indentingEachLine(by: 8))
+                  return
+                  ;;
           """
       }
       .joined(separator: "\n")
@@ -210,9 +210,9 @@ extension ArgumentDefinition {
     case .file(let extensions) where extensions.isEmpty:
       return """
         if declare -F _filedir >/dev/null; then
-          _filedir
+            _filedir
         else
-          COMPREPLY=($(compgen -f -- "$cur"))
+            COMPREPLY=($(compgen -f -- "$cur"))
         fi
         """
 
@@ -224,22 +224,22 @@ extension ArgumentDefinition {
 
       return """
         if declare -F _filedir >/dev/null; then
-          \(safeExts.map { "_filedir '\($0)'" }.joined(separator:"\n  "))
-          _filedir -d
+            \(safeExts.map { "_filedir '\($0)'" }.joined(separator:"\n    "))
+            _filedir -d
         else
-          COMPREPLY=(
-            \(safeExts.map { "$(compgen -f -X '!*.\($0)' -- \"$cur\")" }.joined(separator: "\n    "))
-            $(compgen -d -- "$cur")
-          )
+            COMPREPLY=(
+                \(safeExts.map { "$(compgen -f -X '!*.\($0)' -- \"$cur\")" }.joined(separator: "\n        "))
+                $(compgen -d -- "$cur")
+            )
         fi
         """
 
     case .directory:
       return """
         if declare -F _filedir >/dev/null; then
-          _filedir -d
+            _filedir -d
         else
-          COMPREPLY=($(compgen -d -- "$cur"))
+            COMPREPLY=($(compgen -d -- "$cur"))
         fi
         """
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -203,12 +203,12 @@ extension [ParsableCommand.Type] {
 
     let positionalArguments = positionalArguments
 
-    let flags = flags
-    let options = options
-    if !flags.isEmpty || !options.isEmpty {
+    let flagCompletions = flagCompletions
+    let optionCompletions = optionCompletions
+    if !flagCompletions.isEmpty || !optionCompletions.isEmpty {
       result += """
-            \(declareTopLevelArray)flags=(\(flags.joined(separator: " ")))
-            \(declareTopLevelArray)options=(\(options.joined(separator: " ")))
+            \(declareTopLevelArray)flags=(\(flagCompletions.joined(separator: " ")))
+            \(declareTopLevelArray)options=(\(optionCompletions.joined(separator: " ")))
             \(offerFlagsOptionsFunctionName) \(positionalArguments.count)
 
         """
@@ -307,8 +307,8 @@ extension [ParsableCommand.Type] {
       """
   }
 
-  /// Returns flags for the last command of the given array.
-  private var flags: [String] {
+  /// Returns flag completions for the last command of the given array.
+  private var flagCompletions: [String] {
     argumentsForHelp(visibility: .default).flatMap {
       switch ($0.kind, $0.update) {
       case (.named, .nullary):
@@ -319,8 +319,8 @@ extension [ParsableCommand.Type] {
     }
   }
 
-  /// Returns options for the last command of the given array.
-  private var options: [String] {
+  /// Returns option completions for the last command of the given array.
+  private var optionCompletions: [String] {
     argumentsForHelp(visibility: .default).flatMap {
       switch ($0.kind, $0.update) {
       case (.named, .unary):

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -368,7 +368,7 @@ extension [ParsableCommand.Type] {
 
     case .shellCommand(let command):
       return """
-        COMPREPLY+=($(\(command)))
+        COMPREPLY+=($(eval '\(command.shellEscapeForSingleQuotedString())'))
 
         """
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -193,7 +193,7 @@ extension ArgumentDefinition {
   /// Returns the different completion names for this argument.
   fileprivate func bashCompletionWords() -> [String] {
     help.visibility.base == .default
-      ? names.map { $0.synopsisString }
+      ? names.map(\.synopsisString)
       : []
   }
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -143,6 +143,16 @@ extension [ParsableCommand.Type] {
           done < <(IFS=$'\\n' compgen "${@}" -- "${cur}")
       }
 
+      \(customCompleteFunctionName)() {
+          if [[ -n "${cur}" || -z ${COMP_WORDS[${COMP_CWORD}]} || "${COMP_LINE:${COMP_POINT}:1}" != ' ' ]]; then
+              local -ar words=("${COMP_WORDS[@]}")
+          else
+              local -ar words=("${COMP_WORDS[@]::${COMP_CWORD}}" '' "${COMP_WORDS[@]:${COMP_CWORD}}")
+          fi
+
+          "${COMP_WORDS[0]}" "${@}" "${words[@]}"
+      }
+
       \(completionFunctions)\
       complete -o filenames -F \(completionFunctionName().shellEscapeForVariableName()) \(commandName)
       """
@@ -366,7 +376,7 @@ extension [ParsableCommand.Type] {
       // Generate a call back into the command to retrieve a completions list
       return """
         \(addCompletionsFunctionName) -W\
-         "$("${COMP_WORDS[0]}" \(arg.customCompletionCall(self)) "${COMP_WORDS[@]}")"
+         "$(\(customCompleteFunctionName) \(arg.customCompletionCall(self)))"
 
         """
     }
@@ -378,6 +388,10 @@ extension [ParsableCommand.Type] {
 
   private var addCompletionsFunctionName: String {
     "_\(prefix(1).completionFunctionName().shellEscapeForVariableName())_add_completions"
+  }
+
+  private var customCompleteFunctionName: String {
+    "_\(prefix(1).completionFunctionName().shellEscapeForVariableName())_custom_complete"
   }
 }
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -82,7 +82,7 @@ struct BashCompletionsGenerator {
 
     result += """
           if [[ $COMP_CWORD == "\(dollarOne)" ]]; then
-              COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+              COMPREPLY=($(compgen -W "$opts" -- "$cur"))
               return
           fi
 
@@ -119,7 +119,7 @@ struct BashCompletionsGenerator {
 
     // Finish off the function.
     result += """
-          COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+          COMPREPLY=($(compgen -W "$opts" -- "$cur"))
       }
 
       """
@@ -212,7 +212,7 @@ extension ArgumentDefinition {
         if declare -F _filedir >/dev/null; then
           _filedir
         else
-          COMPREPLY=( $(compgen -f -- "$cur") )
+          COMPREPLY=($(compgen -f -- "$cur"))
         fi
         """
 
@@ -239,21 +239,21 @@ extension ArgumentDefinition {
         if declare -F _filedir >/dev/null; then
           _filedir -d
         else
-          COMPREPLY=( $(compgen -d -- "$cur") )
+          COMPREPLY=($(compgen -d -- "$cur"))
         fi
         """
 
     case .list(let list):
       return
-        #"COMPREPLY=( $(compgen -W "\#(list.joined(separator: " "))" -- "$cur") )"#
+        #"COMPREPLY=($(compgen -W "\#(list.joined(separator: " "))" -- "$cur"))"#
 
     case .shellCommand(let command):
-      return "COMPREPLY=( $(\(command)) )"
+      return "COMPREPLY=($(\(command)))"
 
     case .custom:
       // Generate a call back into the command to retrieve a completions list
       return
-        #"COMPREPLY=( $(compgen -W "$("${COMP_WORDS[0]}" \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "$cur") )"#
+        #"COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "$cur"))"#
     }
   }
 }

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -170,7 +170,7 @@ extension [ParsableCommand.Type] {
       result += """
             trap "$(shopt -p);$(shopt -po)" RETURN
             shopt -s extglob
-            set +o posix
+            set +o history +o posix
 
             local -xr \(CompletionShell.shellEnvironmentVariableName)=bash
             local -x \(CompletionShell.shellVersionEnvironmentVariableName)

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -246,14 +246,12 @@ extension [ParsableCommand.Type] {
     }
 
     if !positionalArguments.allSatisfy({ bashValueCompletion($0).isEmpty }) {
-      var position = 0
       result += """
 
             # Offer positional completions
             case "${positional_number}" in
-        \(positionalArguments
-          .compactMap { arg in
-            position += 1
+        \(zip(1..., positionalArguments)
+          .compactMap { position, arg in
             let completion = bashValueCompletion(arg)
             return completion.isEmpty
               ? nil

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -351,7 +351,9 @@ extension [ParsableCommand.Type] {
 
     case .list(let list):
       return """
-        COMPREPLY+=($(compgen -W "\(list.joined(separator: " "))" -- "${cur}"))
+        COMPREPLY+=($(compgen -W '\(
+          list.map { $0.shellEscapeForSingleQuotedString() }.joined(separator: " ")
+        )' -- "${cur}"))
 
         """
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -61,9 +61,10 @@ struct BashCompletionsGenerator {
     // that other command functions don't need.
     if isRootCommand {
       result += """
-            export \(CompletionShell.shellEnvironmentVariableName)=bash
-            \(CompletionShell.shellVersionEnvironmentVariableName)="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
-            export \(CompletionShell.shellVersionEnvironmentVariableName)
+            local -xr \(CompletionShell.shellEnvironmentVariableName)=bash
+            local -x \(CompletionShell.shellVersionEnvironmentVariableName)
+            \(CompletionShell.shellVersionEnvironmentVariableName)="$(IFS='.';printf %s "${BASH_VERSINFO[*]}")"
+            local -r \(CompletionShell.shellVersionEnvironmentVariableName)
 
             local -r cur="${2}"
             local -r prev="${3}"

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -351,9 +351,8 @@ extension [ParsableCommand.Type] {
 
     case .list(let list):
       return """
-        COMPREPLY+=($(compgen -W '\(
-          list.map { $0.shellEscapeForSingleQuotedString() }.joined(separator: " ")
-        )' -- "${cur}"))
+        \(addCompletionsFunctionName) -W\
+         '\(list.map { $0.shellEscapeForSingleQuotedString() }.joined(separator: "'$'\\n''"))'
 
         """
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -64,9 +64,10 @@ struct BashCompletionsGenerator {
             export \(CompletionShell.shellEnvironmentVariableName)=bash
             \(CompletionShell.shellVersionEnvironmentVariableName)="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
             export \(CompletionShell.shellVersionEnvironmentVariableName)
-            cur="${COMP_WORDS[COMP_CWORD]}"
-            prev="${COMP_WORDS[COMP_CWORD-1]}"
-            COMPREPLY=()
+
+            local -r cur="${2}"
+            local -r prev="${3}"
+
 
         """
     }

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -368,7 +368,7 @@ extension [ParsableCommand.Type] {
 
     case .shellCommand(let command):
       return """
-        COMPREPLY+=($(eval '\(command.shellEscapeForSingleQuotedString())'))
+        \(addCompletionsFunctionName) -W "$(eval '\(command.shellEscapeForSingleQuotedString())')"
 
         """
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -158,9 +158,7 @@ extension [ParsableCommand.Type] {
     // Include initial setup iff the root command.
     let declareTopLevelArray: String
     if count == 1 {
-      if !subcommands.isEmpty {
-        subcommands.append(HelpCommand.self)
-      }
+      subcommands.addHelpSubcommandIfMissing()
 
       result += """
             local -xr \(CompletionShell.shellEnvironmentVariableName)=bash

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -180,7 +180,7 @@ struct BashCompletionsGenerator {
 
         return """
               \(arg.bashCompletionWords().joined(separator: "|")))
-          \(arg.bashValueCompletion(commands).indentingEachLine(by: 8))
+          \(arg.bashValueCompletion(commands).indentingEachLine(by: 8))\
                   return
                   ;;
           """
@@ -214,6 +214,7 @@ extension ArgumentDefinition {
         else
             COMPREPLY=($(compgen -f -- "${cur}"))
         fi
+
         """
 
     case .file(let extensions):
@@ -232,6 +233,7 @@ extension ArgumentDefinition {
                 $(compgen -d -- "${cur}")
             )
         fi
+
         """
 
     case .directory:
@@ -241,19 +243,27 @@ extension ArgumentDefinition {
         else
             COMPREPLY=($(compgen -d -- "${cur}"))
         fi
+
         """
 
     case .list(let list):
-      return
-        #"COMPREPLY=($(compgen -W "\#(list.joined(separator: " "))" -- "${cur}"))"#
+      return """
+        COMPREPLY=($(compgen -W "\(list.joined(separator: " "))" -- "${cur}"))
+
+        """
 
     case .shellCommand(let command):
-      return "COMPREPLY=($(\(command)))"
+      return """
+        COMPREPLY=($(\(command)))
+
+        """
 
     case .custom:
       // Generate a call back into the command to retrieve a completions list
-      return
-        #"COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" \#(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "${cur}"))"#
+      return """
+        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" \(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "${cur}"))
+
+        """
     }
   }
 }

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -122,7 +122,7 @@ extension [ParsableCommand.Type] {
 
         return """
               \(arg.bashCompletionWords.joined(separator: "|")))
-          \(arg.bashValueCompletion(self).indentingEachLine(by: 8))\
+          \(bashValueCompletion(arg).indentingEachLine(by: 8))\
                   return
                   ;;
           """
@@ -164,23 +164,12 @@ extension [ParsableCommand.Type] {
     return
       result + subcommands.map { (self + [$0]).completionFunctions }.joined()
   }
-}
 
-extension ArgumentDefinition {
-  /// Returns the different completion names for this argument.
-  fileprivate var bashCompletionWords: [String] {
-    help.visibility.base == .default
-      ? names.map(\.synopsisString)
-      : []
-  }
-
-  /// Returns the bash completions that can follow this argument's `--name`.
+  /// Returns the bash completions that can follow the given argument's `--name`.
   ///
   /// Uses bash-completion for file and directory values if available.
-  fileprivate func bashValueCompletion(
-    _ commands: [ParsableCommand.Type]
-  ) -> String {
-    switch completion.kind {
+  private func bashValueCompletion(_ arg: ArgumentDefinition) -> String {
+    switch arg.completion.kind {
     case .default:
       return ""
 
@@ -236,9 +225,18 @@ extension ArgumentDefinition {
     case .custom:
       // Generate a call back into the command to retrieve a completions list
       return """
-        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" \(customCompletionCall(commands)) "${COMP_WORDS[@]}")" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" \(arg.customCompletionCall(self)) "${COMP_WORDS[@]}")" -- "${cur}"))
 
         """
     }
+  }
+}
+
+extension ArgumentDefinition {
+  /// Returns the different completion names for this argument.
+  fileprivate var bashCompletionWords: [String] {
+    help.visibility.base == .default
+      ? names.map(\.synopsisString)
+      : []
   }
 }

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -107,7 +107,7 @@ struct BashCompletionsGenerator {
       result += "    case ${COMP_WORDS[\(dollarOne)]} in\n"
       for subcommand in subcommands {
         result += """
-              (\(subcommand._commandName))
+              \(subcommand._commandName))
                   \(functionName)_\(subcommand._commandName) \(subcommandArgument)
                   return
                   ;;

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -25,7 +25,7 @@ struct BashCompletionsGenerator {
   }
 
   /// Generates a Bash completion function for the last command in the given list.
-  fileprivate static func generateCompletionFunction(
+  private static func generateCompletionFunction(
     _ commands: [ParsableCommand.Type]
   ) -> String {
     guard let type = commands.last else {
@@ -131,7 +131,7 @@ struct BashCompletionsGenerator {
   }
 
   /// Returns the option and flag names that can be top-level completions.
-  fileprivate static func generateArgumentWords(
+  private static func generateArgumentWords(
     _ commands: [ParsableCommand.Type]
   ) -> [String] {
     commands
@@ -142,7 +142,7 @@ struct BashCompletionsGenerator {
   /// Returns additional top-level completions from positional arguments.
   ///
   /// These consist of completions that are defined as `.list` or `.custom`.
-  fileprivate static func generateArgumentCompletions(
+  private static func generateArgumentCompletions(
     _ commands: [ParsableCommand.Type]
   ) -> [String] {
     guard let type = commands.last else { return [] }
@@ -166,7 +166,7 @@ struct BashCompletionsGenerator {
   }
 
   /// Returns the case-matching statements for supplying completions after an option or flag.
-  fileprivate static func generateOptionHandlers(
+  private static func generateOptionHandlers(
     _ commands: [ParsableCommand.Type]
   ) -> String {
     guard let type = commands.last else { return "" }

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -187,7 +187,7 @@ extension [ParsableCommand.Type] {
   /// Include default 'help' subcommand in nonempty subcommand list if & only if
   /// no help subcommand already exists.
   mutating func addHelpSubcommandIfMissing() {
-    if !isEmpty && allSatisfy({ $0._commandName != "help" }) {
+    if !isEmpty && !contains(where: { $0._commandName == "help" }) {
       append(HelpCommand.self)
     }
   }

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -176,6 +176,14 @@ extension ParsableCommand {
 }
 
 extension [ParsableCommand.Type] {
+  var positionalArguments: [ArgumentDefinition] {
+    guard let command = last else {
+      return []
+    }
+    return ArgumentSet(command, visibility: .default, parent: nil)
+      .filter(\.isPositional)
+  }
+
   /// Include default 'help' subcommand in nonempty subcommand list if & only if
   /// no help subcommand already exists.
   mutating func addHelpSubcommandIfMissing() {

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -142,7 +142,7 @@ struct CompletionsGenerator {
     case .zsh:
       return [command].zshCompletionScript
     case .bash:
-      return BashCompletionsGenerator.generateCompletionScript(command)
+      return [command].bashCompletionScript
     case .fish:
       return FishCompletionsGenerator.generateCompletionScript(command)
     default:

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -13,22 +13,22 @@ _math() {
         return
     fi
     case ${COMP_WORDS[1]} in
-        (add)
-            _math_add 2
-            return
-            ;;
-        (multiply)
-            _math_multiply 2
-            return
-            ;;
-        (stats)
-            _math_stats 2
-            return
-            ;;
-        (help)
-            _math_help 2
-            return
-            ;;
+    (add)
+        _math_add 2
+        return
+        ;;
+    (multiply)
+        _math_multiply 2
+        return
+        ;;
+    (stats)
+        _math_stats 2
+        return
+        ;;
+    (help)
+        _math_help 2
+        return
+        ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
@@ -55,18 +55,18 @@ _math_stats() {
         return
     fi
     case ${COMP_WORDS[$1]} in
-        (average)
-            _math_stats_average $(($1+1))
-            return
-            ;;
-        (stdev)
-            _math_stats_stdev $(($1+1))
-            return
-            ;;
-        (quantiles)
-            _math_stats_quantiles $(($1+1))
-            return
-            ;;
+    (average)
+        _math_stats_average $(($1+1))
+        return
+        ;;
+    (stdev)
+        _math_stats_stdev $(($1+1))
+        return
+        ;;
+    (quantiles)
+        _math_stats_quantiles $(($1+1))
+        return
+        ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
@@ -77,9 +77,9 @@ _math_stats_average() {
         return
     fi
     case $prev in
-        --kind)
-            COMPREPLY=($(compgen -W "mean median mode" -- "$cur"))
-            return
+    --kind)
+        COMPREPLY=($(compgen -W "mean median mode" -- "$cur"))
+        return
         ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))
@@ -101,39 +101,39 @@ _math_stats_quantiles() {
         return
     fi
     case $prev in
-        --file)
-            if declare -F _filedir >/dev/null; then
-              _filedir 'txt'
-              _filedir 'md'
-              _filedir 'TXT'
-              _filedir 'MD'
-              _filedir -d
-            else
-              COMPREPLY=(
+    --file)
+        if declare -F _filedir >/dev/null; then
+            _filedir 'txt'
+            _filedir 'md'
+            _filedir 'TXT'
+            _filedir 'MD'
+            _filedir -d
+        else
+            COMPREPLY=(
                 $(compgen -f -X '!*.txt' -- "$cur")
                 $(compgen -f -X '!*.md' -- "$cur")
                 $(compgen -f -X '!*.TXT' -- "$cur")
                 $(compgen -f -X '!*.MD' -- "$cur")
                 $(compgen -d -- "$cur")
-              )
-            fi
-            return
+            )
+        fi
+        return
         ;;
-        --directory)
-            if declare -F _filedir >/dev/null; then
-              _filedir -d
-            else
-              COMPREPLY=($(compgen -d -- "$cur"))
-            fi
-            return
+    --directory)
+        if declare -F _filedir >/dev/null; then
+            _filedir -d
+        else
+            COMPREPLY=($(compgen -d -- "$cur"))
+        fi
+        return
         ;;
-        --shell)
-            COMPREPLY=($(head -100 /usr/share/dict/words | tail -50))
-            return
+    --shell)
+        COMPREPLY=($(head -100 /usr/share/dict/words | tail -50))
+        return
         ;;
-        --custom)
-            COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur"))
-            return
+    --custom)
+        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur"))
+        return
         ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -122,6 +122,16 @@ __math_add_completions() {
     done < <(IFS=$'\n' compgen "${@}" -- "${cur}")
 }
 
+__math_custom_complete() {
+    if [[ -n "${cur}" || -z ${COMP_WORDS[${COMP_CWORD}]} || "${COMP_LINE:${COMP_POINT}:1}" != ' ' ]]; then
+        local -ar words=("${COMP_WORDS[@]}")
+    else
+        local -ar words=("${COMP_WORDS[@]::${COMP_CWORD}}" '' "${COMP_WORDS[@]:${COMP_CWORD}}")
+    fi
+
+    "${COMP_WORDS[0]}" "${@}" "${words[@]}"
+}
+
 _math() {
     trap "$(shopt -p);$(shopt -po)" RETURN
     shopt -s extglob
@@ -233,7 +243,7 @@ _math_stats_quantiles() {
         return
         ;;
     --custom)
-        __math_add_completions -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")"
+        __math_add_completions -W "$(__math_custom_complete ---completion stats quantiles -- --custom)"
         return
         ;;
     esac
@@ -245,7 +255,7 @@ _math_stats_quantiles() {
         return
         ;;
     2)
-        __math_add_completions -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
+        __math_add_completions -W "$(__math_custom_complete ---completion stats quantiles -- customArg)"
         return
         ;;
     esac

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -125,7 +125,7 @@ __math_add_completions() {
 _math() {
     trap "$(shopt -p);$(shopt -po)" RETURN
     shopt -s extglob
-    set +o posix
+    set +o history +o posix
 
     local -xr SAP_SHELL=bash
     local -x SAP_SHELL_VERSION

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 _math() {
-    export SAP_SHELL=bash
-    SAP_SHELL_VERSION="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
-    export SAP_SHELL_VERSION
+    local -xr SAP_SHELL=bash
+    local -x SAP_SHELL_VERSION
+    SAP_SHELL_VERSION="$(IFS='.';printf %s "${BASH_VERSINFO[*]}")"
+    local -r SAP_SHELL_VERSION
 
     local -r cur="${2}"
     local -r prev="${3}"

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -1,5 +1,120 @@
 #!/bin/bash
 
+# positional arguments:
+#
+# - 1: the current (sub)command's count of positional arguments
+#
+# required variables:
+#
+# - flags: the flags that the current (sub)command can accept
+# - options: the options that the current (sub)command can accept
+# - positional_number: value ignored
+# - unparsed_words: unparsed words from the current command line
+#
+# modified variables:
+#
+# - flags: remove flags for this (sub)command that are already on the command line
+# - options: remove options for this (sub)command that are already on the command line
+# - positional_number: set to the current positional number
+# - unparsed_words: remove all flags, options, and option values for this (sub)command
+__math_offer_flags_options() {
+    local -ir positional_count="${1}"
+    positional_number=0
+
+    local was_flag_option_terminator_seen=false
+    local is_parsing_option_value=false
+
+    local -ar unparsed_word_indices=("${!unparsed_words[@]}")
+    local -i word_index
+    for word_index in "${unparsed_word_indices[@]}"; do
+        if "${is_parsing_option_value}"; then
+            # This word is an option value:
+            # Reset marker for next word iff not currently the last word
+            [[ "${word_index}" -ne "${unparsed_word_indices[${#unparsed_word_indices[@]} - 1]}" ]] && is_parsing_option_value=false
+            unset "unparsed_words[${word_index}]"
+            # Do not process this word as a flag or an option
+            continue
+        fi
+
+        local word="${unparsed_words["${word_index}"]}"
+        if ! "${was_flag_option_terminator_seen}"; then
+            case "${word}" in
+            --)
+                unset "unparsed_words[${word_index}]"
+                # by itself -- is a flag/option terminator, but if it is the last word, it is the start of a completion
+                if [[ "${word_index}" -ne "${unparsed_word_indices[${#unparsed_word_indices[@]} - 1]}" ]]; then
+                    was_flag_option_terminator_seen=true
+                fi
+                continue
+                ;;
+            -*)
+                # ${word} is a flag or an option
+                # If ${word} is an option, mark that the next word to be parsed is an option value
+                # TODO: handle joined-value options (-o=file.ext), stacked flags (-aBc), legacy long (-long), combos
+                # TODO: if multi-valued options can exist, support them
+                local option
+                for option in "${options[@]}"; do
+                    [[ "${word}" = "${option}" ]] && is_parsing_option_value=true && break
+                done
+
+                # Remove ${word} from ${flags} or ${options} so it isn't offered again
+                # TODO: handle repeatable flags & options
+                # TODO: remove equivalent options (-h/--help) & exclusive options (--yes/--no)
+                local not_found=true
+                local -i index
+                for index in "${!flags[@]}"; do
+                    if [[ "${flags[${index}]}" = "${word}" ]]; then
+                        unset "flags[${index}]"
+                        flags=("${flags[@]}")
+                        not_found=false
+                        break
+                    fi
+                done
+                if "${not_found}"; then
+                    for index in "${!options[@]}"; do
+                        if [[ "${options[${index}]}" = "${word}" ]]; then
+                            unset "options[${index}]"
+                            options=("${options[@]}")
+                            break
+                        fi
+                    done
+                fi
+                unset "unparsed_words[${word_index}]"
+                continue
+                ;;
+            esac
+        fi
+
+        # ${word} is neither a flag, nor an option, nor an option value
+        # TODO: can SAP be configured to require options before positionals?
+        if [[ "${positional_number}" -lt "${positional_count}" ]]; then
+            # ${word} is a positional
+            ((positional_number++))
+            unset "unparsed_words[${word_index}]"
+        else
+            if [[ -z "${word}" ]]; then
+                # Could be completing a flag, option, or subcommand
+                positional_number=-1
+            else
+                # ${word} is a subcommand or invalid, so stop processing this (sub)command
+                positional_number=-2
+            fi
+            break
+        fi
+    done
+
+    unparsed_words=("${unparsed_words[@]}")
+
+    # TODO: offer flags & options after all positionals iff they're allowed after positionals
+    if\
+        ! "${was_flag_option_terminator_seen}"\
+        && ! "${is_parsing_option_value}"\
+        && [[ ("${cur}" = -* && "${positional_number}" -ge 0) || "${positional_number}" -eq -1 ]]
+    then
+        COMPREPLY+=($(compgen -W "${flags[*]} ${options[*]}" -- "${cur}"))
+    fi
+}
+
 _math() {
     local -xr SAP_SHELL=bash
     local -x SAP_SHELL_VERSION
@@ -9,99 +124,90 @@ _math() {
     local -r cur="${2}"
     local -r prev="${3}"
 
-    opts="--version -h --help add multiply stats help"
-    if [[ "${COMP_CWORD}" == "1" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    case "${COMP_WORDS[1]}" in
-    add)
-        _math_add 2
-        return
+    local -i positional_number
+    local -a unparsed_words=("${COMP_WORDS[@]:1:${COMP_CWORD}}")
+
+    local -a flags=(--version -h --help)
+    local -a options=()
+    __math_offer_flags_options 0
+
+    # Offer subcommand / subcommand argument completions
+    local -r subcommand="${unparsed_words[0]}"
+    unset 'unparsed_words[0]'
+    unparsed_words=("${unparsed_words[@]}")
+    case "${subcommand}" in
+    add|multiply|stats|help)
+        # Offer subcommand argument completions
+        "_math_${subcommand}"
         ;;
-    multiply)
-        _math_multiply 2
-        return
-        ;;
-    stats)
-        _math_stats 2
-        return
-        ;;
-    help)
-        _math_help 2
-        return
+    *)
+        # Offer subcommand completions
+        COMPREPLY+=($(compgen -W 'add multiply stats help' -- "${cur}"))
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
+
 _math_add() {
-    opts="--hex-output -x --version -h --help"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    flags=(--hex-output -x --version -h --help)
+    options=()
+    __math_offer_flags_options 1
 }
+
 _math_multiply() {
-    opts="--hex-output -x --version -h --help"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    flags=(--hex-output -x --version -h --help)
+    options=()
+    __math_offer_flags_options 1
 }
+
 _math_stats() {
-    opts="--version -h --help average stdev quantiles"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    case "${COMP_WORDS[${1}]}" in
-    average)
-        _math_stats_average $((${1}+1))
-        return
+    flags=(--version -h --help)
+    options=()
+    __math_offer_flags_options 0
+
+    # Offer subcommand / subcommand argument completions
+    local -r subcommand="${unparsed_words[0]}"
+    unset 'unparsed_words[0]'
+    unparsed_words=("${unparsed_words[@]}")
+    case "${subcommand}" in
+    average|stdev|quantiles)
+        # Offer subcommand argument completions
+        "_math_stats_${subcommand}"
         ;;
-    stdev)
-        _math_stats_stdev $((${1}+1))
-        return
-        ;;
-    quantiles)
-        _math_stats_quantiles $((${1}+1))
-        return
+    *)
+        # Offer subcommand completions
+        COMPREPLY+=($(compgen -W 'average stdev quantiles' -- "${cur}"))
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
+
 _math_stats_average() {
-    opts="--kind --version -h --help"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
+    flags=(--version -h --help)
+    options=(--kind)
+    __math_offer_flags_options 1
+
+    # Offer option value completions
+    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --kind)
-        COMPREPLY=($(compgen -W "mean median mode" -- "${cur}"))
+        COMPREPLY+=($(compgen -W "mean median mode" -- "${cur}"))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
+
 _math_stats_stdev() {
-    opts="--version -h --help"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    flags=(--version -h --help)
+    options=()
+    __math_offer_flags_options 1
 }
+
 _math_stats_quantiles() {
-    opts="--file --directory --shell --custom --version -h --help"
-    opts="${opts} alphabet alligator branch braggart"
-    opts="${opts} $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
+    flags=(--version -h --help)
+    options=(--file --directory --shell --custom)
+    __math_offer_flags_options 3
+
+    # Offer option value completions
+    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --file)
         if declare -F _filedir >/dev/null; then
@@ -130,24 +236,32 @@ _math_stats_quantiles() {
         return
         ;;
     --shell)
-        COMPREPLY=($(head -100 /usr/share/dict/words | tail -50))
+        COMPREPLY+=($(head -100 /usr/share/dict/words | tail -50))
         return
         ;;
     --custom)
-        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "${cur}"))
+        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "${cur}"))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-}
-_math_help() {
-    opts="--version"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+
+    # Offer positional completions
+    case "${positional_number}" in
+    1)
+        COMPREPLY+=($(compgen -W "alphabet alligator branch braggart" -- "${cur}"))
         return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+        ;;
+    2)
+        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")" -- "${cur}"))
+        return
+        ;;
+    esac
 }
 
+_math_help() {
+    flags=(--version)
+    options=()
+    __math_offer_flags_options 1
+}
 
 complete -F _math math

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -221,7 +221,7 @@ _math_stats_quantiles() {
     # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --file)
-        __math_add_completions -o plusdirs -fX '!*.@(txt|TXT|md|MD)'
+        __math_add_completions -o plusdirs -fX '!*.@(txt|md)'
         return
         ;;
     --directory)

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -239,7 +239,7 @@ _math_stats_quantiles() {
         return
         ;;
     --shell)
-        COMPREPLY+=($(head -100 /usr/share/dict/words | tail -50))
+        COMPREPLY+=($(eval 'head -100 /usr/share/dict/words | tail -50'))
         return
         ;;
     --custom)

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -9,7 +9,7 @@ _math() {
     COMPREPLY=()
     opts="--version -h --help add multiply stats help"
     if [[ $COMP_CWORD == "1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case ${COMP_WORDS[1]} in
@@ -30,28 +30,28 @@ _math() {
             return
             ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_add() {
     opts="--hex-output -x --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_multiply() {
     opts="--hex-output -x --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_stats() {
     opts="--version -h --help average stdev quantiles"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case ${COMP_WORDS[$1]} in
@@ -68,36 +68,36 @@ _math_stats() {
             return
             ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_stats_average() {
     opts="--kind --version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case $prev in
         --kind)
-            COMPREPLY=( $(compgen -W "mean median mode" -- "$cur") )
+            COMPREPLY=($(compgen -W "mean median mode" -- "$cur"))
             return
         ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_stats_stdev() {
     opts="--version -h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_stats_quantiles() {
     opts="--file --directory --shell --custom --version -h --help"
     opts="$opts alphabet alligator branch braggart"
     opts="$opts $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case $prev in
@@ -123,28 +123,28 @@ _math_stats_quantiles() {
             if declare -F _filedir >/dev/null; then
               _filedir -d
             else
-              COMPREPLY=( $(compgen -d -- "$cur") )
+              COMPREPLY=($(compgen -d -- "$cur"))
             fi
             return
         ;;
         --shell)
-            COMPREPLY=( $(head -100 /usr/share/dict/words | tail -50) )
+            COMPREPLY=($(head -100 /usr/share/dict/words | tail -50))
             return
         ;;
         --custom)
-            COMPREPLY=( $(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur") )
+            COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur"))
             return
         ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _math_help() {
     opts="--version"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 
 

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -8,11 +8,11 @@ _math() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     COMPREPLY=()
     opts="--version -h --help add multiply stats help"
-    if [[ $COMP_CWORD == "1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "1" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case ${COMP_WORDS[1]} in
+    case "${COMP_WORDS[1]}" in
     add)
         _math_add 2
         return
@@ -30,77 +30,77 @@ _math() {
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_add() {
     opts="--hex-output -x --version -h --help"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_multiply() {
     opts="--hex-output -x --version -h --help"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_stats() {
     opts="--version -h --help average stdev quantiles"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case ${COMP_WORDS[$1]} in
+    case "${COMP_WORDS[${1}]}" in
     average)
-        _math_stats_average $(($1+1))
+        _math_stats_average $((${1}+1))
         return
         ;;
     stdev)
-        _math_stats_stdev $(($1+1))
+        _math_stats_stdev $((${1}+1))
         return
         ;;
     quantiles)
-        _math_stats_quantiles $(($1+1))
+        _math_stats_quantiles $((${1}+1))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_stats_average() {
     opts="--kind --version -h --help"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case $prev in
+    case "${prev}" in
     --kind)
-        COMPREPLY=($(compgen -W "mean median mode" -- "$cur"))
+        COMPREPLY=($(compgen -W "mean median mode" -- "${cur}"))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_stats_stdev() {
     opts="--version -h --help"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_stats_quantiles() {
     opts="--file --directory --shell --custom --version -h --help"
-    opts="$opts alphabet alligator branch braggart"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    opts="${opts} alphabet alligator branch braggart"
+    opts="${opts} $("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case $prev in
+    case "${prev}" in
     --file)
         if declare -F _filedir >/dev/null; then
             _filedir 'txt'
@@ -110,11 +110,11 @@ _math_stats_quantiles() {
             _filedir -d
         else
             COMPREPLY=(
-                $(compgen -f -X '!*.txt' -- "$cur")
-                $(compgen -f -X '!*.md' -- "$cur")
-                $(compgen -f -X '!*.TXT' -- "$cur")
-                $(compgen -f -X '!*.MD' -- "$cur")
-                $(compgen -d -- "$cur")
+                $(compgen -f -X '!*.txt' -- "${cur}")
+                $(compgen -f -X '!*.md' -- "${cur}")
+                $(compgen -f -X '!*.TXT' -- "${cur}")
+                $(compgen -f -X '!*.MD' -- "${cur}")
+                $(compgen -d -- "${cur}")
             )
         fi
         return
@@ -123,7 +123,7 @@ _math_stats_quantiles() {
         if declare -F _filedir >/dev/null; then
             _filedir -d
         else
-            COMPREPLY=($(compgen -d -- "$cur"))
+            COMPREPLY=($(compgen -d -- "${cur}"))
         fi
         return
         ;;
@@ -132,19 +132,19 @@ _math_stats_quantiles() {
         return
         ;;
     --custom)
-        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "$cur"))
+        COMPREPLY=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "${cur}"))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _math_help() {
     opts="--version"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 
 

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -4,9 +4,10 @@ _math() {
     export SAP_SHELL=bash
     SAP_SHELL_VERSION="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
     export SAP_SHELL_VERSION
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    COMPREPLY=()
+
+    local -r cur="${2}"
+    local -r prev="${3}"
+
     opts="--version -h --help add multiply stats help"
     if [[ "${COMP_CWORD}" == "1" ]]; then
         COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -13,19 +13,19 @@ _math() {
         return
     fi
     case ${COMP_WORDS[1]} in
-    (add)
+    add)
         _math_add 2
         return
         ;;
-    (multiply)
+    multiply)
         _math_multiply 2
         return
         ;;
-    (stats)
+    stats)
         _math_stats 2
         return
         ;;
-    (help)
+    help)
         _math_help 2
         return
         ;;
@@ -55,15 +55,15 @@ _math_stats() {
         return
     fi
     case ${COMP_WORDS[$1]} in
-    (average)
+    average)
         _math_stats_average $(($1+1))
         return
         ;;
-    (stdev)
+    stdev)
         _math_stats_stdev $(($1+1))
         return
         ;;
-    (quantiles)
+    quantiles)
         _math_stats_quantiles $(($1+1))
         return
         ;;

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -200,7 +200,7 @@ _math_stats_average() {
     # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --kind)
-        COMPREPLY+=($(compgen -W 'mean median mode' -- "${cur}"))
+        __math_add_completions -W 'mean'$'\n''median'$'\n''mode'
         return
         ;;
     esac
@@ -241,7 +241,7 @@ _math_stats_quantiles() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        COMPREPLY+=($(compgen -W 'alphabet alligator branch braggart' -- "${cur}"))
+        __math_add_completions -W 'alphabet'$'\n''alligator'$'\n''branch'$'\n''braggart'
         return
         ;;
     2)

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -233,7 +233,7 @@ _math_stats_quantiles() {
         return
         ;;
     --custom)
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")" -- "${cur}"))
+        __math_add_completions -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- --custom "${COMP_WORDS[@]}")"
         return
         ;;
     esac
@@ -245,7 +245,7 @@ _math_stats_quantiles() {
         return
         ;;
     2)
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")" -- "${cur}"))
+        __math_add_completions -W "$("${COMP_WORDS[0]}" ---completion stats quantiles -- customArg "${COMP_WORDS[@]}")"
         return
         ;;
     esac

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -200,7 +200,7 @@ _math_stats_average() {
     # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --kind)
-        COMPREPLY+=($(compgen -W "mean median mode" -- "${cur}"))
+        COMPREPLY+=($(compgen -W 'mean median mode' -- "${cur}"))
         return
         ;;
     esac
@@ -241,7 +241,7 @@ _math_stats_quantiles() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        COMPREPLY+=($(compgen -W "alphabet alligator branch braggart" -- "${cur}"))
+        COMPREPLY+=($(compgen -W 'alphabet alligator branch braggart' -- "${cur}"))
         return
         ;;
     2)

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -239,7 +239,7 @@ _math_stats_quantiles() {
         return
         ;;
     --shell)
-        COMPREPLY+=($(eval 'head -100 /usr/share/dict/words | tail -50'))
+        __math_add_completions -W "$(eval 'head -100 /usr/share/dict/words | tail -50')"
         return
         ;;
     --custom)

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -50,16 +50,12 @@ __math_offer_flags_options() {
             -*)
                 # ${word} is a flag or an option
                 # If ${word} is an option, mark that the next word to be parsed is an option value
-                # TODO: handle joined-value options (-o=file.ext), stacked flags (-aBc), legacy long (-long), combos
-                # TODO: if multi-valued options can exist, support them
                 local option
                 for option in "${options[@]}"; do
                     [[ "${word}" = "${option}" ]] && is_parsing_option_value=true && break
                 done
 
                 # Remove ${word} from ${flags} or ${options} so it isn't offered again
-                # TODO: handle repeatable flags & options
-                # TODO: remove equivalent options (-h/--help) & exclusive options (--yes/--no)
                 local not_found=true
                 local -i index
                 for index in "${!flags[@]}"; do
@@ -86,7 +82,6 @@ __math_offer_flags_options() {
         fi
 
         # ${word} is neither a flag, nor an option, nor an option value
-        # TODO: can SAP be configured to require options before positionals?
         if [[ "${positional_number}" -lt "${positional_count}" ]]; then
             # ${word} is a positional
             ((positional_number++))
@@ -105,7 +100,6 @@ __math_offer_flags_options() {
 
     unparsed_words=("${unparsed_words[@]}")
 
-    # TODO: offer flags & options after all positionals iff they're allowed after positionals
     if\
         ! "${was_flag_option_terminator_seen}"\
         && ! "${is_parsing_option_value}"\
@@ -207,7 +201,6 @@ _math_stats_average() {
     __math_offer_flags_options 1
 
     # Offer option value completions
-    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --kind)
         __math_add_completions -W 'mean'$'\n''median'$'\n''mode'
@@ -228,7 +221,6 @@ _math_stats_quantiles() {
     __math_offer_flags_options 3
 
     # Offer option value completions
-    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --file)
         __math_add_completions -o plusdirs -fX '!*.@(txt|md)'

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -149,11 +149,11 @@ _base_test() {
         return
         ;;
     --kind)
-        COMPREPLY+=($(compgen -W "one two custom-three" -- "${cur}"))
+        COMPREPLY+=($(compgen -W 'one two custom-three' -- "${cur}"))
         return
         ;;
     --other-kind)
-        COMPREPLY+=($(compgen -W "b1_bash b2_bash b3_bash" -- "${cur}"))
+        COMPREPLY+=($(compgen -W 'b1_bash b2_bash b3_bash' -- "${cur}"))
         return
         ;;
     --path1)
@@ -165,7 +165,7 @@ _base_test() {
         return
         ;;
     --path3)
-        COMPREPLY+=($(compgen -W "c1_bash c2_bash c3_bash" -- "${cur}"))
+        COMPREPLY+=($(compgen -W 'c1_bash c2_bash c3_bash' -- "${cur}"))
         return
         ;;
     --rep1)

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -149,11 +149,11 @@ _base_test() {
         return
         ;;
     --kind)
-        COMPREPLY+=($(compgen -W 'one two custom-three' -- "${cur}"))
+        __base_test_add_completions -W 'one'$'\n''two'$'\n''custom-three'
         return
         ;;
     --other-kind)
-        COMPREPLY+=($(compgen -W 'b1_bash b2_bash b3_bash' -- "${cur}"))
+        __base_test_add_completions -W 'b1_bash'$'\n''b2_bash'$'\n''b3_bash'
         return
         ;;
     --path1)
@@ -165,7 +165,7 @@ _base_test() {
         return
         ;;
     --path3)
-        COMPREPLY+=($(compgen -W 'c1_bash c2_bash c3_bash' -- "${cur}"))
+        __base_test_add_completions -W 'c1_bash'$'\n''c2_bash'$'\n''c3_bash'
         return
         ;;
     --rep1)

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -115,7 +115,18 @@ __base_test_offer_flags_options() {
     fi
 }
 
+__base_test_add_completions() {
+    local completion
+    while IFS='' read -r completion; do
+        COMPREPLY+=("${completion}")
+    done < <(IFS=$'\n' compgen "${@}" -- "${cur}")
+}
+
 _base_test() {
+    trap "$(shopt -p);$(shopt -po)" RETURN
+    shopt -s extglob
+    set +o posix
+
     local -xr SAP_SHELL=bash
     local -x SAP_SHELL_VERSION
     SAP_SHELL_VERSION="$(IFS='.';printf %s "${BASH_VERSINFO[*]}")"
@@ -146,19 +157,11 @@ _base_test() {
         return
         ;;
     --path1)
-        if declare -F _filedir >/dev/null; then
-            _filedir
-        else
-            COMPREPLY=($(compgen -f -- "${cur}"))
-        fi
+        __base_test_add_completions -f
         return
         ;;
     --path2)
-        if declare -F _filedir >/dev/null; then
-            _filedir
-        else
-            COMPREPLY=($(compgen -f -- "${cur}"))
-        fi
+        __base_test_add_completions -f
         return
         ;;
     --path3)
@@ -233,4 +236,4 @@ _base_test_help() {
     :
 }
 
-complete -F _base_test base-test
+complete -o filenames -F _base_test base-test

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -8,30 +8,30 @@ _base_test() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     COMPREPLY=()
     opts="--name --kind --other-kind --path1 --path2 --path3 --one --two --three --kind-counter --rep1 -r --rep2 -h --help sub-command escaped-command help"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
-    if [[ $COMP_CWORD == "1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
+    opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
+    if [[ "${COMP_CWORD}" == "1" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case $prev in
+    case "${prev}" in
     --name)
 
         return
         ;;
     --kind)
-        COMPREPLY=($(compgen -W "one two custom-three" -- "$cur"))
+        COMPREPLY=($(compgen -W "one two custom-three" -- "${cur}"))
         return
         ;;
     --other-kind)
-        COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "$cur"))
+        COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "${cur}"))
         return
         ;;
     --path1)
         if declare -F _filedir >/dev/null; then
             _filedir
         else
-            COMPREPLY=($(compgen -f -- "$cur"))
+            COMPREPLY=($(compgen -f -- "${cur}"))
         fi
         return
         ;;
@@ -39,12 +39,12 @@ _base_test() {
         if declare -F _filedir >/dev/null; then
             _filedir
         else
-            COMPREPLY=($(compgen -f -- "$cur"))
+            COMPREPLY=($(compgen -f -- "${cur}"))
         fi
         return
         ;;
     --path3)
-        COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "$cur"))
+        COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "${cur}"))
         return
         ;;
     --rep1)
@@ -56,7 +56,7 @@ _base_test() {
         return
         ;;
     esac
-    case ${COMP_WORDS[1]} in
+    case "${COMP_WORDS[1]}" in
     sub-command)
         _base_test_sub-command 2
         return
@@ -70,38 +70,38 @@ _base_test() {
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _base_test_sub_command() {
     opts="-h --help"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _base_test_escaped_command() {
     opts="--one -h --help"
-    opts="$opts $("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    opts="${opts} $("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    case $prev in
+    case "${prev}" in
     --one)
 
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 _base_test_help() {
     opts=""
-    if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    if [[ "${COMP_CWORD}" == "${1}" ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
         return
     fi
-    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 
 

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -1,5 +1,120 @@
 #!/bin/bash
 
+# positional arguments:
+#
+# - 1: the current (sub)command's count of positional arguments
+#
+# required variables:
+#
+# - flags: the flags that the current (sub)command can accept
+# - options: the options that the current (sub)command can accept
+# - positional_number: value ignored
+# - unparsed_words: unparsed words from the current command line
+#
+# modified variables:
+#
+# - flags: remove flags for this (sub)command that are already on the command line
+# - options: remove options for this (sub)command that are already on the command line
+# - positional_number: set to the current positional number
+# - unparsed_words: remove all flags, options, and option values for this (sub)command
+__base_test_offer_flags_options() {
+    local -ir positional_count="${1}"
+    positional_number=0
+
+    local was_flag_option_terminator_seen=false
+    local is_parsing_option_value=false
+
+    local -ar unparsed_word_indices=("${!unparsed_words[@]}")
+    local -i word_index
+    for word_index in "${unparsed_word_indices[@]}"; do
+        if "${is_parsing_option_value}"; then
+            # This word is an option value:
+            # Reset marker for next word iff not currently the last word
+            [[ "${word_index}" -ne "${unparsed_word_indices[${#unparsed_word_indices[@]} - 1]}" ]] && is_parsing_option_value=false
+            unset "unparsed_words[${word_index}]"
+            # Do not process this word as a flag or an option
+            continue
+        fi
+
+        local word="${unparsed_words["${word_index}"]}"
+        if ! "${was_flag_option_terminator_seen}"; then
+            case "${word}" in
+            --)
+                unset "unparsed_words[${word_index}]"
+                # by itself -- is a flag/option terminator, but if it is the last word, it is the start of a completion
+                if [[ "${word_index}" -ne "${unparsed_word_indices[${#unparsed_word_indices[@]} - 1]}" ]]; then
+                    was_flag_option_terminator_seen=true
+                fi
+                continue
+                ;;
+            -*)
+                # ${word} is a flag or an option
+                # If ${word} is an option, mark that the next word to be parsed is an option value
+                # TODO: handle joined-value options (-o=file.ext), stacked flags (-aBc), legacy long (-long), combos
+                # TODO: if multi-valued options can exist, support them
+                local option
+                for option in "${options[@]}"; do
+                    [[ "${word}" = "${option}" ]] && is_parsing_option_value=true && break
+                done
+
+                # Remove ${word} from ${flags} or ${options} so it isn't offered again
+                # TODO: handle repeatable flags & options
+                # TODO: remove equivalent options (-h/--help) & exclusive options (--yes/--no)
+                local not_found=true
+                local -i index
+                for index in "${!flags[@]}"; do
+                    if [[ "${flags[${index}]}" = "${word}" ]]; then
+                        unset "flags[${index}]"
+                        flags=("${flags[@]}")
+                        not_found=false
+                        break
+                    fi
+                done
+                if "${not_found}"; then
+                    for index in "${!options[@]}"; do
+                        if [[ "${options[${index}]}" = "${word}" ]]; then
+                            unset "options[${index}]"
+                            options=("${options[@]}")
+                            break
+                        fi
+                    done
+                fi
+                unset "unparsed_words[${word_index}]"
+                continue
+                ;;
+            esac
+        fi
+
+        # ${word} is neither a flag, nor an option, nor an option value
+        # TODO: can SAP be configured to require options before positionals?
+        if [[ "${positional_number}" -lt "${positional_count}" ]]; then
+            # ${word} is a positional
+            ((positional_number++))
+            unset "unparsed_words[${word_index}]"
+        else
+            if [[ -z "${word}" ]]; then
+                # Could be completing a flag, option, or subcommand
+                positional_number=-1
+            else
+                # ${word} is a subcommand or invalid, so stop processing this (sub)command
+                positional_number=-2
+            fi
+            break
+        fi
+    done
+
+    unparsed_words=("${unparsed_words[@]}")
+
+    # TODO: offer flags & options after all positionals iff they're allowed after positionals
+    if\
+        ! "${was_flag_option_terminator_seen}"\
+        && ! "${is_parsing_option_value}"\
+        && [[ ("${cur}" = -* && "${positional_number}" -ge 0) || "${positional_number}" -eq -1 ]]
+    then
+        COMPREPLY+=($(compgen -W "${flags[*]} ${options[*]}" -- "${cur}"))
+    fi
+}
+
 _base_test() {
     local -xr SAP_SHELL=bash
     local -x SAP_SHELL_VERSION
@@ -9,23 +124,25 @@ _base_test() {
     local -r cur="${2}"
     local -r prev="${3}"
 
-    opts="--name --kind --other-kind --path1 --path2 --path3 --one --two --three --kind-counter --rep1 -r --rep2 -h --help sub-command escaped-command help"
-    opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
-    opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
-    if [[ "${COMP_CWORD}" == "1" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
+    local -i positional_number
+    local -a unparsed_words=("${COMP_WORDS[@]:1:${COMP_CWORD}}")
+
+    local -a flags=(--one --two --three --kind-counter -h --help)
+    local -a options=(--name --kind --other-kind --path1 --path2 --path3 --rep1 -r --rep2)
+    __base_test_offer_flags_options 2
+
+    # Offer option value completions
+    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --name)
         return
         ;;
     --kind)
-        COMPREPLY=($(compgen -W "one two custom-three" -- "${cur}"))
+        COMPREPLY+=($(compgen -W "one two custom-three" -- "${cur}"))
         return
         ;;
     --other-kind)
-        COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "${cur}"))
+        COMPREPLY+=($(compgen -W "b1_bash b2_bash b3_bash" -- "${cur}"))
         return
         ;;
     --path1)
@@ -45,7 +162,7 @@ _base_test() {
         return
         ;;
     --path3)
-        COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "${cur}"))
+        COMPREPLY+=($(compgen -W "c1_bash c2_bash c3_bash" -- "${cur}"))
         return
         ;;
     --rep1)
@@ -55,52 +172,65 @@ _base_test() {
         return
         ;;
     esac
-    case "${COMP_WORDS[1]}" in
-    sub-command)
-        _base_test_sub-command 2
+
+    # Offer positional completions
+    case "${positional_number}" in
+    1)
+        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")" -- "${cur}"))
         return
         ;;
-    escaped-command)
-        _base_test_escaped-command 2
-        return
-        ;;
-    help)
-        _base_test_help 2
+    2)
+        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")" -- "${cur}"))
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+
+    # Offer subcommand / subcommand argument completions
+    local -r subcommand="${unparsed_words[0]}"
+    unset 'unparsed_words[0]'
+    unparsed_words=("${unparsed_words[@]}")
+    case "${subcommand}" in
+    sub-command|escaped-command|help)
+        # Offer subcommand argument completions
+        "_base_test_${subcommand}"
+        ;;
+    *)
+        # Offer subcommand completions
+        COMPREPLY+=($(compgen -W 'sub-command escaped-command help' -- "${cur}"))
+        ;;
+    esac
 }
+
 _base_test_sub_command() {
-    opts="-h --help"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+    flags=(-h --help)
+    options=()
+    __base_test_offer_flags_options 0
 }
+
 _base_test_escaped_command() {
-    opts="--one -h --help"
-    opts="${opts} $("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-        return
-    fi
+    flags=(-h --help)
+    options=(--one)
+    __base_test_offer_flags_options 1
+
+    # Offer option value completions
+    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --one)
         return
         ;;
     esac
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
-}
-_base_test_help() {
-    opts=""
-    if [[ "${COMP_CWORD}" == "${1}" ]]; then
-        COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+
+    # Offer positional completions
+    case "${positional_number}" in
+    1)
+        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")" -- "${cur}"))
         return
-    fi
-    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+        ;;
+    esac
 }
 
+_base_test_help() {
+    :
+}
 
 complete -F _base_test base-test

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -4,9 +4,10 @@ _base_test() {
     export SAP_SHELL=bash
     SAP_SHELL_VERSION="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
     export SAP_SHELL_VERSION
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    COMPREPLY=()
+
+    local -r cur="${2}"
+    local -r prev="${3}"
+
     opts="--name --kind --other-kind --path1 --path2 --path3 --one --two --three --kind-counter --rep1 -r --rep2 -h --help sub-command escaped-command help"
     opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
     opts="${opts} $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 _base_test() {
-    export SAP_SHELL=bash
-    SAP_SHELL_VERSION="$(IFS='.'; printf %s "${BASH_VERSINFO[*]}")"
-    export SAP_SHELL_VERSION
+    local -xr SAP_SHELL=bash
+    local -x SAP_SHELL_VERSION
+    SAP_SHELL_VERSION="$(IFS='.';printf %s "${BASH_VERSINFO[*]}")"
+    local -r SAP_SHELL_VERSION
 
     local -r cur="${2}"
     local -r prev="${3}"

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -125,7 +125,7 @@ __base_test_add_completions() {
 _base_test() {
     trap "$(shopt -p);$(shopt -po)" RETURN
     shopt -s extglob
-    set +o posix
+    set +o history +o posix
 
     local -xr SAP_SHELL=bash
     local -x SAP_SHELL_VERSION

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -11,7 +11,7 @@ _base_test() {
     opts="$opts $("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
     opts="$opts $("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case $prev in
@@ -20,18 +20,18 @@ _base_test() {
             return
         ;;
         --kind)
-            COMPREPLY=( $(compgen -W "one two custom-three" -- "$cur") )
+            COMPREPLY=($(compgen -W "one two custom-three" -- "$cur"))
             return
         ;;
         --other-kind)
-            COMPREPLY=( $(compgen -W "b1_bash b2_bash b3_bash" -- "$cur") )
+            COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "$cur"))
             return
         ;;
         --path1)
             if declare -F _filedir >/dev/null; then
               _filedir
             else
-              COMPREPLY=( $(compgen -f -- "$cur") )
+              COMPREPLY=($(compgen -f -- "$cur"))
             fi
             return
         ;;
@@ -39,12 +39,12 @@ _base_test() {
             if declare -F _filedir >/dev/null; then
               _filedir
             else
-              COMPREPLY=( $(compgen -f -- "$cur") )
+              COMPREPLY=($(compgen -f -- "$cur"))
             fi
             return
         ;;
         --path3)
-            COMPREPLY=( $(compgen -W "c1_bash c2_bash c3_bash" -- "$cur") )
+            COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "$cur"))
             return
         ;;
         --rep1)
@@ -70,21 +70,21 @@ _base_test() {
             return
             ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _base_test_sub_command() {
     opts="-h --help"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _base_test_escaped_command() {
     opts="--one -h --help"
     opts="$opts $("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
     case $prev in
@@ -93,15 +93,15 @@ _base_test_escaped_command() {
             return
         ;;
     esac
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 _base_test_help() {
     opts=""
     if [[ $COMP_CWORD == "$1" ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return
     fi
-    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
 
 

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -50,16 +50,12 @@ __base_test_offer_flags_options() {
             -*)
                 # ${word} is a flag or an option
                 # If ${word} is an option, mark that the next word to be parsed is an option value
-                # TODO: handle joined-value options (-o=file.ext), stacked flags (-aBc), legacy long (-long), combos
-                # TODO: if multi-valued options can exist, support them
                 local option
                 for option in "${options[@]}"; do
                     [[ "${word}" = "${option}" ]] && is_parsing_option_value=true && break
                 done
 
                 # Remove ${word} from ${flags} or ${options} so it isn't offered again
-                # TODO: handle repeatable flags & options
-                # TODO: remove equivalent options (-h/--help) & exclusive options (--yes/--no)
                 local not_found=true
                 local -i index
                 for index in "${!flags[@]}"; do
@@ -86,7 +82,6 @@ __base_test_offer_flags_options() {
         fi
 
         # ${word} is neither a flag, nor an option, nor an option value
-        # TODO: can SAP be configured to require options before positionals?
         if [[ "${positional_number}" -lt "${positional_count}" ]]; then
             # ${word} is a positional
             ((positional_number++))
@@ -105,7 +100,6 @@ __base_test_offer_flags_options() {
 
     unparsed_words=("${unparsed_words[@]}")
 
-    # TODO: offer flags & options after all positionals iff they're allowed after positionals
     if\
         ! "${was_flag_option_terminator_seen}"\
         && ! "${is_parsing_option_value}"\
@@ -153,7 +147,6 @@ _base_test() {
     __base_test_offer_flags_options 2
 
     # Offer option value completions
-    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --name)
         return
@@ -226,7 +219,6 @@ _base_test_escaped_command() {
     __base_test_offer_flags_options 1
 
     # Offer option value completions
-    # TODO: only if ${prev} matches -* & is not an option value
     case "${prev}" in
     --one)
         return

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -15,60 +15,60 @@ _base_test() {
         return
     fi
     case $prev in
-        --name)
+    --name)
 
-            return
+        return
         ;;
-        --kind)
-            COMPREPLY=($(compgen -W "one two custom-three" -- "$cur"))
-            return
+    --kind)
+        COMPREPLY=($(compgen -W "one two custom-three" -- "$cur"))
+        return
         ;;
-        --other-kind)
-            COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "$cur"))
-            return
+    --other-kind)
+        COMPREPLY=($(compgen -W "b1_bash b2_bash b3_bash" -- "$cur"))
+        return
         ;;
-        --path1)
-            if declare -F _filedir >/dev/null; then
-              _filedir
-            else
-              COMPREPLY=($(compgen -f -- "$cur"))
-            fi
-            return
+    --path1)
+        if declare -F _filedir >/dev/null; then
+            _filedir
+        else
+            COMPREPLY=($(compgen -f -- "$cur"))
+        fi
+        return
         ;;
-        --path2)
-            if declare -F _filedir >/dev/null; then
-              _filedir
-            else
-              COMPREPLY=($(compgen -f -- "$cur"))
-            fi
-            return
+    --path2)
+        if declare -F _filedir >/dev/null; then
+            _filedir
+        else
+            COMPREPLY=($(compgen -f -- "$cur"))
+        fi
+        return
         ;;
-        --path3)
-            COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "$cur"))
-            return
+    --path3)
+        COMPREPLY=($(compgen -W "c1_bash c2_bash c3_bash" -- "$cur"))
+        return
         ;;
-        --rep1)
+    --rep1)
 
-            return
+        return
         ;;
-        -r|--rep2)
+    -r|--rep2)
 
-            return
+        return
         ;;
     esac
     case ${COMP_WORDS[1]} in
-        (sub-command)
-            _base_test_sub-command 2
-            return
-            ;;
-        (escaped-command)
-            _base_test_escaped-command 2
-            return
-            ;;
-        (help)
-            _base_test_help 2
-            return
-            ;;
+    (sub-command)
+        _base_test_sub-command 2
+        return
+        ;;
+    (escaped-command)
+        _base_test_escaped-command 2
+        return
+        ;;
+    (help)
+        _base_test_help 2
+        return
+        ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))
 }
@@ -88,9 +88,9 @@ _base_test_escaped_command() {
         return
     fi
     case $prev in
-        --one)
+    --one)
 
-            return
+        return
         ;;
     esac
     COMPREPLY=($(compgen -W "$opts" -- "$cur"))

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -16,7 +16,6 @@ _base_test() {
     fi
     case "${prev}" in
     --name)
-
         return
         ;;
     --kind)
@@ -48,11 +47,9 @@ _base_test() {
         return
         ;;
     --rep1)
-
         return
         ;;
     -r|--rep2)
-
         return
         ;;
     esac
@@ -89,7 +86,6 @@ _base_test_escaped_command() {
     fi
     case "${prev}" in
     --one)
-
         return
         ;;
     esac

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -57,15 +57,15 @@ _base_test() {
         ;;
     esac
     case ${COMP_WORDS[1]} in
-    (sub-command)
+    sub-command)
         _base_test_sub-command 2
         return
         ;;
-    (escaped-command)
+    escaped-command)
         _base_test_escaped-command 2
         return
         ;;
-    (help)
+    help)
         _base_test_help 2
         return
         ;;

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -122,6 +122,16 @@ __base_test_add_completions() {
     done < <(IFS=$'\n' compgen "${@}" -- "${cur}")
 }
 
+__base_test_custom_complete() {
+    if [[ -n "${cur}" || -z ${COMP_WORDS[${COMP_CWORD}]} || "${COMP_LINE:${COMP_POINT}:1}" != ' ' ]]; then
+        local -ar words=("${COMP_WORDS[@]}")
+    else
+        local -ar words=("${COMP_WORDS[@]::${COMP_CWORD}}" '' "${COMP_WORDS[@]:${COMP_CWORD}}")
+    fi
+
+    "${COMP_WORDS[0]}" "${@}" "${words[@]}"
+}
+
 _base_test() {
     trap "$(shopt -p);$(shopt -po)" RETURN
     shopt -s extglob
@@ -179,11 +189,11 @@ _base_test() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
+        __base_test_add_completions -W "$(__base_test_custom_complete ---completion  -- argument)"
         return
         ;;
     2)
-        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
+        __base_test_add_completions -W "$(__base_test_custom_complete ---completion  -- nested.nestedArgument)"
         return
         ;;
     esac
@@ -226,7 +236,7 @@ _base_test_escaped_command() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
+        __base_test_add_completions -W "$(__base_test_custom_complete ---completion escaped-command -- two)"
         return
         ;;
     esac

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -179,11 +179,11 @@ _base_test() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")" -- "${cur}"))
+        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion  -- argument "${COMP_WORDS[@]}")"
         return
         ;;
     2)
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")" -- "${cur}"))
+        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion  -- nested.nestedArgument "${COMP_WORDS[@]}")"
         return
         ;;
     esac
@@ -226,7 +226,7 @@ _base_test_escaped_command() {
     # Offer positional completions
     case "${positional_number}" in
     1)
-        COMPREPLY+=($(compgen -W "$("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")" -- "${cur}"))
+        __base_test_add_completions -W "$("${COMP_WORDS[0]}" ---completion escaped-command -- two "${COMP_WORDS[@]}")"
         return
         ;;
     esac


### PR DESCRIPTION
Improve bash completion script generation.

There are many issues with script generation. Some of them are documented in #679 & its comments.

This issue is for a first batch of bash completion script fixes.

Each commit should note the fix(es) that it contains.

Note that I use "iff" in some Swift & bash comments, but not in code or in DocC. If you want "iff" removed from comments, please let me know.

Will rebase if `main` is updated (especially if #726 is merged).

Resolve #734

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
