### PR TITLE
Simplify configuration check for async root command

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -146,15 +146,12 @@ extension ParsableCommand {
   /// - Parameter arguments: An array of arguments to use for parsing. If
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   public static func main(_ arguments: [String]?) {
-
     #if DEBUG
     if #available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *) {
-      if let asyncCommand = firstAsyncSubcommand(self) {
-        if Self() is AsyncParsableCommand {
-          failAsyncPlatform(rootCommand: self)
-        } else {
-          failAsyncHierarchy(rootCommand: self, subCommand: asyncCommand)
-        }
+      if Self() is AsyncParsableCommand {
+        failAsyncPlatform(rootCommand: self)
+      } else if let asyncCommand = firstAsyncSubcommand(self) {
+        failAsyncHierarchy(rootCommand: self, subCommand: asyncCommand)
       }
     }
     #endif


### PR DESCRIPTION
If the synchronous `main()` is running for an `AsyncParsableCommand` root, something went wrong. Previously, this was only diagnosed when there was an async subcommand; this change expands the failure condition to include standalone async commands.

Fixes #662.

(Tested locally, since we don't have crash tests.)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
