### PR TITLE
Only use `FoundationEssentials` if available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -119,8 +119,7 @@ var package = Package(
       name: "ArgumentParserUnitTests",
       dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
       exclude: ["CMakeLists.txt", "Snapshots"]),
-  ],
-  swiftLanguageModes: [.v6]
+  ]
 )
 
 #if os(macOS)

--- a/Package.swift
+++ b/Package.swift
@@ -119,7 +119,8 @@ var package = Package(
       name: "ArgumentParserUnitTests",
       dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
       exclude: ["CMakeLists.txt", "Snapshots"]),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )
 
 #if os(macOS)

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -203,14 +203,28 @@ extension Sequence where Element == ParsableCommand.Type {
 }
 
 extension String {
+  #if canImport(FoundationEssentials)
   func shellEscapeForSingleQuotedString(iterationCount: UInt64 = 1) -> Self {
     iterationCount == 0
       ? self
       : replacing("'", with: "'\\''")
         .shellEscapeForSingleQuotedString(iterationCount: iterationCount - 1)
   }
-
+  #else
+  func shellEscapeForSingleQuotedString(iterationCount: UInt64 = 1) -> Self {
+    iterationCount == 0
+      ? self
+      : replacingOccurrences(of: "'", with: "'\\''")
+        .shellEscapeForSingleQuotedString(iterationCount: iterationCount - 1)
+  }
+  #endif
+  #if canImport(FoundationEssentials)
   func shellEscapeForVariableName() -> Self {
     replacing("-", with: "_")
   }
+  #else
+  func shellEscapeForVariableName() -> Self {
+    replacingOccurrences(of: "-", with: "_")
+  }
+  #endif
 }

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -218,6 +218,7 @@ extension String {
         .shellEscapeForSingleQuotedString(iterationCount: iterationCount - 1)
   }
   #endif
+  
   #if canImport(FoundationEssentials)
   func shellEscapeForVariableName() -> Self {
     replacing("-", with: "_")

--- a/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/CompletionsGenerator.swift
@@ -206,11 +206,11 @@ extension String {
   func shellEscapeForSingleQuotedString(iterationCount: UInt64 = 1) -> Self {
     iterationCount == 0
       ? self
-      : replacingOccurrences(of: "'", with: "'\\''")
+      : replacing("'", with: "'\\''")
         .shellEscapeForSingleQuotedString(iterationCount: iterationCount - 1)
   }
 
   func shellEscapeForVariableName() -> Self {
-    replacingOccurrences(of: "-", with: "_")
+    replacing("-", with: "_")
   }
 }

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -133,7 +133,7 @@ extension Name {
 
 extension String {
   fileprivate func fishEscape() -> String {
-    replacingOccurrences(of: "'", with: #"\'"#)
+    replacing("'", with: #"\'"#)
   }
 }
 

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -132,9 +132,15 @@ extension Name {
 }
 
 extension String {
+  #if canImport(FoundationEssentials)
   fileprivate func fishEscape() -> String {
     replacing("'", with: #"\'"#)
   }
+  #else
+  fileprivate func fishEscape() -> String {
+    replacingOccurrences(of: "'", with: #"\'"#)
+  }
+  #endif
 }
 
 extension FishCompletionsGenerator {

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -222,11 +222,7 @@ extension [ParsableCommand.Type] {
 
 extension String {
   fileprivate func zshEscapeForSingleQuotedExplanation() -> String {
-    replacingOccurrences(
-      of: #"[\\\[\]]"#,
-      with: #"\\$0"#,
-      options: .regularExpression
-    )
+    replacing(#"[\\\[\]]"#, with: #"\\$0"#)
     .shellEscapeForSingleQuotedString()
   }
 }

--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -221,10 +221,20 @@ extension [ParsableCommand.Type] {
 }
 
 extension String {
+  #if canImport(FoundationEssentials)
   fileprivate func zshEscapeForSingleQuotedExplanation() -> String {
-    replacing(#"[\\\[\]]"#, with: #"\\$0"#)
+    replacing(#/[\\\[\]]/#, with: { "\\\($0.output)" })
     .shellEscapeForSingleQuotedString()
   }
+  #else
+  fileprivate func zshEscapeForSingleQuotedExplanation() -> String {
+    replacingOccurrences(
+      of: #"[\\\[\]]"#,
+      with: #"\\$0"#,
+      options: .regularExpression)
+    .shellEscapeForSingleQuotedString()
+  }
+  #endif
 }
 
 extension ArgumentDefinition {

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -35,7 +35,7 @@ struct _WrappedParsableCommand<P: ParsableArguments>: ParsableCommand {
 
     // If the type is named something like "TransformOptions", we only want
     // to use "transform" as the command name.
-    if let optionsRange = name.range(of: "_options"),
+    if let optionsRange = name._range(of: "_options"),
       optionsRange.upperBound == name.endIndex
     {
       return String(name[..<optionsRange.lowerBound])

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -16,8 +16,13 @@ internal import class FoundationEssentials.ProcessInfo
 internal import class Foundation.ProcessInfo
 #endif
 #else
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
 #endif
+#endif
+
 
 struct CommandError: Error {
   var commandStack: [ParsableCommand.Type]

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -10,7 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import class FoundationEssentials.ProcessInfo
+#else
 internal import class Foundation.ProcessInfo
+#endif
 #else
 import class Foundation.ProcessInfo
 #endif

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -12,13 +12,17 @@
 #if swift(>=6.0)
 internal import ArgumentParserToolInfo
 #if canImport(FoundationEssentials)
-internal import class FoundationEssentials.ProcessInfo
+internal import class FoundationEssentials.JSONEncoder
 #else
-internal import class Foundation.ProcessInfo
+internal import class Foundation.JSONEncoder
 #endif
 #else
 import ArgumentParserToolInfo
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.JSONEncoder
+#else
 import class Foundation.JSONEncoder
+#endif
 #endif
 
 internal struct DumpHelpGenerator {

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -11,7 +11,11 @@
 
 #if swift(>=6.0)
 internal import ArgumentParserToolInfo
-internal import class Foundation.JSONEncoder
+#if canImport(FoundationEssentials)
+internal import class FoundationEssentials.ProcessInfo
+#else
+internal import class Foundation.ProcessInfo
+#endif
 #else
 import ArgumentParserToolInfo
 import class Foundation.JSONEncoder

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -10,8 +10,12 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import protocol FoundationEssentials.LocalizedError
+#else
 internal import protocol Foundation.LocalizedError
 internal import class Foundation.NSError
+#endif
 #else
 import protocol Foundation.LocalizedError
 import class Foundation.NSError
@@ -135,11 +139,15 @@ enum MessageInfo {
         // No way to unwrap bind description in pattern
         self = .other(message: error.errorDescription!, exitCode: .failure)
       default:
+        #if canImport(FoundationEssentials)
+        self = .other(message: String(describing: error), exitCode: .failure)
+        #else
         if Swift.type(of: error) is NSError.Type {
           self = .other(message: error.localizedDescription, exitCode: .failure)
         } else {
           self = .other(message: String(describing: error), exitCode: .failure)
         }
+        #endif
       }
     } else if let parserError = parserError {
       let usage: String = {

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -17,8 +17,12 @@ internal import protocol Foundation.LocalizedError
 internal import class Foundation.NSError
 #endif
 #else
+#if canImport(FoundationEssentials)
+import protocol FoundationEssentials.LocalizedError
+#else
 import protocol Foundation.LocalizedError
 import class Foundation.NSError
+#endif
 #endif
 
 enum MessageInfo {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -16,7 +16,11 @@ internal import protocol FoundationEssentials.LocalizedError
 internal import protocol Foundation.LocalizedError
 #endif
 #else
+#if canImport(FoundationEssentials)
+import protocol FoundationEssentials.LocalizedError
+#else
 import protocol Foundation.LocalizedError
+#endif
 #endif
 
 struct UsageGenerator {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -10,7 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 #if swift(>=6.0)
+#if canImport(FoundationEssentials)
+internal import protocol FoundationEssentials.LocalizedError
+#else
 internal import protocol Foundation.LocalizedError
+#endif
 #else
 import protocol Foundation.LocalizedError
 #endif

--- a/Sources/ArgumentParser/Utilities/BidirectionalCollection.swift
+++ b/Sources/ArgumentParser/Utilities/BidirectionalCollection.swift
@@ -10,55 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension BidirectionalCollection where Index == String.Index {
-    internal func _alignIndex(roundingDown i: Index) -> Index {
-        index(i, offsetBy: 0)
-    }
-
-    internal func _alignIndex(roundingUp i: Index) -> Index {
-        let truncated = _alignIndex(roundingDown: i)
-        guard i > truncated && truncated < endIndex else { return truncated }
-        return index(after: truncated)
-    }
-
-    internal func _boundaryAlignedRange(_ r: some RangeExpression<Index>) -> Range<Index> {
-        let range = r.relative(to: self)
-        return _alignIndex(roundingDown: range.lowerBound)..<_alignIndex(roundingUp: range.upperBound)
-    }
-
-    internal func _checkRange(_ r: Range<Index>) -> Range<Index>? {
-        guard r.lowerBound >= startIndex, r.upperBound <= endIndex else {
-            return nil
-        }
-        return r
-    }
-}
 
 extension BidirectionalCollection {
-    func _trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
-        var idx = startIndex
-        while idx < endIndex && predicate(self[idx]) {
-            formIndex(after: &idx)
-        }
-
-        let startOfNonTrimmedRange = idx // Points at the first char not in the set
-        guard startOfNonTrimmedRange != endIndex else {
-            return self[endIndex...]
-        }
-
-        let beforeEnd = index(before: endIndex)
-        guard startOfNonTrimmedRange < beforeEnd else {
-            return self[startOfNonTrimmedRange ..< endIndex]
-        }
-
-        var backIdx = beforeEnd
-        // No need to bound-check because we've already trimmed from the beginning, so we'd definitely break off of this loop before `backIdx` rewinds before `startIndex`
-        while predicate(self[backIdx]) {
-            formIndex(before: &backIdx)
-        }
-        return self[startOfNonTrimmedRange ... backIdx]
-    }
-
     // Equal to calling `index(&idx, offsetBy: -other.count)` with just one loop
     func _index<S: BidirectionalCollection>(_ index: Index, backwardsOffsetByCountOf other: S) -> Index? {
         var idx = index

--- a/Sources/ArgumentParser/Utilities/BidirectionalCollection.swift
+++ b/Sources/ArgumentParser/Utilities/BidirectionalCollection.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection where Index == String.Index {
+    internal func _alignIndex(roundingDown i: Index) -> Index {
+        index(i, offsetBy: 0)
+    }
+
+    internal func _alignIndex(roundingUp i: Index) -> Index {
+        let truncated = _alignIndex(roundingDown: i)
+        guard i > truncated && truncated < endIndex else { return truncated }
+        return index(after: truncated)
+    }
+
+    internal func _boundaryAlignedRange(_ r: some RangeExpression<Index>) -> Range<Index> {
+        let range = r.relative(to: self)
+        return _alignIndex(roundingDown: range.lowerBound)..<_alignIndex(roundingUp: range.upperBound)
+    }
+
+    internal func _checkRange(_ r: Range<Index>) -> Range<Index>? {
+        guard r.lowerBound >= startIndex, r.upperBound <= endIndex else {
+            return nil
+        }
+        return r
+    }
+}
+
+extension BidirectionalCollection {
+    func _trimmingCharacters(while predicate: (Element) -> Bool) -> SubSequence {
+        var idx = startIndex
+        while idx < endIndex && predicate(self[idx]) {
+            formIndex(after: &idx)
+        }
+
+        let startOfNonTrimmedRange = idx // Points at the first char not in the set
+        guard startOfNonTrimmedRange != endIndex else {
+            return self[endIndex...]
+        }
+
+        let beforeEnd = index(before: endIndex)
+        guard startOfNonTrimmedRange < beforeEnd else {
+            return self[startOfNonTrimmedRange ..< endIndex]
+        }
+
+        var backIdx = beforeEnd
+        // No need to bound-check because we've already trimmed from the beginning, so we'd definitely break off of this loop before `backIdx` rewinds before `startIndex`
+        while predicate(self[backIdx]) {
+            formIndex(before: &backIdx)
+        }
+        return self[startOfNonTrimmedRange ... backIdx]
+    }
+
+    // Equal to calling `index(&idx, offsetBy: -other.count)` with just one loop
+    func _index<S: BidirectionalCollection>(_ index: Index, backwardsOffsetByCountOf other: S) -> Index? {
+        var idx = index
+        var otherIdx = other.endIndex
+        while otherIdx > other.startIndex {
+            guard idx > startIndex else {
+                // other.count > self.count: bail
+                return nil
+            }
+            other.formIndex(before: &otherIdx)
+            formIndex(before: &idx)
+        }
+        return idx
+    }
+
+    func _range<S: BidirectionalCollection>(of other: S, anchored: Bool = false, backwards: Bool = false) -> Range<Index>? where S.Element == Element, Element : Equatable {
+        var result: Range<Index>? = nil
+        var fromLoc: Index
+        var toLoc: Index
+        if backwards {
+            guard let idx = _index(endIndex, backwardsOffsetByCountOf: other) else {
+                // other.count > string.count: bail
+                return nil
+            }
+            fromLoc = idx
+
+            toLoc = anchored ? fromLoc : startIndex
+        } else {
+            fromLoc = startIndex
+            if anchored {
+                toLoc = fromLoc
+            } else {
+                guard let idx = _index(endIndex, backwardsOffsetByCountOf: other) else {
+                    return nil
+                }
+                toLoc = idx
+            }
+        }
+
+        let delta = fromLoc <= toLoc ? 1 : -1
+
+        while true {
+            var str1Index = fromLoc
+            var str2Index = other.startIndex
+
+            while str2Index < other.endIndex && str1Index < endIndex {
+                if self[str1Index] != other[str2Index] {
+                    break
+                }
+                formIndex(after: &str1Index)
+                other.formIndex(after: &str2Index)
+            }
+
+            if str2Index == other.endIndex {
+                result = fromLoc..<str1Index
+                break
+            }
+
+            if fromLoc == toLoc {
+                break
+            }
+
+            formIndex(&fromLoc, offsetBy: delta)
+        }
+
+        return result
+    }
+}

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -9,8 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Synchronization)
-import Synchronization
+#if !canImport(FoundationEssentials)
+import class Foundation.NSLock
+#endif
 
 /// A synchronization primitive that protects shared mutable state via mutual
 /// exclusion.
@@ -19,29 +20,13 @@ import Synchronization
 /// protecting by blocking threads attempting to acquire the lock. Only one
 /// execution context at a time has access to the value stored within the
 /// `Mutex` allowing for exclusive access.
-class Mutex<T>: @unchecked Sendable {
-  private let mutex: Synchronization.Mutex<T>
-
-  init(_ value: sending T) {
-    self.mutex = .init(value)
-  }
-
-  func withLock<U>(_ body: (inout sending T) throws -> sending U) rethrows -> sending U {
-    try mutex.withLock(body)
-  }
-}
-#else
-import Foundation
-/// A synchronization primitive that protects shared mutable state via mutual
-/// exclusion.
-///
-/// The `Mutex` type offers non-recursive exclusive access to the state it is
-/// protecting by blocking threads attempting to acquire the lock. Only one
-/// execution context at a time has access to the value stored within the
-/// `Mutex` allowing for exclusive access.
-class Mutex<T>: @unchecked Sendable {
+final class Mutex<T>: @unchecked Sendable {
   /// The lock used to synchronize access to the value.
+  #if canImport(FoundationEssentials)
+  var lock: NIOLock
+  #else
   var lock: NSLock
+  #endif
   /// The value protected by the mutex.
   var value: T
 
@@ -75,4 +60,268 @@ class Mutex<T>: @unchecked Sendable {
     return try body(&self.value)
   }
 }
+
+#if canImport(FoundationEssentials)
+
+#if os(Windows)
+import ucrt
+import WinSDK
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(Bionic)
+@preconcurrency import Bionic
+#elseif canImport(WASILibc)
+@preconcurrency import WASILibc
+#if canImport(wasi_pthread)
+import wasi_pthread
+#endif
+#else
+#error("The concurrency NIOLock module was unable to identify your C library.")
+#endif
+
+#if os(Windows)
+@usableFromInline
+typealias LockPrimitive = SRWLOCK
+#else
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t
+#endif
+
+@usableFromInline
+enum LockOperations {}
+
+extension LockOperations {
+    @inlinable
+    static func create(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        InitializeSRWLock(mutex)
+        #elseif !os(WASI)
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr)
+        debugOnly {
+            pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+        }
+
+        let err = pthread_mutex_init(mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func destroy(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        // SRWLOCK does not need to be free'd
+        #elseif !os(WASI)
+        let err = pthread_mutex_destroy(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func lock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        AcquireSRWLockExclusive(mutex)
+        #elseif !os(WASI)
+        let err = pthread_mutex_lock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func unlock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        ReleaseSRWLockExclusive(mutex)
+        #elseif !os(WASI)
+        let err = pthread_mutex_unlock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+}
+
+// Tail allocate both the mutex and a generic value using ManagedBuffer.
+// Both the header pointer and the elements pointer are stable for
+// the class's entire lifetime.
+//
+// However, for safety reasons, we elect to place the lock in the "elements"
+// section of the buffer instead of the head. The reasoning here is subtle,
+// so buckle in.
+//
+// _As a practical matter_, the implementation of ManagedBuffer ensures that
+// the pointer to the header is stable across the lifetime of the class, and so
+// each time you call `withUnsafeMutablePointers` or `withUnsafeMutablePointerToHeader`
+// the value of the header pointer will be the same. This is because ManagedBuffer uses
+// `Builtin.addressOf` to load the value of the header, and that does ~magic~ to ensure
+// that it does not invoke any weird Swift accessors that might copy the value.
+//
+// _However_, the header is also available via the `.header` field on the ManagedBuffer.
+// This presents a problem! The reason there's an issue is that `Builtin.addressOf` and friends
+// do not interact with Swift's exclusivity model. That is, the various `with` functions do not
+// conceptually trigger a mutating access to `.header`. For elements this isn't a concern because
+// there's literally no other way to perform the access, but for `.header` it's entirely possible
+// to accidentally recursively read it.
+//
+// Our implementation is free from these issues, so we don't _really_ need to worry about it.
+// However, out of an abundance of caution, we store the Value in the header, and the LockPrimitive
+// in the trailing elements. We still don't use `.header`, but it's better to be safe than sorry,
+// and future maintainers will be happier that we were cautious.
+//
+// See also: https://github.com/apple/swift/pull/40000
+@usableFromInline
+final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
+
+    @inlinable
+    static func create(value: Value) -> Self {
+        let buffer = Self.create(minimumCapacity: 1) { _ in
+            value
+        }
+        // Intentionally using a force cast here to avoid a miss compiliation in 5.10.
+        // This is as fast as an unsafeDownCast since ManagedBuffer is inlined and the optimizer
+        // can eliminate the upcast/downcast pair
+        let storage = buffer as! Self
+
+        storage.withUnsafeMutablePointers { _, lockPtr in
+            LockOperations.create(lockPtr)
+        }
+
+        return storage
+    }
+
+    @inlinable
+    func lock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.lock(lockPtr)
+        }
+    }
+
+    @inlinable
+    func unlock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.unlock(lockPtr)
+        }
+    }
+
+    @inlinable
+    deinit {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.destroy(lockPtr)
+        }
+    }
+
+    @inlinable
+    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointerToElements { lockPtr in
+            try body(lockPtr)
+        }
+    }
+
+    @inlinable
+    func withLockedValue<T>(_ mutate: (inout Value) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointers { valuePtr, lockPtr in
+            LockOperations.lock(lockPtr)
+            defer { LockOperations.unlock(lockPtr) }
+            return try mutate(&valuePtr.pointee)
+        }
+    }
+}
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// - Note: ``NIOLock`` has reference semantics.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+public struct NIOLock {
+    @usableFromInline
+    internal let _storage: LockStorage<Void>
+
+    /// Create a new lock.
+    @inlinable
+    public init() {
+        self._storage = .create(value: ())
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    @inlinable
+    public func lock() {
+        self._storage.lock()
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    @inlinable
+    public func unlock() {
+        self._storage.unlock()
+    }
+
+    @inlinable
+    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try self._storage.withLockPrimitive(body)
+    }
+}
+
+extension NIOLock {
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    @inlinable
+    public func withLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withLock(body)
+    }
+}
+
+extension NIOLock: @unchecked Sendable {}
+
+extension UnsafeMutablePointer {
+    @inlinable
+    func assertValidAlignment() {
+        assert(UInt(bitPattern: self) % UInt(MemoryLayout<Pointee>.alignment) == 0)
+    }
+}
+
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
+@inlinable
+internal func debugOnly(_ body: () -> Void) {
+    assert(
+        {
+            body()
+            return true
+        }()
+    )
+}
+
 #endif

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -9,12 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=6.0)
-internal import Foundation
-#else
-import Foundation
-#endif
-
 /// A synchronization primitive that protects shared mutable state via mutual
 /// exclusion.
 ///
@@ -24,7 +18,7 @@ import Foundation
 /// `Mutex` allowing for exclusive access.
 class Mutex<T>: @unchecked Sendable {
   /// The lock used to synchronize access to the value.
-  var lock: NSLock
+  var lock: Lock
   /// The value protected by the mutex.
   var value: T
 
@@ -58,3 +52,327 @@ class Mutex<T>: @unchecked Sendable {
     return try body(&self.value)
   }
 }
+
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import ucrt
+import WinSDK
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(WASILibc)
+import WASILibc
+#if canImport(wasi_pthread)
+import wasi_pthread
+#endif
+#else
+#error("The concurrency lock module was unable to identify your C library.")
+#endif
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+@available(*, deprecated, renamed: "NIOLock")
+public final class Lock {
+    #if os(Windows)
+    fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #else
+    fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #endif
+
+    /// Create a new lock.
+    public init() {
+        #if os(Windows)
+        InitializeSRWLock(self.mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr)
+        debugOnly {
+            pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
+        }
+
+        let err = pthread_mutex_init(self.mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    deinit {
+        #if os(Windows)
+        // SRWLOCK does not need to be free'd
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_destroy(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+        mutex.deallocate()
+    }
+
+    /// Acquire the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `unlock`, to simplify lock handling.
+    public func lock() {
+        #if os(Windows)
+        AcquireSRWLockExclusive(self.mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_lock(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    /// Release the lock.
+    ///
+    /// Whenever possible, consider using `withLock` instead of this method and
+    /// `lock`, to simplify lock handling.
+    public func unlock() {
+        #if os(Windows)
+        ReleaseSRWLockExclusive(self.mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_unlock(self.mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// This convenience method should be preferred to `lock` and `unlock` in
+    /// most situations, as it ensures that the lock will be released regardless
+    /// of how `body` exits.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    // specialise Void return (for performance)
+    @inlinable
+    public func withLockVoid(_ body: () throws -> Void) rethrows {
+        try self.withLock(body)
+    }
+}
+
+/// A `Lock` with a built-in state variable.
+///
+/// This class provides a convenience addition to `Lock`: it provides the ability to wait
+/// until the state variable is set to a specific value to acquire the lock.
+public final class ConditionLock<T: Equatable> {
+    private var _value: T
+    private let mutex: NIOLock
+    #if os(Windows)
+    private let cond: UnsafeMutablePointer<CONDITION_VARIABLE> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+    private let cond: UnsafeMutablePointer<pthread_cond_t> =
+        UnsafeMutablePointer.allocate(capacity: 1)
+    #endif
+
+    /// Create the lock, and initialize the state variable to `value`.
+    ///
+    /// - Parameter value: The initial value to give the state variable.
+    public init(value: T) {
+        self._value = value
+        self.mutex = NIOLock()
+        #if os(Windows)
+        InitializeConditionVariable(self.cond)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_cond_init(self.cond, nil)
+        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
+        #endif
+    }
+
+    deinit {
+        #if os(Windows)
+        // condition variables do not need to be explicitly destroyed
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_cond_destroy(self.cond)
+        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
+        self.cond.deallocate()
+        #endif
+    }
+
+    /// Acquire the lock, regardless of the value of the state variable.
+    public func lock() {
+        self.mutex.lock()
+    }
+
+    /// Release the lock, regardless of the value of the state variable.
+    public func unlock() {
+        self.mutex.unlock()
+    }
+
+    /// The value of the state variable.
+    ///
+    /// Obtaining the value of the state variable requires acquiring the lock.
+    /// This means that it is not safe to access this property while holding the
+    /// lock: it is only safe to use it when not holding it.
+    public var value: T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return self._value
+    }
+
+    /// Acquire the lock when the state variable is equal to `wantedValue`.
+    ///
+    /// - Parameter wantedValue: The value to wait for the state variable
+    ///     to have before acquiring the lock.
+    public func lock(whenValue wantedValue: T) {
+        self.lock()
+        while true {
+            if self._value == wantedValue {
+                break
+            }
+            self.mutex.withLockPrimitive { mutex in
+                #if os(Windows)
+                let result = SleepConditionVariableSRW(self.cond, mutex, INFINITE, 0)
+                precondition(result, "\(#function) failed in SleepConditionVariableSRW with error \(GetLastError())")
+                #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+                let err = pthread_cond_wait(self.cond, mutex)
+                precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
+                #endif
+            }
+        }
+    }
+
+    /// Acquire the lock when the state variable is equal to `wantedValue`,
+    /// waiting no more than `timeoutSeconds` seconds.
+    ///
+    /// - Parameter wantedValue: The value to wait for the state variable
+    ///     to have before acquiring the lock.
+    /// - Parameter timeoutSeconds: The number of seconds to wait to acquire
+    ///     the lock before giving up.
+    /// - Returns: `true` if the lock was acquired, `false` if the wait timed out.
+    public func lock(whenValue wantedValue: T, timeoutSeconds: Double) -> Bool {
+        precondition(timeoutSeconds >= 0)
+
+        #if os(Windows)
+        var dwMilliseconds: DWORD = DWORD(timeoutSeconds * 1000)
+
+        self.lock()
+        while true {
+            if self._value == wantedValue {
+                return true
+            }
+
+            let dwWaitStart = timeGetTime()
+            let result = self.mutex.withLockPrimitive { mutex in
+                SleepConditionVariableSRW(self.cond, mutex, dwMilliseconds, 0)
+            }
+            if !result {
+                let dwError = GetLastError()
+                if dwError == ERROR_TIMEOUT {
+                    self.unlock()
+                    return false
+                }
+                fatalError("SleepConditionVariableSRW: \(dwError)")
+            }
+            // NOTE: this may be a spurious wakeup, adjust the timeout accordingly
+            dwMilliseconds = dwMilliseconds - (timeGetTime() - dwWaitStart)
+        }
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let nsecPerSec: Int64 = 1_000_000_000
+        self.lock()
+        // the timeout as a (seconds, nano seconds) pair
+        let timeoutNS = Int64(timeoutSeconds * Double(nsecPerSec))
+
+        var curTime = timeval()
+        gettimeofday(&curTime, nil)
+
+        let allNSecs: Int64 = timeoutNS + Int64(curTime.tv_usec) * 1000
+        #if canImport(wasi_pthread)
+        let tvSec = curTime.tv_sec + (allNSecs / nsecPerSec)
+        #else
+        let tvSec = curTime.tv_sec + Int((allNSecs / nsecPerSec))
+        #endif
+
+        var timeoutAbs = timespec(
+            tv_sec: tvSec,
+            tv_nsec: Int(allNSecs % nsecPerSec)
+        )
+        assert(timeoutAbs.tv_nsec >= 0 && timeoutAbs.tv_nsec < Int(nsecPerSec))
+        assert(timeoutAbs.tv_sec >= curTime.tv_sec)
+        return self.mutex.withLockPrimitive { mutex -> Bool in
+            while true {
+                if self._value == wantedValue {
+                    return true
+                }
+                switch pthread_cond_timedwait(self.cond, mutex, &timeoutAbs) {
+                case 0:
+                    continue
+                case ETIMEDOUT:
+                    self.unlock()
+                    return false
+                case let e:
+                    fatalError("caught error \(e) when calling pthread_cond_timedwait")
+                }
+            }
+        }
+        #else
+        return true
+        #endif
+    }
+
+    /// Release the lock, setting the state variable to `newValue`.
+    ///
+    /// - Parameter newValue: The value to give to the state variable when we
+    ///     release the lock.
+    public func unlock(withValue newValue: T) {
+        self._value = newValue
+        self.unlock()
+        #if os(Windows)
+        WakeAllConditionVariable(self.cond)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_cond_broadcast(self.cond)
+        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
+        #endif
+    }
+}
+
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
+@inlinable
+internal func debugOnly(_ body: () -> Void) {
+    assert(
+        {
+            body()
+            return true
+        }()
+    )
+}
+
+@available(*, deprecated)
+extension Lock: @unchecked Sendable {}
+extension ConditionLock: @unchecked Sendable {}

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -18,7 +18,7 @@
 /// `Mutex` allowing for exclusive access.
 class Mutex<T>: @unchecked Sendable {
   /// The lock used to synchronize access to the value.
-  var lock: Lock
+  var lock: NIOLock
   /// The value protected by the mutex.
   var value: T
 
@@ -58,7 +58,7 @@ class Mutex<T>: @unchecked Sendable {
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -85,29 +85,27 @@ import WASILibc
 import wasi_pthread
 #endif
 #else
-#error("The concurrency lock module was unable to identify your C library.")
+#error("The concurrency NIOLock module was unable to identify your C library.")
 #endif
 
-/// A threading lock based on `libpthread` instead of `libdispatch`.
-///
-/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
-/// of lock is safe to use with `libpthread`-based threading models, such as the
-/// one used by NIO. On Windows, the lock is based on the substantially similar
-/// `SRWLOCK` type.
-@available(*, deprecated, renamed: "NIOLock")
-public final class Lock {
-    #if os(Windows)
-    fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
-        UnsafeMutablePointer.allocate(capacity: 1)
-    #else
-    fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> =
-        UnsafeMutablePointer.allocate(capacity: 1)
-    #endif
+#if os(Windows)
+@usableFromInline
+typealias LockPrimitive = SRWLOCK
+#else
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t
+#endif
 
-    /// Create a new lock.
-    public init() {
+@usableFromInline
+enum LockOperations {}
+
+extension LockOperations {
+    @inlinable
+    static func create(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
         #if os(Windows)
-        InitializeSRWLock(self.mutex)
+        InitializeSRWLock(mutex)
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
         var attr = pthread_mutexattr_t()
         pthread_mutexattr_init(&attr)
@@ -115,47 +113,177 @@ public final class Lock {
             pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
         }
 
-        let err = pthread_mutex_init(self.mutex, &attr)
+        let err = pthread_mutex_init(mutex, &attr)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
     }
 
-    deinit {
+    @inlinable
+    static func destroy(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
         #if os(Windows)
         // SRWLOCK does not need to be free'd
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_destroy(self.mutex)
+        let err = pthread_mutex_destroy(mutex)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
-        mutex.deallocate()
+    }
+
+    @inlinable
+    static func lock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        AcquireSRWLockExclusive(mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_lock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func unlock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if os(Windows)
+        ReleaseSRWLockExclusive(mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_unlock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+}
+
+// Tail allocate both the mutex and a generic value using ManagedBuffer.
+// Both the header pointer and the elements pointer are stable for
+// the class's entire lifetime.
+//
+// However, for safety reasons, we elect to place the lock in the "elements"
+// section of the buffer instead of the head. The reasoning here is subtle,
+// so buckle in.
+//
+// _As a practical matter_, the implementation of ManagedBuffer ensures that
+// the pointer to the header is stable across the lifetime of the class, and so
+// each time you call `withUnsafeMutablePointers` or `withUnsafeMutablePointerToHeader`
+// the value of the header pointer will be the same. This is because ManagedBuffer uses
+// `Builtin.addressOf` to load the value of the header, and that does ~magic~ to ensure
+// that it does not invoke any weird Swift accessors that might copy the value.
+//
+// _However_, the header is also available via the `.header` field on the ManagedBuffer.
+// This presents a problem! The reason there's an issue is that `Builtin.addressOf` and friends
+// do not interact with Swift's exclusivity model. That is, the various `with` functions do not
+// conceptually trigger a mutating access to `.header`. For elements this isn't a concern because
+// there's literally no other way to perform the access, but for `.header` it's entirely possible
+// to accidentally recursively read it.
+//
+// Our implementation is free from these issues, so we don't _really_ need to worry about it.
+// However, out of an abundance of caution, we store the Value in the header, and the LockPrimitive
+// in the trailing elements. We still don't use `.header`, but it's better to be safe than sorry,
+// and future maintainers will be happier that we were cautious.
+//
+// See also: https://github.com/apple/swift/pull/40000
+@usableFromInline
+final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
+
+    @inlinable
+    static func create(value: Value) -> Self {
+        let buffer = Self.create(minimumCapacity: 1) { _ in
+            value
+        }
+        // Intentionally using a force cast here to avoid a miss compiliation in 5.10.
+        // This is as fast as an unsafeDownCast since ManagedBuffer is inlined and the optimizer
+        // can eliminate the upcast/downcast pair
+        let storage = buffer as! Self
+
+        storage.withUnsafeMutablePointers { _, lockPtr in
+            LockOperations.create(lockPtr)
+        }
+
+        return storage
+    }
+
+    @inlinable
+    func lock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.lock(lockPtr)
+        }
+    }
+
+    @inlinable
+    func unlock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.unlock(lockPtr)
+        }
+    }
+
+    @inlinable
+    deinit {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.destroy(lockPtr)
+        }
+    }
+
+    @inlinable
+    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointerToElements { lockPtr in
+            try body(lockPtr)
+        }
+    }
+
+    @inlinable
+    func withLockedValue<T>(_ mutate: (inout Value) throws -> T) rethrows -> T {
+        try self.withUnsafeMutablePointers { valuePtr, lockPtr in
+            LockOperations.lock(lockPtr)
+            defer { LockOperations.unlock(lockPtr) }
+            return try mutate(&valuePtr.pointee)
+        }
+    }
+}
+
+/// A threading lock based on `libpthread` instead of `libdispatch`.
+///
+/// - Note: ``NIOLock`` has reference semantics.
+///
+/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
+/// of lock is safe to use with `libpthread`-based threading models, such as the
+/// one used by NIO. On Windows, the lock is based on the substantially similar
+/// `SRWLOCK` type.
+public struct NIOLock {
+    @usableFromInline
+    internal let _storage: LockStorage<Void>
+
+    /// Create a new lock.
+    @inlinable
+    public init() {
+        self._storage = .create(value: ())
     }
 
     /// Acquire the lock.
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `unlock`, to simplify lock handling.
+    @inlinable
     public func lock() {
-        #if os(Windows)
-        AcquireSRWLockExclusive(self.mutex)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_lock(self.mutex)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
+        self._storage.lock()
     }
 
     /// Release the lock.
     ///
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `lock`, to simplify lock handling.
+    @inlinable
     public func unlock() {
-        #if os(Windows)
-        ReleaseSRWLockExclusive(self.mutex)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_unlock(self.mutex)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
+        self._storage.unlock()
     }
 
+    @inlinable
+    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
+        try self._storage.withLockPrimitive(body)
+    }
+}
+
+extension NIOLock {
     /// Acquire the lock for the duration of the given block.
     ///
     /// This convenience method should be preferred to `lock` and `unlock` in
@@ -173,206 +301,17 @@ public final class Lock {
         return try body()
     }
 
-    // specialise Void return (for performance)
     @inlinable
     public func withLockVoid(_ body: () throws -> Void) rethrows {
         try self.withLock(body)
     }
 }
 
-/// A `Lock` with a built-in state variable.
-///
-/// This class provides a convenience addition to `Lock`: it provides the ability to wait
-/// until the state variable is set to a specific value to acquire the lock.
-public final class ConditionLock<T: Equatable> {
-    private var _value: T
-    private let mutex: NIOLock
-    #if os(Windows)
-    private let cond: UnsafeMutablePointer<CONDITION_VARIABLE> =
-        UnsafeMutablePointer.allocate(capacity: 1)
-    #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-    private let cond: UnsafeMutablePointer<pthread_cond_t> =
-        UnsafeMutablePointer.allocate(capacity: 1)
-    #endif
+extension NIOLock: @unchecked Sendable {}
 
-    /// Create the lock, and initialize the state variable to `value`.
-    ///
-    /// - Parameter value: The initial value to give the state variable.
-    public init(value: T) {
-        self._value = value
-        self.mutex = NIOLock()
-        #if os(Windows)
-        InitializeConditionVariable(self.cond)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_cond_init(self.cond, nil)
-        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
-        #endif
-    }
-
-    deinit {
-        #if os(Windows)
-        // condition variables do not need to be explicitly destroyed
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_cond_destroy(self.cond)
-        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
-        self.cond.deallocate()
-        #endif
-    }
-
-    /// Acquire the lock, regardless of the value of the state variable.
-    public func lock() {
-        self.mutex.lock()
-    }
-
-    /// Release the lock, regardless of the value of the state variable.
-    public func unlock() {
-        self.mutex.unlock()
-    }
-
-    /// The value of the state variable.
-    ///
-    /// Obtaining the value of the state variable requires acquiring the lock.
-    /// This means that it is not safe to access this property while holding the
-    /// lock: it is only safe to use it when not holding it.
-    public var value: T {
-        self.lock()
-        defer {
-            self.unlock()
-        }
-        return self._value
-    }
-
-    /// Acquire the lock when the state variable is equal to `wantedValue`.
-    ///
-    /// - Parameter wantedValue: The value to wait for the state variable
-    ///     to have before acquiring the lock.
-    public func lock(whenValue wantedValue: T) {
-        self.lock()
-        while true {
-            if self._value == wantedValue {
-                break
-            }
-            self.mutex.withLockPrimitive { mutex in
-                #if os(Windows)
-                let result = SleepConditionVariableSRW(self.cond, mutex, INFINITE, 0)
-                precondition(result, "\(#function) failed in SleepConditionVariableSRW with error \(GetLastError())")
-                #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-                let err = pthread_cond_wait(self.cond, mutex)
-                precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
-                #endif
-            }
-        }
-    }
-
-    /// Acquire the lock when the state variable is equal to `wantedValue`,
-    /// waiting no more than `timeoutSeconds` seconds.
-    ///
-    /// - Parameter wantedValue: The value to wait for the state variable
-    ///     to have before acquiring the lock.
-    /// - Parameter timeoutSeconds: The number of seconds to wait to acquire
-    ///     the lock before giving up.
-    /// - Returns: `true` if the lock was acquired, `false` if the wait timed out.
-    public func lock(whenValue wantedValue: T, timeoutSeconds: Double) -> Bool {
-        precondition(timeoutSeconds >= 0)
-
-        #if os(Windows)
-        var dwMilliseconds: DWORD = DWORD(timeoutSeconds * 1000)
-
-        self.lock()
-        while true {
-            if self._value == wantedValue {
-                return true
-            }
-
-            let dwWaitStart = timeGetTime()
-            let result = self.mutex.withLockPrimitive { mutex in
-                SleepConditionVariableSRW(self.cond, mutex, dwMilliseconds, 0)
-            }
-            if !result {
-                let dwError = GetLastError()
-                if dwError == ERROR_TIMEOUT {
-                    self.unlock()
-                    return false
-                }
-                fatalError("SleepConditionVariableSRW: \(dwError)")
-            }
-            // NOTE: this may be a spurious wakeup, adjust the timeout accordingly
-            dwMilliseconds = dwMilliseconds - (timeGetTime() - dwWaitStart)
-        }
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let nsecPerSec: Int64 = 1_000_000_000
-        self.lock()
-        // the timeout as a (seconds, nano seconds) pair
-        let timeoutNS = Int64(timeoutSeconds * Double(nsecPerSec))
-
-        var curTime = timeval()
-        gettimeofday(&curTime, nil)
-
-        let allNSecs: Int64 = timeoutNS + Int64(curTime.tv_usec) * 1000
-        #if canImport(wasi_pthread)
-        let tvSec = curTime.tv_sec + (allNSecs / nsecPerSec)
-        #else
-        let tvSec = curTime.tv_sec + Int((allNSecs / nsecPerSec))
-        #endif
-
-        var timeoutAbs = timespec(
-            tv_sec: tvSec,
-            tv_nsec: Int(allNSecs % nsecPerSec)
-        )
-        assert(timeoutAbs.tv_nsec >= 0 && timeoutAbs.tv_nsec < Int(nsecPerSec))
-        assert(timeoutAbs.tv_sec >= curTime.tv_sec)
-        return self.mutex.withLockPrimitive { mutex -> Bool in
-            while true {
-                if self._value == wantedValue {
-                    return true
-                }
-                switch pthread_cond_timedwait(self.cond, mutex, &timeoutAbs) {
-                case 0:
-                    continue
-                case ETIMEDOUT:
-                    self.unlock()
-                    return false
-                case let e:
-                    fatalError("caught error \(e) when calling pthread_cond_timedwait")
-                }
-            }
-        }
-        #else
-        return true
-        #endif
-    }
-
-    /// Release the lock, setting the state variable to `newValue`.
-    ///
-    /// - Parameter newValue: The value to give to the state variable when we
-    ///     release the lock.
-    public func unlock(withValue newValue: T) {
-        self._value = newValue
-        self.unlock()
-        #if os(Windows)
-        WakeAllConditionVariable(self.cond)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_cond_broadcast(self.cond)
-        precondition(err == 0, "\(#function) failed in pthread_cond with error \(err)")
-        #endif
+extension UnsafeMutablePointer {
+    @inlinable
+    func assertValidAlignment() {
+        assert(UInt(bitPattern: self) % UInt(MemoryLayout<Pointee>.alignment) == 0)
     }
 }
-
-/// A utility function that runs the body code only in debug builds, without
-/// emitting compiler warnings.
-///
-/// This is currently the only way to do this in Swift: see
-/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
-@inlinable
-internal func debugOnly(_ body: () -> Void) {
-    assert(
-        {
-            body()
-            return true
-        }()
-    )
-}
-
-@available(*, deprecated)
-extension Lock: @unchecked Sendable {}
-extension ConditionLock: @unchecked Sendable {}

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -249,13 +249,13 @@ final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
-public struct NIOLock {
+internal struct NIOLock {
     @usableFromInline
     internal let _storage: LockStorage<Void>
 
     /// Create a new lock.
     @inlinable
-    public init() {
+    init() {
         self._storage = .create(value: ())
     }
 
@@ -264,7 +264,7 @@ public struct NIOLock {
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `unlock`, to simplify lock handling.
     @inlinable
-    public func lock() {
+    func lock() {
         self._storage.lock()
     }
 
@@ -273,7 +273,7 @@ public struct NIOLock {
     /// Whenever possible, consider using `withLock` instead of this method and
     /// `lock`, to simplify lock handling.
     @inlinable
-    public func unlock() {
+    func unlock() {
         self._storage.unlock()
     }
 
@@ -293,7 +293,7 @@ extension NIOLock {
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
     @inlinable
-    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lock()
         defer {
             self.unlock()
@@ -302,7 +302,7 @@ extension NIOLock {
     }
 
     @inlinable
-    public func withLockVoid(_ body: () throws -> Void) rethrows {
+    func withLockVoid(_ body: () throws -> Void) rethrows {
         try self.withLock(body)
     }
 }
@@ -314,4 +314,19 @@ extension UnsafeMutablePointer {
     func assertValidAlignment() {
         assert(UInt(bitPattern: self) % UInt(MemoryLayout<Pointee>.alignment) == 0)
     }
+}
+
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
+@inlinable
+internal func debugOnly(_ body: () -> Void) {
+    assert(
+        {
+            body()
+            return true
+        }()
+    )
 }

--- a/Sources/ArgumentParser/Utilities/Mutex.swift
+++ b/Sources/ArgumentParser/Utilities/Mutex.swift
@@ -9,6 +9,29 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Synchronization)
+import Synchronization
+
+/// A synchronization primitive that protects shared mutable state via mutual
+/// exclusion.
+///
+/// The `Mutex` type offers non-recursive exclusive access to the state it is
+/// protecting by blocking threads attempting to acquire the lock. Only one
+/// execution context at a time has access to the value stored within the
+/// `Mutex` allowing for exclusive access.
+class Mutex<T>: @unchecked Sendable {
+  private let mutex: Synchronization.Mutex<T>
+
+  init(_ value: sending T) {
+    self.mutex = .init(value)
+  }
+
+  func withLock<U>(_ body: (inout sending T) throws -> sending U) rethrows -> sending U {
+    try mutex.withLock(body)
+  }
+}
+#else
+import Foundation
 /// A synchronization primitive that protects shared mutable state via mutual
 /// exclusion.
 ///
@@ -18,7 +41,7 @@
 /// `Mutex` allowing for exclusive access.
 class Mutex<T>: @unchecked Sendable {
   /// The lock used to synchronize access to the value.
-  var lock: NIOLock
+  var lock: NSLock
   /// The value protected by the mutex.
   var value: T
 
@@ -52,281 +75,4 @@ class Mutex<T>: @unchecked Sendable {
     return try body(&self.value)
   }
 }
-
-
-//===----------------------------------------------------------------------===//
-//
-// This source file is part of the SwiftNIO open source project
-//
-// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
-// Licensed under Apache License v2.0
-//
-// See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-//===----------------------------------------------------------------------===//
-
-#if canImport(Darwin)
-import Darwin
-#elseif os(Windows)
-import ucrt
-import WinSDK
-#elseif canImport(Glibc)
-import Glibc
-#elseif canImport(Musl)
-import Musl
-#elseif canImport(Bionic)
-import Bionic
-#elseif canImport(WASILibc)
-import WASILibc
-#if canImport(wasi_pthread)
-import wasi_pthread
 #endif
-#else
-#error("The concurrency NIOLock module was unable to identify your C library.")
-#endif
-
-#if os(Windows)
-@usableFromInline
-typealias LockPrimitive = SRWLOCK
-#else
-@usableFromInline
-typealias LockPrimitive = pthread_mutex_t
-#endif
-
-@usableFromInline
-enum LockOperations {}
-
-extension LockOperations {
-    @inlinable
-    static func create(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
-        mutex.assertValidAlignment()
-
-        #if os(Windows)
-        InitializeSRWLock(mutex)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        var attr = pthread_mutexattr_t()
-        pthread_mutexattr_init(&attr)
-        debugOnly {
-            pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
-        }
-
-        let err = pthread_mutex_init(mutex, &attr)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
-    }
-
-    @inlinable
-    static func destroy(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
-        mutex.assertValidAlignment()
-
-        #if os(Windows)
-        // SRWLOCK does not need to be free'd
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_destroy(mutex)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
-    }
-
-    @inlinable
-    static func lock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
-        mutex.assertValidAlignment()
-
-        #if os(Windows)
-        AcquireSRWLockExclusive(mutex)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_lock(mutex)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
-    }
-
-    @inlinable
-    static func unlock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
-        mutex.assertValidAlignment()
-
-        #if os(Windows)
-        ReleaseSRWLockExclusive(mutex)
-        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
-        let err = pthread_mutex_unlock(mutex)
-        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
-    }
-}
-
-// Tail allocate both the mutex and a generic value using ManagedBuffer.
-// Both the header pointer and the elements pointer are stable for
-// the class's entire lifetime.
-//
-// However, for safety reasons, we elect to place the lock in the "elements"
-// section of the buffer instead of the head. The reasoning here is subtle,
-// so buckle in.
-//
-// _As a practical matter_, the implementation of ManagedBuffer ensures that
-// the pointer to the header is stable across the lifetime of the class, and so
-// each time you call `withUnsafeMutablePointers` or `withUnsafeMutablePointerToHeader`
-// the value of the header pointer will be the same. This is because ManagedBuffer uses
-// `Builtin.addressOf` to load the value of the header, and that does ~magic~ to ensure
-// that it does not invoke any weird Swift accessors that might copy the value.
-//
-// _However_, the header is also available via the `.header` field on the ManagedBuffer.
-// This presents a problem! The reason there's an issue is that `Builtin.addressOf` and friends
-// do not interact with Swift's exclusivity model. That is, the various `with` functions do not
-// conceptually trigger a mutating access to `.header`. For elements this isn't a concern because
-// there's literally no other way to perform the access, but for `.header` it's entirely possible
-// to accidentally recursively read it.
-//
-// Our implementation is free from these issues, so we don't _really_ need to worry about it.
-// However, out of an abundance of caution, we store the Value in the header, and the LockPrimitive
-// in the trailing elements. We still don't use `.header`, but it's better to be safe than sorry,
-// and future maintainers will be happier that we were cautious.
-//
-// See also: https://github.com/apple/swift/pull/40000
-@usableFromInline
-final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
-
-    @inlinable
-    static func create(value: Value) -> Self {
-        let buffer = Self.create(minimumCapacity: 1) { _ in
-            value
-        }
-        // Intentionally using a force cast here to avoid a miss compiliation in 5.10.
-        // This is as fast as an unsafeDownCast since ManagedBuffer is inlined and the optimizer
-        // can eliminate the upcast/downcast pair
-        let storage = buffer as! Self
-
-        storage.withUnsafeMutablePointers { _, lockPtr in
-            LockOperations.create(lockPtr)
-        }
-
-        return storage
-    }
-
-    @inlinable
-    func lock() {
-        self.withUnsafeMutablePointerToElements { lockPtr in
-            LockOperations.lock(lockPtr)
-        }
-    }
-
-    @inlinable
-    func unlock() {
-        self.withUnsafeMutablePointerToElements { lockPtr in
-            LockOperations.unlock(lockPtr)
-        }
-    }
-
-    @inlinable
-    deinit {
-        self.withUnsafeMutablePointerToElements { lockPtr in
-            LockOperations.destroy(lockPtr)
-        }
-    }
-
-    @inlinable
-    func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
-        try self.withUnsafeMutablePointerToElements { lockPtr in
-            try body(lockPtr)
-        }
-    }
-
-    @inlinable
-    func withLockedValue<T>(_ mutate: (inout Value) throws -> T) rethrows -> T {
-        try self.withUnsafeMutablePointers { valuePtr, lockPtr in
-            LockOperations.lock(lockPtr)
-            defer { LockOperations.unlock(lockPtr) }
-            return try mutate(&valuePtr.pointee)
-        }
-    }
-}
-
-/// A threading lock based on `libpthread` instead of `libdispatch`.
-///
-/// - Note: ``NIOLock`` has reference semantics.
-///
-/// This object provides a lock on top of a single `pthread_mutex_t`. This kind
-/// of lock is safe to use with `libpthread`-based threading models, such as the
-/// one used by NIO. On Windows, the lock is based on the substantially similar
-/// `SRWLOCK` type.
-internal struct NIOLock {
-    @usableFromInline
-    internal let _storage: LockStorage<Void>
-
-    /// Create a new lock.
-    @inlinable
-    init() {
-        self._storage = .create(value: ())
-    }
-
-    /// Acquire the lock.
-    ///
-    /// Whenever possible, consider using `withLock` instead of this method and
-    /// `unlock`, to simplify lock handling.
-    @inlinable
-    func lock() {
-        self._storage.lock()
-    }
-
-    /// Release the lock.
-    ///
-    /// Whenever possible, consider using `withLock` instead of this method and
-    /// `lock`, to simplify lock handling.
-    @inlinable
-    func unlock() {
-        self._storage.unlock()
-    }
-
-    @inlinable
-    internal func withLockPrimitive<T>(_ body: (UnsafeMutablePointer<LockPrimitive>) throws -> T) rethrows -> T {
-        try self._storage.withLockPrimitive(body)
-    }
-}
-
-extension NIOLock {
-    /// Acquire the lock for the duration of the given block.
-    ///
-    /// This convenience method should be preferred to `lock` and `unlock` in
-    /// most situations, as it ensures that the lock will be released regardless
-    /// of how `body` exits.
-    ///
-    /// - Parameter body: The block to execute while holding the lock.
-    /// - Returns: The value returned by the block.
-    @inlinable
-    func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        self.lock()
-        defer {
-            self.unlock()
-        }
-        return try body()
-    }
-
-    @inlinable
-    func withLockVoid(_ body: () throws -> Void) rethrows {
-        try self.withLock(body)
-    }
-}
-
-extension NIOLock: @unchecked Sendable {}
-
-extension UnsafeMutablePointer {
-    @inlinable
-    func assertValidAlignment() {
-        assert(UInt(bitPattern: self) % UInt(MemoryLayout<Pointee>.alignment) == 0)
-    }
-}
-
-/// A utility function that runs the body code only in debug builds, without
-/// emitting compiler warnings.
-///
-/// This is currently the only way to do this in Swift: see
-/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
-@inlinable
-internal func debugOnly(_ body: () -> Void) {
-    assert(
-        {
-            body()
-            return true
-        }()
-    )
-}

--- a/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
+++ b/Tests/ArgumentParserUnitTests/ExitCodeTests.swift
@@ -83,7 +83,10 @@ extension ExitCodeTests {
 // MARK: - NSError tests
 
 extension ExitCodeTests {
-  func testNSErrorIsHandled() {
+  func testNSErrorIsHandled() throws{
+    #if canImport(FoundationEssentials)
+    throw XCTSkip("FoundationEssentials doesn't have NSError")
+    #else
     struct NSErrorCommand: ParsableCommand {
       static let fileNotFoundNSError = NSError(
         domain: "", code: 1,
@@ -98,5 +101,6 @@ extension ExitCodeTests {
     XCTAssertEqual(
       NSErrorCommand.message(for: NSErrorCommand.fileNotFoundNSError),
       "The file “foo/bar” couldn’t be opened because there is no such file")
+    #endif
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This is a new attempt similar to #674 to only use `FoundationEssentials` if it is available. It should address #748.

To enable the usage of only `FoundationEssentials` some API usage was replaced with either API from the StdLib (eg. `replaceOccurances` -> `replace`).

Instead of using `range(_)` method, we use the `_range(_)` message pulled from `swift-foundation` itself.

However, to make `Mutex<T>` work without `NSLock`, I pulled in `NIOLock` from `swift-nio`. Unfortunately, I did not find a nice way to make it work with `Synchronization.Mutex` instead.

Tests pass on swift 5.7 to 6.0 on linux.
