### PR TITLE
[GenerateDocCReference] Improve filtering and categorization of arguments in documentation with sectionTitle

### DIFF
--- a/Sources/ArgumentParserToolInfo/ToolInfo.swift
+++ b/Sources/ArgumentParserToolInfo/ToolInfo.swift
@@ -218,7 +218,23 @@ public struct ArgumentInfoV0: Codable, Hashable {
     self.kind = kind
 
     self.shouldDisplay = shouldDisplay
-    self.sectionTitle = sectionTitle
+
+    // The section title helps categorize arguments
+    // for better organization in documentation.
+
+    // The switch statement checks the kind of argument
+    // and assigns a default section title related to the argument type
+    // if the provided one is nil.
+    switch kind {
+    case .positional:
+      self.sectionTitle = sectionTitle ?? "Arguments"
+
+    case .option:
+      self.sectionTitle = sectionTitle ?? "Optionals"
+
+    case .flag:
+      self.sectionTitle = sectionTitle ?? "Flags"
+    }
 
     self.isOptional = isOptional
     self.isRepeating = isRepeating

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
@@ -6,22 +6,28 @@
 color --fav=<fav> [--second=<second>] [--help]
 ```
 
-**--fav=\<fav\>:**
+## Flags
+
+**`--help`**
+
+*Show help information.*
+
+
+## Optionals
+
+**`--fav=\<fav\>`**
 
 *Your favorite color.*
 
 
-**--second=\<second\>:**
+**`--second=\<second\>`**
 
 *Your second favorite color.*
 
 This is optional.
 
 
-**--help:**
-
-*Show help information.*
-
+## Subcommands
 
 ## color.help
 
@@ -31,9 +37,6 @@ Show subcommand help information.
 color help [<subcommands>...] 
 ```
 
-**subcommands:**
+## Arguments
 
-
-
-
-
+**`subcommands`**

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
@@ -6,25 +6,33 @@
 count-lines [<input-file>] [--prefix=<prefix>] [--verbose] [--help]
 ```
 
-**input-file:**
+## Arguments
+
+**`input-file`**
 
 *A file to count lines in. If omitted, counts the lines of stdin.*
 
 
-**--prefix=\<prefix\>:**
+## Flags
 
-*Only count lines with this prefix.*
-
-
-**--verbose:**
+**`--verbose`**
 
 *Include extra information in the output.*
 
 
-**--help:**
+**`--help`**
 
 *Show help information.*
 
+
+## Optionals
+
+**`--prefix=\<prefix\>`**
+
+*Only count lines with this prefix.*
+
+
+## Subcommands
 
 ## count-lines.help
 
@@ -34,9 +42,6 @@ Show subcommand help information.
 count-lines help [<subcommands>...] 
 ```
 
-**subcommands:**
+## Arguments
 
-
-
-
-
+**`subcommands`**

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
@@ -8,15 +8,19 @@ A utility for performing maths.
 math [--version] [--help]
 ```
 
-**--version:**
+## Flags
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
 *Show help information.*
 
+
+## Subcommands
 
 ## math.add
 
@@ -26,29 +30,28 @@ Print the sum of the values.
 math add [--hex-output] [<values>...] [--version] [--help]
 ```
 
-**--hex-output:**
+## Arguments
 
-*Use hexadecimal notation for the result.*
-
-
-**values:**
+**`values`**
 
 *A group of integers to operate on.*
 
 
-**--version:**
+## Flags
+
+**`--hex-output`**
+
+*Use hexadecimal notation for the result.*
+
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
-*Show help information.*
-
-
-
-
-## math.multiply
+*Show help information.*## math.multiply
 
 Print the product of the values.
 
@@ -56,29 +59,28 @@ Print the product of the values.
 math multiply [--hex-output] [<values>...] [--version] [--help]
 ```
 
-**--hex-output:**
+## Arguments
 
-*Use hexadecimal notation for the result.*
-
-
-**values:**
+**`values`**
 
 *A group of integers to operate on.*
 
 
-**--version:**
+## Flags
+
+**`--hex-output`**
+
+*Use hexadecimal notation for the result.*
+
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
-*Show help information.*
-
-
-
-
-## math.stats
+*Show help information.*## math.stats
 
 Calculate descriptive statistics.
 
@@ -86,15 +88,19 @@ Calculate descriptive statistics.
 math stats [--version] [--help]
 ```
 
-**--version:**
+## Flags
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
 *Show help information.*
 
+
+## Subcommands
 
 ### math.stats.average
 
@@ -104,29 +110,30 @@ Print the average of the values.
 math stats average [--kind=<kind>] [<values>...] [--version] [--help]
 ```
 
-**--kind=\<kind\>:**
+## Arguments
 
-*The kind of average to provide.*
-
-
-**values:**
+**`values`**
 
 *A group of floating-point values to operate on.*
 
 
-**--version:**
+## Flags
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
 *Show help information.*
 
 
+## Optionals
 
+**`--kind=\<kind\>`**
 
-### math.stats.stdev
+*The kind of average to provide.*### math.stats.stdev
 
 Print the standard deviation of the values.
 
@@ -134,24 +141,23 @@ Print the standard deviation of the values.
 math stats stdev [<values>...] [--version] [--help]
 ```
 
-**values:**
+## Arguments
+
+**`values`**
 
 *A group of floating-point values to operate on.*
 
 
-**--version:**
+## Flags
+
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
-*Show help information.*
-
-
-
-
-### math.stats.quantiles
+*Show help information.*### math.stats.quantiles
 
 Print the quantiles of the values (TBD).
 
@@ -159,44 +165,43 @@ Print the quantiles of the values (TBD).
 math stats quantiles [<one-of-four>] [<custom-arg>] [<values>...]     [--file=<file>] [--directory=<directory>] [--shell=<shell>] [--custom=<custom>] [--version] [--help]
 ```
 
-**one-of-four:**
+## Arguments
+
+**`one-of-four`**
 
 
-**custom-arg:**
+**`custom-arg`**
 
 
-**values:**
+**`values`**
 
 *A group of floating-point values to operate on.*
 
 
-**--file=\<file\>:**
+## Flags
 
-
-**--directory=\<directory\>:**
-
-
-**--shell=\<shell\>:**
-
-
-**--custom=\<custom\>:**
-
-
-**--version:**
+**`--version`**
 
 *Show the version.*
 
 
-**--help:**
+**`--help`**
 
 *Show help information.*
 
 
+## Optionals
+
+**`--file=\<file\>`**
 
 
+**`--directory=\<directory\>`**
 
 
-## math.help
+**`--shell=\<shell\>`**
+
+
+**`--custom=\<custom\>`**## math.help
 
 Show subcommand help information.
 
@@ -204,9 +209,6 @@ Show subcommand help information.
 math help [<subcommands>...] 
 ```
 
-**subcommands:**
+## Arguments
 
-
-
-
-
+**`subcommands`**

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
@@ -6,25 +6,33 @@
 repeat [--count=<count>] [--include-counter] <phrase> [--help]
 ```
 
-**--count=\<count\>:**
+## Arguments
 
-*The number of times to repeat 'phrase'.*
-
-
-**--include-counter:**
-
-*Include a counter with each repetition.*
-
-
-**phrase:**
+**`phrase`**
 
 *The phrase to repeat.*
 
 
-**--help:**
+## Flags
+
+**`--include-counter`**
+
+*Include a counter with each repetition.*
+
+
+**`--help`**
 
 *Show help information.*
 
+
+## Optionals
+
+**`--count=\<count\>`**
+
+*The number of times to repeat 'phrase'.*
+
+
+## Subcommands
 
 ## repeat.help
 
@@ -34,9 +42,6 @@ Show subcommand help information.
 repeat help [<subcommands>...] 
 ```
 
-**subcommands:**
+## Arguments
 
-
-
-
-
+**`subcommands`**

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
@@ -6,32 +6,38 @@
 roll [--times=<n>] [--sides=<m>] [--seed=<seed>] [--verbose] [--help]
 ```
 
-**--times=\<n\>:**
+## Flags
+
+**`--verbose`**
+
+*Show all roll results.*
+
+
+**`--help`**
+
+*Show help information.*
+
+
+## Optionals
+
+**`--times=\<n\>`**
 
 *Rolls the dice <n> times.*
 
 
-**--sides=\<m\>:**
+**`--sides=\<m\>`**
 
 *Rolls an <m>-sided dice.*
 
 Use this option to override the default value of a six-sided die.
 
 
-**--seed=\<seed\>:**
+**`--seed=\<seed\>`**
 
 *A seed to use for repeatable random generation.*
 
 
-**--verbose:**
-
-*Show all roll results.*
-
-
-**--help:**
-
-*Show help information.*
-
+## Subcommands
 
 ## roll.help
 
@@ -41,9 +47,6 @@ Show subcommand help information.
 roll help [<subcommands>...] 
 ```
 
-**subcommands:**
+## Arguments
 
-
-
-
-
+**`subcommands`**

--- a/Tests/ArgumentParserUnitTests/Snapshots/testADumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testADumpHelp().json
@@ -29,6 +29,7 @@
           "kind" : "long",
           "name" : "enumerated-option"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "enumerated-option"
       },
@@ -61,6 +62,7 @@
           "kind" : "long",
           "name" : "enumerated-option-with-default-value"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "enumerated-option-with-default-value"
       },
@@ -78,6 +80,7 @@
           "kind" : "long",
           "name" : "no-help-option"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "no-help-option"
       },
@@ -96,6 +99,7 @@
           "kind" : "long",
           "name" : "int-option"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "int-option"
       },
@@ -115,6 +119,7 @@
           "kind" : "long",
           "name" : "int-option-with-default-value"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "int-option-with-default-value"
       },
@@ -122,6 +127,7 @@
         "isOptional" : false,
         "isRepeating" : false,
         "kind" : "positional",
+        "sectionTitle" : "Arguments",
         "shouldDisplay" : true,
         "valueName" : "arg"
       },
@@ -130,6 +136,7 @@
         "isOptional" : false,
         "isRepeating" : false,
         "kind" : "positional",
+        "sectionTitle" : "Arguments",
         "shouldDisplay" : true,
         "valueName" : "arg-with-help"
       },
@@ -139,6 +146,7 @@
         "isOptional" : true,
         "isRepeating" : false,
         "kind" : "positional",
+        "sectionTitle" : "Arguments",
         "shouldDisplay" : true,
         "valueName" : "arg-with-default-value"
       },
@@ -161,6 +169,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -175,6 +184,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -200,6 +210,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBDumpHelp().json
@@ -56,6 +56,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -70,6 +71,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -95,6 +97,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testCDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testCDumpHelp().json
@@ -35,6 +35,7 @@
           "kind" : "long",
           "name" : "color"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "color"
       },
@@ -73,6 +74,7 @@
           "kind" : "long",
           "name" : "default-color"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "default-color"
       },
@@ -110,6 +112,7 @@
           "kind" : "long",
           "name" : "opt"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "opt"
       },
@@ -147,6 +150,7 @@
           "kind" : "long",
           "name" : "extra"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "extra"
       },
@@ -165,6 +169,7 @@
           "kind" : "long",
           "name" : "discussion"
         },
+        "sectionTitle" : "Optionals",
         "shouldDisplay" : true,
         "valueName" : "discussion"
       },
@@ -187,6 +192,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -201,6 +207,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -226,6 +233,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathAddDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathAddDumpHelp().json
@@ -21,6 +21,7 @@
           "kind" : "long",
           "name" : "hex-output"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "hex-output"
       },
@@ -29,6 +30,7 @@
         "isOptional" : true,
         "isRepeating" : true,
         "kind" : "positional",
+        "sectionTitle" : "Arguments",
         "shouldDisplay" : true,
         "valueName" : "values"
       },
@@ -47,6 +49,7 @@
           "kind" : "long",
           "name" : "version"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "version"
       },
@@ -69,6 +72,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -83,6 +87,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -108,6 +113,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathDumpHelp().json
@@ -17,6 +17,7 @@
           "kind" : "long",
           "name" : "version"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "version"
       },
@@ -39,6 +40,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -68,6 +70,7 @@
               "kind" : "long",
               "name" : "hex-output"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "hex-output"
           },
@@ -76,6 +79,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "values"
           },
@@ -94,6 +98,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -116,6 +121,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -148,6 +154,7 @@
               "kind" : "long",
               "name" : "hex-output"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "hex-output"
           },
@@ -156,6 +163,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "values"
           },
@@ -174,6 +182,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -196,6 +205,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -224,6 +234,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -246,6 +257,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -286,6 +298,7 @@
                   "kind" : "long",
                   "name" : "kind"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : true,
                 "valueName" : "kind"
               },
@@ -294,6 +307,7 @@
                 "isOptional" : true,
                 "isRepeating" : true,
                 "kind" : "positional",
+                "sectionTitle" : "Arguments",
                 "shouldDisplay" : true,
                 "valueName" : "values"
               },
@@ -312,6 +326,7 @@
                   "kind" : "long",
                   "name" : "version"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "version"
               },
@@ -334,6 +349,7 @@
                   "kind" : "long",
                   "name" : "help"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "help"
               }
@@ -353,6 +369,7 @@
                 "isOptional" : true,
                 "isRepeating" : true,
                 "kind" : "positional",
+                "sectionTitle" : "Arguments",
                 "shouldDisplay" : true,
                 "valueName" : "values"
               },
@@ -371,6 +388,7 @@
                   "kind" : "long",
                   "name" : "version"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "version"
               },
@@ -393,6 +411,7 @@
                   "kind" : "long",
                   "name" : "help"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "help"
               }
@@ -421,6 +440,7 @@
                 "isOptional" : true,
                 "isRepeating" : false,
                 "kind" : "positional",
+                "sectionTitle" : "Arguments",
                 "shouldDisplay" : true,
                 "valueName" : "one-of-four"
               },
@@ -433,6 +453,7 @@
                 "isOptional" : true,
                 "isRepeating" : false,
                 "kind" : "positional",
+                "sectionTitle" : "Arguments",
                 "shouldDisplay" : true,
                 "valueName" : "custom-arg"
               },
@@ -441,6 +462,7 @@
                 "isOptional" : true,
                 "isRepeating" : true,
                 "kind" : "positional",
+                "sectionTitle" : "Arguments",
                 "shouldDisplay" : true,
                 "valueName" : "values"
               },
@@ -458,6 +480,7 @@
                   "kind" : "long",
                   "name" : "test-success-exit-code"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : false,
                 "valueName" : "test-success-exit-code"
               },
@@ -475,6 +498,7 @@
                   "kind" : "long",
                   "name" : "test-failure-exit-code"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : false,
                 "valueName" : "test-failure-exit-code"
               },
@@ -492,6 +516,7 @@
                   "kind" : "long",
                   "name" : "test-validation-exit-code"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : false,
                 "valueName" : "test-validation-exit-code"
               },
@@ -509,6 +534,7 @@
                   "kind" : "long",
                   "name" : "test-custom-exit-code"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : false,
                 "valueName" : "test-custom-exit-code"
               },
@@ -534,6 +560,7 @@
                   "kind" : "long",
                   "name" : "file"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : true,
                 "valueName" : "file"
               },
@@ -556,6 +583,7 @@
                   "kind" : "long",
                   "name" : "directory"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : true,
                 "valueName" : "directory"
               },
@@ -578,6 +606,7 @@
                   "kind" : "long",
                   "name" : "shell"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : true,
                 "valueName" : "shell"
               },
@@ -600,6 +629,7 @@
                   "kind" : "long",
                   "name" : "custom"
                 },
+                "sectionTitle" : "Optionals",
                 "shouldDisplay" : true,
                 "valueName" : "custom"
               },
@@ -618,6 +648,7 @@
                   "kind" : "long",
                   "name" : "version"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "version"
               },
@@ -640,6 +671,7 @@
                   "kind" : "long",
                   "name" : "help"
                 },
+                "sectionTitle" : "Flags",
                 "shouldDisplay" : true,
                 "valueName" : "help"
               }
@@ -663,6 +695,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -688,6 +721,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathMultiplyDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathMultiplyDumpHelp().json
@@ -21,6 +21,7 @@
           "kind" : "long",
           "name" : "hex-output"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "hex-output"
       },
@@ -29,6 +30,7 @@
         "isOptional" : true,
         "isRepeating" : true,
         "kind" : "positional",
+        "sectionTitle" : "Arguments",
         "shouldDisplay" : true,
         "valueName" : "values"
       },
@@ -47,6 +49,7 @@
           "kind" : "long",
           "name" : "version"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "version"
       },
@@ -69,6 +72,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -83,6 +87,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -108,6 +113,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathStatsDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathStatsDumpHelp().json
@@ -17,6 +17,7 @@
           "kind" : "long",
           "name" : "version"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "version"
       },
@@ -39,6 +40,7 @@
           "kind" : "long",
           "name" : "help"
         },
+        "sectionTitle" : "Flags",
         "shouldDisplay" : true,
         "valueName" : "help"
       }
@@ -79,6 +81,7 @@
               "kind" : "long",
               "name" : "kind"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : true,
             "valueName" : "kind"
           },
@@ -87,6 +90,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "values"
           },
@@ -105,6 +109,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -127,6 +132,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -146,6 +152,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "values"
           },
@@ -164,6 +171,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -186,6 +194,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -214,6 +223,7 @@
             "isOptional" : true,
             "isRepeating" : false,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "one-of-four"
           },
@@ -226,6 +236,7 @@
             "isOptional" : true,
             "isRepeating" : false,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "custom-arg"
           },
@@ -234,6 +245,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "values"
           },
@@ -251,6 +263,7 @@
               "kind" : "long",
               "name" : "test-success-exit-code"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "test-success-exit-code"
           },
@@ -268,6 +281,7 @@
               "kind" : "long",
               "name" : "test-failure-exit-code"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "test-failure-exit-code"
           },
@@ -285,6 +299,7 @@
               "kind" : "long",
               "name" : "test-validation-exit-code"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "test-validation-exit-code"
           },
@@ -302,6 +317,7 @@
               "kind" : "long",
               "name" : "test-custom-exit-code"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : false,
             "valueName" : "test-custom-exit-code"
           },
@@ -327,6 +343,7 @@
               "kind" : "long",
               "name" : "file"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : true,
             "valueName" : "file"
           },
@@ -349,6 +366,7 @@
               "kind" : "long",
               "name" : "directory"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : true,
             "valueName" : "directory"
           },
@@ -371,6 +389,7 @@
               "kind" : "long",
               "name" : "shell"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : true,
             "valueName" : "shell"
           },
@@ -393,6 +412,7 @@
               "kind" : "long",
               "name" : "custom"
             },
+            "sectionTitle" : "Optionals",
             "shouldDisplay" : true,
             "valueName" : "custom"
           },
@@ -411,6 +431,7 @@
               "kind" : "long",
               "name" : "version"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "version"
           },
@@ -433,6 +454,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : true,
             "valueName" : "help"
           }
@@ -451,6 +473,7 @@
             "isOptional" : true,
             "isRepeating" : true,
             "kind" : "positional",
+            "sectionTitle" : "Arguments",
             "shouldDisplay" : true,
             "valueName" : "subcommands"
           },
@@ -476,6 +499,7 @@
               "kind" : "long",
               "name" : "help"
             },
+            "sectionTitle" : "Flags",
             "shouldDisplay" : false,
             "valueName" : "help"
           }


### PR DESCRIPTION
### Summary
The recent modifications improve the readability and structure of documents generated using the **GenerateDocC** plugin. This update addresses https://github.com/apple/swift-argument-parser/issues/722 by enhancing how arguments are categorized within sections using the sectionTitle property. 

Now, arguments—including required arguments, optionals, and flags—are grouped under their respective **sectionTitles** based on their type. Since **sectionTitle** is an optional value, some arguments may not have one explicitly provided. To handle this, we introduced logic that assigns a default section when no custom **sectionTitle** is specified. These default sections are:  

- **Arguments** – for required arguments  
- **Options** – for optional values  
- **Flags** – for boolean flags  

Each argument is placed under its corresponding section based on its type. This ensures a well-structured and organized documentation format while allowing users to define their own custom **sectionTitles** when needed.

### Changes

- Listing arguments under custom sectionTitles
  - If a custom sectionTitle is provided, arguments are correctly grouped under it.
- Default section titles for missing values
  - When no custom sectionTitle is given, arguments are automatically grouped based on their type:
      - Positional arguments → "Arguments"
      - Options → "Options"
      - Flags → "Flags"

- Better argument categorization and organization
   - Arguments are now properly grouped and listed under designated sections.
   - Ensures all arguments appear under an appropriate category, whether a custom or default sectionTitle is provided.

- Fixed missing dash in argument output
   - The previous method incorrectly displayed arguments like -option instead of --option.
   - Now, options are displayed correctly with a double dash (--option) by wrapping the argument in (‘’)

- Updated unit tests and snapshot recordings

   - Re-ran and updated snapshot tests for:
      - Documentation snapshots
      - Dump help snapshots

   - Since section titles now have default values, output consistency has been verified.

- Subcommands now have their own category
   - Ensured subcommands are listed under a dedicated section to maintain consistency across all argument categories.

(Closes https://github.com/apple/swift-argument-parser/issues/722)"

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
