### PR TITLE
fixes misformating of docc term list output

### DIFF
--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
@@ -6,19 +6,19 @@
 color --fav=<fav> [--second=<second>] [--help]
 ```
 
-- term **--fav=\<fav\>:**
+- term **--fav=\<fav\>**:
 
 *Your favorite color.*
 
 
-- term **--second=\<second\>:**
+- term **--second=\<second\>**:
 
 *Your second favorite color.*
 
 This is optional.
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -31,7 +31,7 @@ Show subcommand help information.
 color help [<subcommands>...] 
 ```
 
-- term **subcommands:**
+- term **subcommands**:
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
@@ -6,22 +6,22 @@
 count-lines [<input-file>] [--prefix=<prefix>] [--verbose] [--help]
 ```
 
-- term **input-file:**
+- term **input-file**:
 
 *A file to count lines in. If omitted, counts the lines of stdin.*
 
 
-- term **--prefix=\<prefix\>:**
+- term **--prefix=\<prefix\>**:
 
 *Only count lines with this prefix.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Include extra information in the output.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -34,7 +34,7 @@ Show subcommand help information.
 count-lines help [<subcommands>...] 
 ```
 
-- term **subcommands:**
+- term **subcommands**:
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
@@ -8,12 +8,12 @@ A utility for performing maths.
 math [--version] [--help]
 ```
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -26,22 +26,22 @@ Print the sum of the values.
 math add [--hex-output] [<values>...] [--version] [--help]
 ```
 
-- term **--hex-output:**
+- term **--hex-output**:
 
 *Use hexadecimal notation for the result.*
 
 
-- term **values:**
+- term **values**:
 
 *A group of integers to operate on.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -56,22 +56,22 @@ Print the product of the values.
 math multiply [--hex-output] [<values>...] [--version] [--help]
 ```
 
-- term **--hex-output:**
+- term **--hex-output**:
 
 *Use hexadecimal notation for the result.*
 
 
-- term **values:**
+- term **values**:
 
 *A group of integers to operate on.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -86,12 +86,12 @@ Calculate descriptive statistics.
 math stats [--version] [--help]
 ```
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -104,22 +104,22 @@ Print the average of the values.
 math stats average [--kind=<kind>] [<values>...] [--version] [--help]
 ```
 
-- term **--kind=\<kind\>:**
+- term **--kind=\<kind\>**:
 
 *The kind of average to provide.*
 
 
-- term **values:**
+- term **values**:
 
 *A group of floating-point values to operate on.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -134,17 +134,17 @@ Print the standard deviation of the values.
 math stats stdev [<values>...] [--version] [--help]
 ```
 
-- term **values:**
+- term **values**:
 
 *A group of floating-point values to operate on.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -159,41 +159,41 @@ Print the quantiles of the values (TBD).
 math stats quantiles [<one-of-four>] [<custom-arg>] [<custom-deprecated-arg>] [<values>...]     [--file=<file>] [--directory=<directory>] [--shell=<shell>] [--custom=<custom>] [--custom-deprecated=<custom-deprecated>] [--version] [--help]
 ```
 
-- term **one-of-four:**
+- term **one-of-four**:
 
 
-- term **custom-arg:**
+- term **custom-arg**:
 
 
-- term **custom-deprecated-arg:**
+- term **custom-deprecated-arg**:
 
 
-- term **values:**
+- term **values**:
 
 *A group of floating-point values to operate on.*
 
 
-- term **--file=\<file\>:**
+- term **--file=\<file\>**:
 
 
-- term **--directory=\<directory\>:**
+- term **--directory=\<directory\>**:
 
 
-- term **--shell=\<shell\>:**
+- term **--shell=\<shell\>**:
 
 
-- term **--custom=\<custom\>:**
+- term **--custom=\<custom\>**:
 
 
-- term **--custom-deprecated=\<custom-deprecated\>:**
+- term **--custom-deprecated=\<custom-deprecated\>**:
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -210,7 +210,7 @@ Show subcommand help information.
 math help [<subcommands>...] 
 ```
 
-- term **subcommands:**
+- term **subcommands**:
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
@@ -6,22 +6,22 @@
 repeat [--count=<count>] [--include-counter] <phrase> [--help]
 ```
 
-- term **--count=\<count\>:**
+- term **--count=\<count\>**:
 
 *The number of times to repeat 'phrase'.*
 
 
-- term **--include-counter:**
+- term **--include-counter**:
 
 *Include a counter with each repetition.*
 
 
-- term **phrase:**
+- term **phrase**:
 
 *The phrase to repeat.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -34,7 +34,7 @@ Show subcommand help information.
 repeat help [<subcommands>...] 
 ```
 
-- term **subcommands:**
+- term **subcommands**:
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
@@ -6,29 +6,29 @@
 roll [--times=<n>] [--sides=<m>] [--seed=<seed>] [--verbose] [--help]
 ```
 
-- term **--times=\<n\>:**
+- term **--times=\<n\>**:
 
 *Rolls the dice <n> times.*
 
 
-- term **--sides=\<m\>:**
+- term **--sides=\<m\>**:
 
 *Rolls an <m>-sided dice.*
 
 Use this option to override the default value of a six-sided die.
 
 
-- term **--seed=\<seed\>:**
+- term **--seed=\<seed\>**:
 
 *A seed to use for repeatable random generation.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Show all roll results.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -41,7 +41,7 @@ Show subcommand help information.
 roll help [<subcommands>...] 
 ```
 
-- term **subcommands:**
+- term **subcommands**:
 
 
 

--- a/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
+++ b/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
@@ -74,7 +74,7 @@ extension CommandInfoV0 {
 
         switch markdownStyle {
         case .docc:
-          result += "- term **\(arg.identity()):**\n\n"
+          result += "- term **\(arg.identity())**:\n\n"
         case .github:
           result += "**\(arg.identity()):**\n\n"
         }


### PR DESCRIPTION
resolves #772 

The term list output originally followed the markdown format and embedded the trailing `:` in the bold section, but DocC doesn't recognize the list element as a term list if the `:` is embedded, only if it's trailing. This PR resolves that situation, and updates the associated snapshot tests.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
