### PR TITLE
Preserve order of supplied zsh completion candidates

### DIFF
--- a/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift
@@ -23,7 +23,7 @@ extension [ParsableCommand.Type] {
       \(completeFunctionName)() {
           local -ar non_empty_completions=("${@:#(|:*)}")
           local -ar empty_completions=("${(M)@:#(|:*)}")
-          _describe '' non_empty_completions -- empty_completions -P $'\\'\\''
+          _describe -V '' non_empty_completions -- empty_completions -P $'\\'\\''
       }
 
       \(customCompleteFunctionName)() {
@@ -83,7 +83,7 @@ extension [ParsableCommand.Type] {
           .joined(separator: "\n")
         )
                 )
-                _describe "subcommand" subcommands
+                _describe -V subcommand subcommands
                 ;;
             arg)
                 case "${words[1]}" in
@@ -195,7 +195,7 @@ extension [ParsableCommand.Type] {
 
     case .shellCommand(let command):
       return (
-        "{local -a list;list=(${(f)\"$(\(command.shellEscapeForSingleQuotedString()))\"});_describe \"\" list}",
+        "{local -a list;list=(${(f)\"$(\(command.shellEscapeForSingleQuotedString()))\"});_describe -V \"\" list}",
         nil
       )
 

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathZshCompletionScript().zsh
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathZshCompletionScript().zsh
@@ -3,7 +3,7 @@
 __math_complete() {
     local -ar non_empty_completions=("${@:#(|:*)}")
     local -ar empty_completions=("${(M)@:#(|:*)}")
-    _describe '' non_empty_completions -- empty_completions -P $'\'\''
+    _describe -V '' non_empty_completions -- empty_completions -P $'\'\''
 }
 
 __math_custom_complete() {
@@ -55,7 +55,7 @@ _math() {
             'stats:Calculate descriptive statistics.'
             'help:Show subcommand help information.'
         )
-        _describe "subcommand" subcommands
+        _describe -V subcommand subcommands
         ;;
     arg)
         case "${words[1]}" in
@@ -111,7 +111,7 @@ _math_stats() {
             'stdev:Print the standard deviation of the values.'
             'quantiles:Print the quantiles of the values (TBD).'
         )
-        _describe "subcommand" subcommands
+        _describe -V subcommand subcommands
         ;;
     arg)
         case "${words[1]}" in
@@ -161,7 +161,7 @@ _math_stats_quantiles() {
         ':values:'
         '--file:file:_files -g '\''*.txt *.md'\'''
         '--directory:directory:_files -/'
-        '--shell:shell:{local -a list;list=(${(f)"$(head -100 /usr/share/dict/words | tail -50)"});_describe "" list}'
+        '--shell:shell:{local -a list;list=(${(f)"$(head -100 /usr/share/dict/words | tail -50)"});_describe -V "" list}'
         '--custom:custom:{__math_custom_complete ---completion stats quantiles -- --custom "${current_word_index}" "$(__math_cursor_index_in_current_word)"}'
         '--custom-deprecated:custom-deprecated:{__math_custom_complete ---completion stats quantiles -- --custom-deprecated}'
         '--version[Show the version.]'

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Zsh().zsh
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Zsh().zsh
@@ -3,7 +3,7 @@
 __base-test_complete() {
     local -ar non_empty_completions=("${@:#(|:*)}")
     local -ar empty_completions=("${(M)@:#(|:*)}")
-    _describe '' non_empty_completions -- empty_completions -P $'\'\''
+    _describe -V '' non_empty_completions -- empty_completions -P $'\'\''
 }
 
 __base-test_custom_complete() {
@@ -70,7 +70,7 @@ _base-test() {
             'escaped-command:'
             'help:Show subcommand help information.'
         )
-        _describe "subcommand" subcommands
+        _describe -V subcommand subcommands
         ;;
     arg)
         case "${words[1]}" in


### PR DESCRIPTION
Preserve order of supplied zsh completion candidates.

Resolve #774

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
