### PR TITLE
Bash Completion: fix bug in dash vs underscore (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 ## [Unreleased]
 
-*No new changes.*
+### Fixes
+
+- Bash completion scripts correctly handles subcommands with hyphens. ([#780])
 
 ---
 

--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -290,7 +290,7 @@ extension [ParsableCommand.Type] {
             case "${subcommand}" in
             \(subcommands.map { $0._commandName }.joined(separator: "|")))
                 # Offer subcommand argument completions
-                "\(functionName)_${subcommand}"
+                "\(functionName)_${subcommand//-/_}"
                 ;;
             *)
                 # Offer subcommand completions

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -169,7 +169,7 @@ _math() {
     case "${subcommand}" in
     add|multiply|stats|help)
         # Offer subcommand argument completions
-        "_math_${subcommand}"
+        "_math_${subcommand//-/_}"
         ;;
     *)
         # Offer subcommand completions
@@ -202,7 +202,7 @@ _math_stats() {
     case "${subcommand}" in
     average|stdev|quantiles)
         # Offer subcommand argument completions
-        "_math_stats_${subcommand}"
+        "_math_stats_${subcommand//-/_}"
         ;;
     *)
         # Offer subcommand completions

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -214,7 +214,7 @@ _base_test() {
     case "${subcommand}" in
     sub-command|escaped-command|help)
         # Offer subcommand argument completions
-        "_base_test_${subcommand}"
+        "_base_test_${subcommand//-/_}"
         ;;
     *)
         # Offer subcommand completions


### PR DESCRIPTION
The generated script tries to call sub-functions that have hyphens in them instead of underscores.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
