### PR TITLE
build: conditionally add Foundation dependency edge

### DIFF
--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -59,8 +59,11 @@ set_target_properties(ArgumentParser PROPERTIES
 target_compile_options(ArgumentParser PRIVATE
   $<$<BOOL:${BUILD_TESTING}>:-enable-testing>)
 target_link_libraries(ArgumentParser PRIVATE
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   ArgumentParserToolInfo)
+if(Foundation_FOUND)
+  target_link_libraries(ArgumentParser PRIVATE
+    Foundation)
+endif()
 
 
 _install_target(ArgumentParser)

--- a/Sources/ArgumentParserTestHelpers/CMakeLists.txt
+++ b/Sources/ArgumentParserTestHelpers/CMakeLists.txt
@@ -5,6 +5,12 @@ set_target_properties(ArgumentParserTestHelpers PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(ArgumentParserTestHelpers PUBLIC
   ArgumentParser
-  ArgumentParserToolInfo
-  XCTest
-  Foundation)
+  ArgumentParserToolInfo)
+if(Foundation_FOUND)
+  target_link_libraries(ArgumentParserTestHelpers PUBLIC
+    Foundation)
+endif()
+if(XCTest_Found)
+  target_link_libraries(ArgumentParserTestHelpers PUBLIC
+    XCTest)
+endif()


### PR DESCRIPTION
When building without `-DFoundation_DIR=...`, we should not wire up a dependency on Foundation and instead rely on autolinking and the driver to collude to resolve the linkage. Failure to do so will instill a rogue `-lFoundation.lib` when linking on Windows.