### PR TITLE
docs: update help text for readability in Repeat example and README

### DIFF
--- a/Examples/repeat/Repeat.swift
+++ b/Examples/repeat/Repeat.swift
@@ -13,7 +13,7 @@ import ArgumentParser
 
 @main
 struct Repeat: ParsableCommand {
-  @Option(help: "The number of times to repeat 'phrase'.")
+  @Option(help: "How many times to repeat 'phrase'.")
   var count: Int? = nil
 
   @Flag(help: "Include a counter with each repetition.")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ struct Repeat: ParsableCommand {
     @Flag(help: "Include a counter with each repetition.")
     var includeCounter = false
 
-    @Option(name: .shortAndLong, help: "The number of times to repeat 'phrase'.")
+    @Option(name: .shortAndLong, help: "How many times to repeat 'phrase'.")
     var count: Int? = nil
 
     @Argument(help: "The phrase to repeat.")


### PR DESCRIPTION
### Changes  
- Updated help text in `Repeat.swift` and README for better readability.  

### Motivation  
The current help text is slightly unclear; this improves UX for new users.  

### Checklist  
- [x] I’ve followed the code style of the rest of the project  
- [x] I’ve updated the documentation (README and inline help text)  
- [ ] I’ve added tests (if applicable)  
- [x] I’ve read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)  