### PR TITLE
add Sendable conformance requirements for Parsable Types to build cleanly with Swift 6

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that can be expressed as a command-line argument.
-public protocol ExpressibleByArgument {
+public protocol ExpressibleByArgument: Sendable {
   /// Creates a new instance of this type from a command-line-specified
   /// argument.
   init?(argument: String)

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -13,7 +13,7 @@
 ///
 /// When you implement a `ParsableArguments` type, all properties must be declared with
 /// one of the four property wrappers provided by the `ArgumentParser` library.
-public protocol ParsableArguments: Decodable {
+public protocol ParsableArguments: Decodable, Sendable {
   /// Creates an instance of this parsable type using the definitions
   /// given by each property's wrapper.
   init()


### PR DESCRIPTION
This repo won't build with Xcode 26 beta 1, it has the following compiler errors. This PR adds sendable conformance to the Types that are contained in Sendable structs

```
fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/ArgumentDiscussion.swift:85:8: error: associated value 'enumerated(preamble:_:)' of 'Sendable'-conforming enum 'ArgumentDiscussion' contains non-Sendable type 'any ExpressibleByArgument.Type'
 83 | enum ArgumentDiscussion {
 84 |   case staticText(String)
 85 |   case enumerated(preamble: String? = nil, any ExpressibleByArgument.Type)
    |        `- error: associated value 'enumerated(preamble:_:)' of 'Sendable'-conforming enum 'ArgumentDiscussion' contains non-Sendable type 'any ExpressibleByArgument.Type'
 86 | 
 87 |   init?(

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsable Properties/ArgumentHelp.swift:45:14: error: stored property 'argumentType' of 'Sendable'-conforming struct 'ArgumentHelp' contains non-Sendable type 'any ExpressibleByArgument.Type'
43 |   /// A property of meta type `any ExpressibleByArgument.Type` that serves to retain
44 |   /// information about any arguments that have enumerable values and their descriptions.
45 |   public var argumentType: (any ExpressibleByArgument.Type)?
   |              `- error: stored property 'argumentType' of 'Sendable'-conforming struct 'ArgumentHelp' contains non-Sendable type 'any ExpressibleByArgument.Type'
46 | 
47 |   /// Creates a new help instance.

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift:70:14: error: stored property 'ungroupedSubcommands' of 'Sendable'-conforming struct 'CommandConfiguration' contains non-Sendable type 'any ParsableCommand.Type'
 68 |   /// An array of types that define subcommands for this command and are
 69 |   /// not part of any command group.
 70 |   public var ungroupedSubcommands: [ParsableCommand.Type]
    |              `- error: stored property 'ungroupedSubcommands' of 'Sendable'-conforming struct 'CommandConfiguration' contains non-Sendable type 'any ParsableCommand.Type'
 71 | 
 72 |   /// The list of subcommands and subcommand groups.

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift:76:14: error: stored property 'defaultSubcommand' of 'Sendable'-conforming struct 'CommandConfiguration' contains non-Sendable type 'any ParsableCommand.Type'
 74 | 
 75 |   /// The default command type to run if no subcommand is given.
 76 |   public var defaultSubcommand: ParsableCommand.Type?
    |              `- error: stored property 'defaultSubcommand' of 'Sendable'-conforming struct 'CommandConfiguration' contains non-Sendable type 'any ParsableCommand.Type'
 77 | 
 78 |   /// Flag names to be used for help.

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsable Types/CommandGroup.swift:18:14: error: stored property 'subcommands' of 'Sendable'-conforming struct 'CommandGroup' contains non-Sendable type 'any ParsableCommand.Type'
16 | 
17 |   /// The list of subcommands that are part of this group.
18 |   public let subcommands: [ParsableCommand.Type]
   |              `- error: stored property 'subcommands' of 'Sendable'-conforming struct 'CommandGroup' contains non-Sendable type 'any ParsableCommand.Type'
19 | 
20 |   /// Create a command group.

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Parsing/CommandParser.swift:23:7: error: stored property 'commandStack' of 'Sendable'-conforming struct 'CommandError' contains non-Sendable type 'any ParsableCommand.Type'
 21 | 
 22 | struct CommandError: Error {
 23 |   var commandStack: [ParsableCommand.Type]
    |       `- error: stored property 'commandStack' of 'Sendable'-conforming struct 'CommandError' contains non-Sendable type 'any ParsableCommand.Type'
 24 |   var parserError: ParserError
 25 | }

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Utilities/Tree.swift:109:10: error: associated value 'recursiveSubcommand' of 'Sendable'-conforming enum 'InitializationError' has non-Sendable type 'any ParsableCommand.Type'
107 | 
108 |   enum InitializationError: Error {
109 |     case recursiveSubcommand(ParsableCommand.Type)
    |          `- error: associated value 'recursiveSubcommand' of 'Sendable'-conforming enum 'InitializationError' has non-Sendable type 'any ParsableCommand.Type'
110 |     case aliasMatchingCommand(ParsableCommand.Type)
111 |   }

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Utilities/Tree.swift:110:10: error: associated value 'aliasMatchingCommand' of 'Sendable'-conforming enum 'InitializationError' has non-Sendable type 'any ParsableCommand.Type'
108 |   enum InitializationError: Error {
109 |     case recursiveSubcommand(ParsableCommand.Type)
110 |     case aliasMatchingCommand(ParsableCommand.Type)
    |          `- error: associated value 'aliasMatchingCommand' of 'Sendable'-conforming enum 'InitializationError' has non-Sendable type 'any ParsableCommand.Type'
111 |   }
112 | }

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Validators/CodingKeyValidator.swift:83:9: error: stored property 'type' of 'Sendable'-conforming struct 'InvalidDecoderError' has non-Sendable type 'any ParsableArguments.Type'
 81 |     CustomStringConvertible
 82 |   {
 83 |     let type: ParsableArguments.Type
    |         `- error: stored property 'type' of 'Sendable'-conforming struct 'InvalidDecoderError' has non-Sendable type 'any ParsableArguments.Type'
 84 | 
 85 |     var description: String {

fbobjc/VendorLib/swift-argument-parser/Sources/ArgumentParser/Validators/ParsableArgumentsValidation.swift:45:7: error: stored property 'parsableArgumentsType' of 'Sendable'-conforming struct 'ParsableArgumentsValidationError' has non-Sendable type 'any ParsableArguments.Type'
43 | 
44 | struct ParsableArgumentsValidationError: Error, CustomStringConvertible {
45 |   let parsableArgumentsType: ParsableArguments.Type
   |       `- error: stored property 'parsableArgumentsType' of 'Sendable'-conforming struct 'ParsableArgumentsValidationError' has non-Sendable type 'any ParsableArguments.Type'
46 |   let underlayingErrors: [Error]
47 | 
```



### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
