### PR TITLE
Handle Swift 6.2 sendability changes

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that can be expressed as a command-line argument.
-public protocol ExpressibleByArgument {
+public protocol ExpressibleByArgument: SendableMetatype {
   /// Creates a new instance of this type from a command-line-specified
   /// argument.
   init?(argument: String)

--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -13,7 +13,7 @@
 ///
 /// When you implement a `ParsableArguments` type, all properties must be declared with
 /// one of the four property wrappers provided by the `ArgumentParser` library.
-public protocol ParsableArguments: Decodable {
+public protocol ParsableArguments: Decodable, SendableMetatype {
   /// Creates an instance of this parsable type using the definitions
   /// given by each property's wrapper.
   init()

--- a/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
@@ -35,10 +35,11 @@ extension Array where Element == Name {
 // MARK: -
 
 private struct Foo: ParsableCommand {
-  enum Subgroup: Equatable {
+  enum Subgroup: Equatable, Sendable {
     case first(Int)
     case second(Int)
 
+    @Sendable
     static func makeFirst(_ str: String) throws -> Subgroup {
       guard let value = Int(str) else {
         throw ValidationError("Not a valid integer for 'first'")
@@ -46,6 +47,7 @@ private struct Foo: ParsableCommand {
       return .first(value)
     }
 
+    @Sendable
     static func makeSecond(_ str: String) throws -> Subgroup {
       guard let value = Int(str) else {
         throw ValidationError("Not a valid integer for 'second'")

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -148,6 +148,8 @@ extension HelpGenerationTests {
   enum OptionFlags: String, EnumerableFlag { case optional, required }
   enum Degree {
     case bachelor, graduate, doctorate
+
+    @Sendable
     static func degreeTransform(_ string: String) throws -> Degree {
       switch string {
       case "bachelor":

--- a/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/UsageGenerationTests.swift
@@ -132,6 +132,7 @@ extension UsageGenerationTests {
     enum Color {
       case red, blue
 
+      @Sendable
       static func transform(_ string: String) throws -> Color {
         switch string {
         case "red":


### PR DESCRIPTION
Adds `SendableMetatype` conformance to the `ExpressibleByArgument` and `ParsableArguments` protocols, enabline existential use in Swift 6.2.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
