### PR TITLE
Designate `_SendableMetatype` as a marker protocol

### DIFF
--- a/Sources/ArgumentParser/Utilities/SwiftExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/SwiftExtensions.swift
@@ -11,7 +11,7 @@
 
 #if compiler(>=6.2)
 /// Designates a type as having a sendable metatype.
-public protocol _SendableMetatype: SendableMetatype {}
+@_marker public protocol _SendableMetatype: SendableMetatype {}
 #else
-public protocol _SendableMetatype {}
+@_marker public protocol _SendableMetatype {}
 #endif

--- a/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
@@ -241,3 +241,33 @@ extension PositionalEndToEndTests {
     }
   }
 }
+
+// MARK: Conditional ExpressibleByArgument conformance
+
+// Note: This retroactive conformance is a compilation test
+extension Range<Int>: ArgumentParser.ExpressibleByArgument {
+  public init?(argument: String) {
+    guard let i = argument.firstIndex(of: ":"),
+      let low = Int(String(argument[..<i])),
+      let high = Int(String(argument[i...].dropFirst())),
+      low <= high
+    else { return nil }
+    self = low..<high
+  }
+}
+
+extension PositionalEndToEndTests {
+  struct HasRange: ParsableArguments {
+    @Argument var range: Range<Int>
+  }
+
+  func testParseCustomRangeConformance() throws {
+    AssertParse(HasRange.self, ["0:4"]) { args in
+      XCTAssertEqual(args.range, 0..<4)
+    }
+
+    XCTAssertThrowsError(try HasRange.parse([]))
+    XCTAssertThrowsError(try HasRange.parse(["1"]))
+    XCTAssertThrowsError(try HasRange.parse(["1:0"]))
+  }
+}


### PR DESCRIPTION
This change addresses a source break around conditional conformances to `ExpressibleByArgument` and `ParsableArgument` that I didn't anticipate, and eliminates the unneeded runtime presence of `_SendableMetatype`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
