### PR TITLE
Skip Xcode 16.0 and 16.1 in PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
       enable_macos_checks: true
+      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.0\"}, {\"xcode_version\": \"16.1\"}]"
 
   cmake-build:
     name: CMake Build


### PR DESCRIPTION
These two versions aren't installed on the runner any more…