### PR TITLE
parseAllAsRoot() for list of parsed commands

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -68,6 +68,23 @@ extension ParsableCommand {
     return try parser.parse(arguments: arguments).get()
   }
 
+  /// Parses an instance of this type, from command-line arguments
+  /// and provide all of the commands in order from this one to possible
+  /// subcommands to a final leaf command to be run.
+  ///
+  /// - Parameter arguments: An array of arguments to use for parsing. If
+  ///   `arguments` is `nil`, this uses the program's command-line arguments.
+  /// - Returns: A new instance of this type, one of its subcommands, or a
+  ///   command type internal to the `ArgumentParser` library.
+  /// - Throws: If parsing fails.
+  public static func parseAllAsRoot(
+    _ arguments: [String]? = nil
+  ) throws -> [ParsableCommand] {
+    var parser = CommandParser(self)
+    let arguments = arguments ?? Array(CommandLine._staticArguments.dropFirst())
+    return try parser.parseAll(arguments: arguments).get()
+  }
+
   /// Returns the text of the help screen for the given subcommand of this
   /// command.
   ///

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -283,7 +283,8 @@ extension CommandParser {
   mutating func parse(
     arguments: [String]
   ) -> Result<ParsableCommand, CommandError> {
-    return self.parseAll(arguments: arguments).map { $0.last! }
+    // swift-format-ignore: NeverForceUnwrap
+    self.parseAll(arguments: arguments).map { $0.last! }
   }
 
   /// Returns the fully-parsed matching commands for `arguments`, or an

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -340,9 +340,11 @@ extension CommandParser {
         CommandError(commandStack: commandStack, parserError: error))
     } catch let helpRequest as HelpRequested {
       return .success(
-        [HelpCommand(
-          commandStack: commandStack,
-          visibility: helpRequest.visibility)])
+        [
+          HelpCommand(
+            commandStack: commandStack,
+            visibility: helpRequest.visibility)
+        ])
     } catch {
       return .failure(
         CommandError(commandStack: commandStack, parserError: .invalidState))

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -68,6 +68,19 @@ extension SubcommandEndToEndTests {
       XCTAssertEqual(a.foo.name, "Foo")
     }
 
+    let allCmds = try Foo.parseAllAsRoot(["--name", "Foo", "a", "--bar", "42"])
+    XCTAssertEqual(allCmds.count, 2)
+    guard let fooCmd = (allCmds[0] as? Foo) else {
+      XCTFail("")
+      return
+    }
+    XCTAssertEqual(fooCmd.name, "Foo")
+    guard let aCmd = (allCmds[1] as? CommandA) else {
+      XCTFail("")
+      return
+    }
+    XCTAssertEqual(aCmd.bar, 42)
+
     AssertParseCommand(Foo.self, Foo.self, ["--name", "Foo"]) { foo in
       XCTAssertEqual(foo.name, "Foo")
     }


### PR DESCRIPTION
### Description
It can be useful to get the list of parseable commands from the root
to the last subcommand in order to trace the path taken through the
command decision tree, and access parent command states from a
subcommand.

Here is an example of two paths through a decision tree encoded
as swift argument parser commands, subcommands and options.

```
mycmd decision1 --opt1=abc decision2 --opt2=def
mycmd decision1 --opt1=abc decision2A --opt3=ghi
```

In both leaf commands (decision2 and decision2A) they want to
know two things. First, is the fact that decision1 was chosen. It's
possible that subcommands can be reused at different points in a
decision tree. That choice can affect the behaviour of the
subcommand when it executes.

Second, the subcommands might further alter their behaviour
in the presence of flags/options, such as opt1 in this example.

Option groups are the usual method to propagate options down
to subcommands, but they have some limitations. The options
become present in the subcommands, and often visible with the
online help. This causes bloat in the subcommands if they need
to be aware of parent options. Also, they only apply to options
(or flags). There is no way to identify the parent commands that
were chosen.

### Detailed Design
Provide a new parseAllAsRoot() function that operates much in the
same way as parseAsRoot(), except it returns the list of parsed
commands. With such a list, a client can either store the list in a
shared location, or connect the commands together with parent
and child relationships with a custom command protocol.

```swift
let cmds = Foo.parseAllAsRoot(CommandLine.arguments)
var last = cmds.first
for cmd in cmd.dropFirst() {
    if let nestedCmd = (cmd as? NestedCommand) {
        nestedCmd.parent = last
    }
    last = cmd
}
guard let last else {
    fatalError("Nothing to run")
}
try last.run()
```

### Documentation Plan
The documentation has been updated with a documentation string for the new
parseAllAsRoot() function on ParseableCommand.

### Test Plan
The code paths are very similar to the existing parseAsRoot(), except that the
parsed commands list is preserved in this new function instead of being thrown
away. Existing tests will continue to verify the shared code paths. In order to
verify that the command list is formed as expected, an existing E2E test case
has been enhanced to verify the correctness of the whole list.

### Source Impact
There should be no impact to existing client.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
