### PR TITLE
Use official Swift SDK for Wasm in `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,7 +55,8 @@ jobs:
     name: Wasm Build
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.2-noble
+      # pinned nightly-6.2-noble with `swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a` for Wasm Swift SDK
+      image: swiftlang/swift:ab5c6ddd6a7e
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # pinned nightly-6.2-noble with `swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a` for Wasm Swift SDK
-      image: swiftlang/swift:ab5c6ddd6a7e
+      image: swiftlang/swift:nightly-6.2-noble@sha256:cc6ee97537f601b344dfe02071e91b0952212bba377ece463f1c2737984c06c2
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,7 +65,7 @@ jobs:
           swift sdk list
       - name: Build
         run: |
-          swift build --swift-sdk wasm32-unknown-wasi --target ArgumentParser
+          swift build --swift-sdk wasm32-unknown-wasip1 --target ArgumentParser
 
   soundness:
     name: Soundness

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,7 +65,7 @@ jobs:
           swift sdk list
       - name: Build
         run: |
-          swift build --swift-sdk wasm32-unknown-wasip1 --target ArgumentParser
+          swift build --swift-sdk swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm --target ArgumentParser
 
   soundness:
     name: Soundness

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,7 +55,7 @@ jobs:
     name: Wasm Build
     runs-on: ubuntu-latest
     container:
-      image: swift:6.1-noble
+      image: swiftlang/swift:nightly-6.2-noble
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,14 +61,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Swift SDKs for WebAssembly
         run: |
-          # TODO: We can replace these Swift SDKs with the swift.org one once it supports Foundation.
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasip1-threads.artifactbundle.zip --checksum 0dd273be28741f8e1eb00682c39bdc956361ed24b5572e183dd8a4e9d1c5f6ec
+          swift sdk install https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz --checksum 0294f106efcf4ca8944da5284b7a12825e9c4ca1316daa3f45d05ea0f65bedff
           swift sdk list
       - name: Build
         run: |
           swift build --swift-sdk wasm32-unknown-wasi --target ArgumentParser
-          swift build --swift-sdk wasm32-unknown-wasip1-threads --target ArgumentParser
 
   soundness:
     name: Soundness


### PR DESCRIPTION
Using official swift.org Swift SDKs for testing on Wasm. Unfortunately, Swift SDK URLs and IDs need to be hardcoded until https://github.com/swiftlang/swift-package-manager/pull/8703 is merged.

Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary