### PR TITLE
Use swiftlang/github-workflows' workflow for Wasm

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,22 +53,13 @@ jobs:
 
   wasm-build:
     name: Wasm Build
-    runs-on: ubuntu-latest
-    container:
-      image: swift:6.1-noble
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Install Swift SDKs for WebAssembly
-        run: |
-          # TODO: We can replace these Swift SDKs with the swift.org one once it supports Foundation.
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasip1-threads.artifactbundle.zip --checksum 0dd273be28741f8e1eb00682c39bdc956361ed24b5572e183dd8a4e9d1c5f6ec
-          swift sdk list
-      - name: Build
-        run: |
-          swift build --swift-sdk wasm32-unknown-wasi --target ArgumentParser
-          swift build --swift-sdk wasm32-unknown-wasip1-threads --target ArgumentParser
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --target ArgumentParser
+      swift_nightly_flags: --target ArgumentParser
 
   soundness:
     name: Soundness


### PR DESCRIPTION
Resolves https://github.com/apple/swift-argument-parser/pull/794#issuecomment-3045465439

Closes #798 

I replaced wasm-build job using swiftlang/github-workflows' workflow added by https://github.com/swiftlang/github-workflows/pull/142. Since it uses the official Swift SDK, #798 can be closed.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- ~~[ ] I've updated the documentation if necessary~~
