### PR TITLE
Consistently use enum raw value instead of description on the command line

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -250,7 +250,6 @@ extension Flag where Value == Bool? {
       exclusivity: exclusivity,
       help: help)
   }
-
 }
 
 extension Flag where Value == Bool {
@@ -556,7 +555,6 @@ extension Flag {
                 key: parentKey, value: value, origin: origin, values: &values,
                 exclusivity: exclusivity)
             }))
-
         }
         return ArgumentSet(args)
       })

--- a/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
+++ b/Sources/ArgumentParser/Parsable Types/EnumerableFlag.swift
@@ -81,3 +81,10 @@ extension EnumerableFlag {
     nil
   }
 }
+
+extension EnumerableFlag
+where Self: RawRepresentable, Self: CustomStringConvertible {
+  public var description: String {
+    String(describing: rawValue)
+  }
+}

--- a/Sources/ArgumentParser/Parsing/InputKey.swift
+++ b/Sources/ArgumentParser/Parsing/InputKey.swift
@@ -12,7 +12,7 @@
 /// Represents the path to a parsed field, annotated with ``Flag``, ``Option``
 /// or ``Argument``.
 ///
-/// Fields that are directly declared on a ``ParsableComand`` have a path of
+/// Fields that are directly declared on a ``ParsableCommand`` have a path of
 /// length 1, while fields that are declared indirectly (and included via an
 /// option group) have longer paths.
 struct InputKey: Hashable {

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -48,7 +48,12 @@ extension CompletionScriptTests {
     }
   }
 
-  enum Kind: String, ExpressibleByArgument, EnumerableFlag {
+  enum Kind:
+    String,
+    ExpressibleByArgument,
+    EnumerableFlag,
+    CustomStringConvertible
+  {
     case one, two
     case three = "custom-three"
   }

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -158,7 +158,7 @@ _base-test() {
     local -i positional_number
     local -a unparsed_words=("${COMP_WORDS[@]:1:${COMP_CWORD}}")
 
-    local -a flags=(--one --two --three --kind-counter -h --help)
+    local -a flags=(--one --two --custom-three --kind-counter -h --help)
     local -a options=(--name --kind --other-kind --path1 --path2 --path3 --rep1 -r --rep2)
     __base-test_offer_flags_options 2
 

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Fish().fish
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Fish().fish
@@ -5,7 +5,7 @@ function __base-test_should_offer_completions_for -a expected_commands -a expect
 
     switch $unparsed_tokens[1]
     case 'base-test'
-        __base-test_parse_subcommand 2 'name=' 'kind=' 'other-kind=' 'path1=' 'path2=' 'path3=' 'one' 'two' 'three' 'kind-counter' 'rep1=' 'r/rep2=' 'h/help'
+        __base-test_parse_subcommand 2 'name=' 'kind=' 'other-kind=' 'path1=' 'path2=' 'path3=' 'one' 'two' 'custom-three' 'kind-counter' 'rep1=' 'r/rep2=' 'h/help'
         switch $unparsed_tokens[1]
         case 'sub-command'
             __base-test_parse_subcommand 0 'h/help'
@@ -76,7 +76,7 @@ complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'path3' -rfka 'c1_fish c2_fish c3_fish'
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'one'
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'two'
-complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'three'
+complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'custom-three'
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'kind-counter'
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -l 'rep1' -rfka ''
 complete -c 'base-test' -n '__base-test_should_offer_completions_for "base-test"' -s 'r' -l 'rep2' -rfka ''

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Zsh().zsh
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Zsh().zsh
@@ -52,7 +52,7 @@ _base-test() {
         '--path3:path3:{__base-test_complete "${___path3[@]}"}'
         '--one'
         '--two'
-        '--three'
+        '--custom-three'
         '*--kind-counter'
         '*--rep1:rep1:'
         '*'{-r,--rep2}':rep2:'


### PR DESCRIPTION
Consistently use enum raw value instead of description on the command line. See issue #771.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
