### PR TITLE
Escape single quotes in `shellCommand` completions for fish

### DIFF
--- a/Examples/math/Math.swift
+++ b/Examples/math/Math.swift
@@ -229,7 +229,7 @@ extension Math.Statistics {
     var directory: String?
 
     @Option(
-      completion: .shellCommand("head -100 /usr/share/dict/words | tail -50")
+      completion: .shellCommand("head -100 '/usr/share/dict/words' | tail -50")
     )
     var shell: String?
 

--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -217,7 +217,9 @@ extension CommandInfoV0 {
     case .directory:
       results += ["-\(r)fa '(\(completeDirectoriesFunctionName))'"]
     case .shellCommand(let shellCommand):
-      results += ["-\(r)fka '(\(shellCommand))'"]
+      results += [
+        "-\(r)fka '(\(shellCommand.fishEscapeForSingleQuotedString()))'"
+      ]
     case .custom, .customAsync:
       results += [
         """

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -247,7 +247,7 @@ _math_stats_quantiles() {
         return
         ;;
     '--shell')
-        __math_add_completions -W "$(eval 'head -100 /usr/share/dict/words | tail -50')"
+        __math_add_completions -W "$(eval 'head -100 '\''/usr/share/dict/words'\'' | tail -50')"
         return
         ;;
     '--custom')

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathFishCompletionScript().fish
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathFishCompletionScript().fish
@@ -105,7 +105,7 @@ complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles" 3' -fka '(__math_custom_completion ---completion stats quantiles -- positional@2)'
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'file' -rfa '(set -l exts \'txt\' \'md\';for p in (string match -e -- \'*/\' (commandline -t);or printf \n)*.{$exts};printf %s\n $p;end;__fish_complete_directories (commandline -t) \'\')'
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'directory' -rfa '(__math_complete_directories)'
-complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'shell' -rfka '(head -100 /usr/share/dict/words | tail -50)'
+complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'shell' -rfka '(head -100 \'/usr/share/dict/words\' | tail -50)'
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'custom' -rfka '(__math_custom_completion ---completion stats quantiles -- --custom (count (__math_tokens -pc)) (__math_tokens -tC))'
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'custom-deprecated' -rfka '(__math_custom_completion ---completion stats quantiles -- --custom-deprecated)'
 complete -c 'math' -n '__math_should_offer_completions_for "math stats quantiles"' -l 'version' -d 'Show the version.'

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathZshCompletionScript().zsh
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathZshCompletionScript().zsh
@@ -161,7 +161,7 @@ _math_stats_quantiles() {
         '*:values:'
         '--file:file:_files -g '\''*.txt *.md'\'''
         '--directory:directory:_files -/'
-        '--shell:shell:{local -a list;list=(${(f)"$(head -100 /usr/share/dict/words | tail -50)"});_describe -V "" list}'
+        '--shell:shell:{local -a list;list=(${(f)"$(head -100 '\''/usr/share/dict/words'\'' | tail -50)"});_describe -V "" list}'
         '--custom:custom:{__math_custom_complete ---completion stats quantiles -- --custom "${current_word_index}" "$(__math_cursor_index_in_current_word)"}'
         '--custom-deprecated:custom-deprecated:{__math_custom_complete ---completion stats quantiles -- --custom-deprecated}'
         '--version[Show the version.]'

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathDumpHelp().json
@@ -603,7 +603,7 @@
               {
                 "completionKind" : {
                   "shellCommand" : {
-                    "command" : "head -100 \/usr\/share\/dict\/words | tail -50"
+                    "command" : "head -100 '\/usr\/share\/dict\/words' | tail -50"
                   }
                 },
                 "isOptional" : true,

--- a/Tests/ArgumentParserUnitTests/Snapshots/testMathStatsDumpHelp().json
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testMathStatsDumpHelp().json
@@ -386,7 +386,7 @@
           {
             "completionKind" : {
               "shellCommand" : {
-                "command" : "head -100 \/usr\/share\/dict\/words | tail -50"
+                "command" : "head -100 '\/usr\/share\/dict\/words' | tail -50"
               }
             },
             "isOptional" : true,


### PR DESCRIPTION
Escape single quotes in `shellCommand` completions for fish.

Resolve #810

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
