### PR TITLE
feat: allow negative numeric positional arguments

### DIFF
--- a/Tests/ArgumentParserUnitTests/NegativeNumberArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/NegativeNumberArgumentTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ArgumentParser
+
+final class NegativeNumberArgumentTests: XCTestCase {
+  struct Absolute: ParsableCommand {
+    @Argument var number: Int
+  }
+
+  func testParsesNegativeIntegerAsArgument() throws {
+    let cmd = try Absolute.parse(["-5"]) // should be treated as value, not option
+    XCTAssertEqual(cmd.number, -5)
+  }
+
+  struct FloatArg: ParsableCommand {
+    @Argument var value: Double
+  }
+
+  func testParsesNegativeDoubleAsArgument() throws {
+    let cmd = try FloatArg.parse(["-3.14"]) // negative decimal
+    XCTAssertEqual(cmd.value, -3.14, accuracy: 1e-9)
+  }
+}
+


### PR DESCRIPTION
## Summary
Treat '-<number>' tokens as values during argument splitting so that positional arguments of numeric types (Int/Double) can accept negative literals, e.g.  or .

## Motivation
Currently, inputs like  are interpreted as options, causing  errors for commands that legitimately expect a negative number as a positional argument (see #31). This change aligns with common CLI expectations where negative numeric literals are valid values.

## Implementation
- Update  to classify '-<digits>' and '-<digits>.<digits>' as values rather than options.
- Preserve existing short/long option behavior (e.g. , , , and ).
- Add unit tests covering negative  and  positional arguments.

## Considerations
- This change gives precedence to numeric literals over short options that would be single-digit flags (which are relatively uncommon). Options with letters or grouped short options are unaffected.

Fixes #31
