### PR TITLE
Exclude Xcode 16.2 from CI testing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
       enable_macos_checks: true
-      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.0\"}, {\"xcode_version\": \"16.1\"}]"
+      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.0\"}, {\"xcode_version\": \"16.1\"}, {\"xcode_version\": \"16.2\"}]"
       enable_wasm_sdk_build: true
       wasm_sdk_build_command: swift build --target ArgumentParser
 


### PR DESCRIPTION
This configuration is no longer enabled in CI. 