### PR TITLE
#778: Suppress builtin `-h,--help` from usage text when command already contains an option using `-h`

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -519,7 +519,19 @@ extension BidirectionalCollection where Element == ParsableCommand.Type {
       })
     else { return ArgumentSet() }
     self.versionArgumentDefinition().map { arguments.append($0) }
-    self.helpArgumentDefinition().map { arguments.append($0) }
+    
+    let shouldAppendBuiltinHelp = !arguments
+      .flatMap(\.names)
+      .contains { name in
+        if case .short(let char, _) = name {
+          return char == "h"
+        }
+        return false
+      }
+    
+    if shouldAppendBuiltinHelp {
+      self.helpArgumentDefinition().map { arguments.append($0) }
+    }
 
     // To add when 'dump-help' is public API:
     // arguments.append(self.dumpHelpArgumentDefinition())

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -1493,3 +1493,28 @@ extension HelpGenerationTests {
     #endif
   }
 }
+
+extension HelpGenerationTests {
+  struct Issue778: ParsableCommand {
+    @Argument(help: "The phrase to repeat.")
+    var phrase: String
+    
+    @Option(name: .shortAndLong, help: "The name of the talking horse.")
+    var horse: String
+  }
+  
+  func testCommandWithShortOptionNameHDoesNotIncludeBuiltInHelp() {
+    AssertHelp(
+      .default, for: Issue778.self, columns: nil,
+      equals: """
+        USAGE: issue778 <phrase> --horse <horse>
+
+        ARGUMENTS:
+          <phrase>                The phrase to repeat.
+
+        OPTIONS:
+          -h, --horse <horse>     The name of the talking horse.
+        
+        """)
+  }
+}


### PR DESCRIPTION
This PR fixes part of the behavior described in #778, fixing the generated error and usage texts to not list the builtin `-h, --help`:

> I would expect -h to only be added if no existing flag or option already has that name.

I still need to address the other behaviors there, and to fix command invocation, applying the custom command and not the builtin help one.

#### Before

```
Error: Missing expected argument '<phrase>'

USAGE: repeat [--count <count>] [--include-counter] <phrase> --horse <horse>

ARGUMENTS:
  <phrase>                The phrase to repeat.

OPTIONS:
  --count <count>         How many times to repeat 'phrase'.
  --include-counter       Include a counter with each repetition.
  -h, --horse <horse>     The name of the talking horse.
  -h, --help              Show help information.
```

#### After

```
Error: Missing expected argument '<phrase>'

USAGE: repeat [--count <count>] [--include-counter] <phrase> --horse <horse>

ARGUMENTS:
  <phrase>                The phrase to repeat.

OPTIONS:
  --count <count>         How many times to repeat 'phrase'.
  --include-counter       Include a counter with each repetition.
  -h, --horse <horse>     The name of the talking horse.
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
