### PR TITLE
Add `ParsableArguments#_errorPrefix` to allow a more-customized error prefix than `ParsableArguments#_errorLabel`

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableArguments.swift
@@ -25,7 +25,15 @@ public protocol ParsableArguments: Decodable, _SendableMetatype {
   mutating func validate() throws
 
   /// The label to use for "Error: ..." messages from this type (experimental).
+  ///
+  /// Can be ignored if `_errorPrefix`'s is changed.
+  @available(*, deprecated, message: "Use _errorPrefix instead.")
   static var _errorLabel: String { get }
+
+  /// The prefix to use for "Error: ..." messages from this type (experimental).
+  ///
+  /// Defaults to `"\(_errorLabel): "`.
+  static var _errorPrefix: String { get }
 }
 
 /// A type that provides the `ParsableCommand` interface to a `ParsableArguments` type.
@@ -59,6 +67,13 @@ extension ParsableArguments {
 
   public static var _errorLabel: String {
     "Error"
+  }
+
+  /// The prefix to use for "Error: ..." messages from this type (experimental).
+  ///
+  /// Defaults to `"\(_errorLabel): "`.
+  public static var _errorPrefix: String {
+    "\(_errorLabel): "
   }
 }
 

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -164,10 +164,10 @@ enum MessageInfo {
     case .validation(let message, let usage, let help):
       let helpMessage = help.isEmpty ? "" : "Help:  \(help)\n"
       let errorMessage =
-        message.isEmpty ? "" : "\(args._errorLabel): \(message)\n"
+        message.isEmpty ? "" : "\(args._errorPrefix)\(message)\n"
       return errorMessage + helpMessage + usage
     case .other(let message, _):
-      return message.isEmpty ? "" : "\(args._errorLabel): \(message)"
+      return message.isEmpty ? "" : "\(args._errorPrefix)\(message)"
     }
   }
 


### PR DESCRIPTION
Add `ParsableArguments#_errorPrefix` to allow a more-customized error prefix than `ParsableArguments#_errorLabel`.

`_errorLabel` wasn't tested or documented outside DocC, so I didn't do anything more for `_errorPrefix`.

Resolve #836.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
