### PR TITLE
Break ExpressibleByArgument default ambiguity

### DIFF
--- a/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
+++ b/Sources/ArgumentParser/Parsable Types/ExpressibleByArgument.swift
@@ -122,6 +122,17 @@ extension LosslessStringConvertible where Self: ExpressibleByArgument {
   }
 }
 
+extension LosslessStringConvertible
+where
+  Self: ExpressibleByArgument & RawRepresentable,
+  RawValue: ExpressibleByArgument
+{
+  // Ambiguity breaker
+  public init?(argument: String) {
+    self.init(argument)
+  }
+}
+
 extension Int: ExpressibleByArgument {}
 extension Int8: ExpressibleByArgument {}
 extension Int16: ExpressibleByArgument {}

--- a/Tests/ArgumentParserEndToEndTests/RawRepresentableEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RawRepresentableEndToEndTests.swift
@@ -48,3 +48,16 @@ extension RawRepresentableEndToEndTests {
     XCTAssertThrowsError(try Bar.parse(["--identifier", "123.456"]))
   }
 }
+
+struct LogLevel: RawRepresentable, CustomStringConvertible {
+  var rawValue: String
+  var description: String { rawValue }
+}
+
+extension LogLevel: LosslessStringConvertible {
+  init(_ description: String) {
+    self.rawValue = description
+  }
+}
+
+extension LogLevel: ExpressibleByArgument {}


### PR DESCRIPTION
For types that conform to both RawRepresentable and LosslessStringConvertible, the provided default implementations of `init(argument:)` are ambiguous. This provides a doubly- constrained implementation that breaks that ambiguity.


### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
