### PR TITLE
Prevent bash option reversion commands in bash completion function from being appended to bash history

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -188,7 +188,9 @@ extension CommandInfoV0 {
     let declareTopLevelArray: String
     if (superCommands ?? []).isEmpty {
       result += """
-            trap "$(shopt -p);$(shopt -po)" RETURN
+            local state
+            state="$(shopt -p;shopt -po)"
+            trap "${state//$'\\n'/;}" RETURN
             shopt -s extglob
             set +o history +o posix
 

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -145,7 +145,9 @@ __math_custom_complete() {
 }
 
 _math() {
-    trap "$(shopt -p);$(shopt -po)" RETURN
+    local state
+    state="$(shopt -p;shopt -po)"
+    trap "${state//$'\n'/;}" RETURN
     shopt -s extglob
     set +o history +o posix
 

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -145,7 +145,9 @@ __base-test_custom_complete() {
 }
 
 _base-test() {
-    trap "$(shopt -p);$(shopt -po)" RETURN
+    local state
+    state="$(shopt -p;shopt -po)"
+    trap "${state//$'\n'/;}" RETURN
     shopt -s extglob
     set +o history +o posix
 


### PR DESCRIPTION
Prevent bash option reversion commands in bash completion function from being appended to bash history.

Resolve #858

### Checklist

- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
