### PR TITLE
Fix --help in nested subcommands with default subcommands

### DIFF
--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -126,7 +126,8 @@ extension CommandParser {
 
       // Require that all remaining parsed arguments came from the same input
       // argument.
-      let originIndex = split.elements[split.elements.startIndex].index.inputIndex
+      let originIndex = split.elements[split.elements.startIndex].index
+        .inputIndex
       for element in split.elements {
         guard element.index.inputIndex == originIndex else {
           return

--- a/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
@@ -358,15 +358,21 @@ extension DefaultSubcommandEndToEndTests {
       NestedDefaultSubcommandHelp.self, HelpCommand.self, ["--help"]
     ) { command in
       XCTAssert(command.commandStack.count == 1)
-      XCTAssert(type(of: command.commandStack[0]) == NestedDefaultSubcommandHelp.Type.self)
+      XCTAssert(
+        type(of: command.commandStack[0])
+          == NestedDefaultSubcommandHelp.Type.self)
     }
 
     AssertParseCommand(
       NestedDefaultSubcommandHelp.self, HelpCommand.self, ["nested", "--help"]
     ) { command in
       XCTAssert(command.commandStack.count == 2)
-      XCTAssert(type(of: command.commandStack[0]) == NestedDefaultSubcommandHelp.Type.self)
-      XCTAssert(type(of: command.commandStack[1]) == NestedDefaultSubcommandHelp.Nested.Type.self)
+      XCTAssert(
+        type(of: command.commandStack[0])
+          == NestedDefaultSubcommandHelp.Type.self)
+      XCTAssert(
+        type(of: command.commandStack[1])
+          == NestedDefaultSubcommandHelp.Nested.Type.self)
     }
   }
 }


### PR DESCRIPTION
This fixes the issue discussed in #865. I updated the implementation of `checkForBuiltInFlags`'s `requireSoloArgument` parameter to explicitly check for a single input argument rather than a single parsed argument, as some input arguments get parsed into multiple synthetic arguments, for example `-help` -> `[-help, -h, -e, -l, -p]`. #612 was trying to do this but did it in a bit of a hacky way that introduced #865. I have added a unit test that fails without these changes and succeeds with them.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
