### PR TITLE
GenerateDoccReference: group arguments by section like CLI help

### DIFF
--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorDoccReference().md
@@ -6,6 +6,8 @@
 color --fav=<fav> [--second=<second>] [--help]
 ```
 
+## Options
+
 - term **--fav=\<fav\>**:
 
 *Your favorite color.*
@@ -30,6 +32,8 @@ Show subcommand help information.
 ```
 color help [<subcommands>...]
 ```
+
+### Arguments
 
 - term **subcommands**:
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorMarkdownReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testColorMarkdownReference().md
@@ -6,6 +6,8 @@
 color --fav=<fav> [--second=<second>] [--help]
 ```
 
+## Options
+
 **--fav=\<fav\>:**
 
 *Your favorite color.*
@@ -30,6 +32,8 @@ Show subcommand help information.
 ```
 color help [<subcommands>...]
 ```
+
+### Arguments
 
 **subcommands:**
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesDoccReference().md
@@ -7,10 +7,14 @@ count-lines [<input-file>] [--prefix=<prefix>] [--verbose]
   [--help]
 ```
 
+## Arguments
+
 - term **input-file**:
 
 *A file to count lines in. If omitted, counts the lines of stdin.*
 
+
+## Options
 
 - term **--prefix=\<prefix\>**:
 
@@ -35,8 +39,9 @@ Show subcommand help information.
 count-lines help [<subcommands>...]
 ```
 
-- term **subcommands**:
+### Arguments
 
+- term **subcommands**:
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesMarkdownReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testCountLinesMarkdownReference().md
@@ -6,10 +6,14 @@
 count-lines [<input-file>] [--prefix=<prefix>] [--verbose] [--help]
 ```
 
+## Arguments
+
 **input-file:**
 
 *A file to count lines in. If omitted, counts the lines of stdin.*
 
+
+## Options
 
 **--prefix=\<prefix\>:**
 
@@ -34,8 +38,9 @@ Show subcommand help information.
 count-lines help [<subcommands>...]
 ```
 
-**subcommands:**
+### Arguments
 
+**subcommands:**
 
 
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathDoccReference().md
@@ -8,6 +8,8 @@ A utility for performing maths.
 math [--version] [--help]
 ```
 
+## Options
+
 - term **--version**:
 
 *Show the version.*
@@ -26,14 +28,18 @@ Print the sum of the values.
 math add [--hex-output] [<values>...] [--version] [--help]
 ```
 
-- term **--hex-output**:
-
-*Use hexadecimal notation for the result.*
-
+### Arguments
 
 - term **values**:
 
 *A group of integers to operate on.*
+
+
+### Options
+
+- term **--hex-output**:
+
+*Use hexadecimal notation for the result.*
 
 
 - term **--version**:
@@ -57,14 +63,18 @@ math multiply [--hex-output] [<values>...] [--version]
   [--help]
 ```
 
-- term **--hex-output**:
-
-*Use hexadecimal notation for the result.*
-
+### Arguments
 
 - term **values**:
 
 *A group of integers to operate on.*
+
+
+### Options
+
+- term **--hex-output**:
+
+*Use hexadecimal notation for the result.*
 
 
 - term **--version**:
@@ -87,6 +97,8 @@ Calculate descriptive statistics.
 math stats [--version] [--help]
 ```
 
+### Options
+
 - term **--version**:
 
 *Show the version.*
@@ -106,14 +118,18 @@ math stats average [--kind=<kind>] [<values>...] [--version]
   [--help]
 ```
 
-- term **--kind=\<kind\>**:
-
-*The kind of average to provide.*
-
+#### Arguments
 
 - term **values**:
 
 *A group of floating-point values to operate on.*
+
+
+#### Options
+
+- term **--kind=\<kind\>**:
+
+*The kind of average to provide.*
 
 
 - term **--version**:
@@ -136,10 +152,14 @@ Print the standard deviation of the values.
 math stats stdev [<values>...] [--version] [--help]
 ```
 
+#### Arguments
+
 - term **values**:
 
 *A group of floating-point values to operate on.*
 
+
+#### Options
 
 - term **--version**:
 
@@ -166,6 +186,8 @@ math stats quantiles [<one-of-four>] [<custom-arg>]
   [--help]
 ```
 
+#### Arguments
+
 - term **one-of-four**:
 
 
@@ -179,6 +201,8 @@ math stats quantiles [<one-of-four>] [<custom-arg>]
 
 *A group of floating-point values to operate on.*
 
+
+#### Options
 
 - term **--file=\<file\>**:
 
@@ -217,8 +241,12 @@ Show subcommand help information.
 math help [<subcommands>...] [--version]
 ```
 
+### Arguments
+
 - term **subcommands**:
 
+
+### Options
 
 - term **--version**:
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathMarkdownReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testMathMarkdownReference().md
@@ -8,6 +8,8 @@ A utility for performing maths.
 math [--version] [--help]
 ```
 
+## Options
+
 **--version:**
 
 *Show the version.*
@@ -26,14 +28,18 @@ Print the sum of the values.
 math add [--hex-output] [<values>...] [--version] [--help]
 ```
 
-**--hex-output:**
-
-*Use hexadecimal notation for the result.*
-
+### Arguments
 
 **values:**
 
 *A group of integers to operate on.*
+
+
+### Options
+
+**--hex-output:**
+
+*Use hexadecimal notation for the result.*
 
 
 **--version:**
@@ -56,14 +62,18 @@ Print the product of the values.
 math multiply [--hex-output] [<values>...] [--version] [--help]
 ```
 
-**--hex-output:**
-
-*Use hexadecimal notation for the result.*
-
+### Arguments
 
 **values:**
 
 *A group of integers to operate on.*
+
+
+### Options
+
+**--hex-output:**
+
+*Use hexadecimal notation for the result.*
 
 
 **--version:**
@@ -86,6 +96,8 @@ Calculate descriptive statistics.
 math stats [--version] [--help]
 ```
 
+### Options
+
 **--version:**
 
 *Show the version.*
@@ -104,14 +116,18 @@ Print the average of the values.
 math stats average [--kind=<kind>] [<values>...] [--version] [--help]
 ```
 
-**--kind=\<kind\>:**
-
-*The kind of average to provide.*
-
+#### Arguments
 
 **values:**
 
 *A group of floating-point values to operate on.*
+
+
+#### Options
+
+**--kind=\<kind\>:**
+
+*The kind of average to provide.*
 
 
 **--version:**
@@ -134,10 +150,14 @@ Print the standard deviation of the values.
 math stats stdev [<values>...] [--version] [--help]
 ```
 
+#### Arguments
+
 **values:**
 
 *A group of floating-point values to operate on.*
 
+
+#### Options
 
 **--version:**
 
@@ -162,6 +182,8 @@ math stats quantiles [<one-of-four>] [<custom-arg>] [<custom-deprecated-arg>]
   [--help]
 ```
 
+#### Arguments
+
 **one-of-four:**
 
 
@@ -175,6 +197,8 @@ math stats quantiles [<one-of-four>] [<custom-arg>] [<custom-deprecated-arg>]
 
 *A group of floating-point values to operate on.*
 
+
+#### Options
 
 **--file=\<file\>:**
 
@@ -213,8 +237,12 @@ Show subcommand help information.
 math help [<subcommands>...] [--version]
 ```
 
+### Arguments
+
 **subcommands:**
 
+
+### Options
 
 **--version:**
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatDoccReference().md
@@ -7,6 +7,15 @@ repeat [--count=<count>] [--include-counter] <phrase>
   [--help]
 ```
 
+## Arguments
+
+- term **phrase**:
+
+*The phrase to repeat.*
+
+
+## Options
+
 - term **--count=\<count\>**:
 
 *How many times to repeat 'phrase'.*
@@ -15,11 +24,6 @@ repeat [--count=<count>] [--include-counter] <phrase>
 - term **--include-counter**:
 
 *Include a counter with each repetition.*
-
-
-- term **phrase**:
-
-*The phrase to repeat.*
 
 
 - term **--help**:
@@ -34,6 +38,8 @@ Show subcommand help information.
 ```
 repeat help [<subcommands>...]
 ```
+
+### Arguments
 
 - term **subcommands**:
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatMarkdownReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRepeatMarkdownReference().md
@@ -6,6 +6,15 @@
 repeat [--count=<count>] [--include-counter] <phrase> [--help]
 ```
 
+## Arguments
+
+**phrase:**
+
+*The phrase to repeat.*
+
+
+## Options
+
 **--count=\<count\>:**
 
 *How many times to repeat 'phrase'.*
@@ -14,11 +23,6 @@ repeat [--count=<count>] [--include-counter] <phrase> [--help]
 **--include-counter:**
 
 *Include a counter with each repetition.*
-
-
-**phrase:**
-
-*The phrase to repeat.*
 
 
 **--help:**
@@ -33,6 +37,8 @@ Show subcommand help information.
 ```
 repeat help [<subcommands>...]
 ```
+
+### Arguments
 
 **subcommands:**
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollDoccReference().md
@@ -7,6 +7,8 @@ roll [--times=<n>] [--sides=<m>] [--seed=<seed>] [--verbose]
   [--help]
 ```
 
+## Options
+
 - term **--times=\<n\>**:
 
 *Rolls the dice <n> times.*
@@ -41,6 +43,8 @@ Show subcommand help information.
 ```
 roll help [<subcommands>...]
 ```
+
+### Arguments
 
 - term **subcommands**:
 

--- a/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollMarkdownReference().md
+++ b/Tests/ArgumentParserGenerateDoccReferenceTests/Snapshots/testRollMarkdownReference().md
@@ -6,6 +6,8 @@
 roll [--times=<n>] [--sides=<m>] [--seed=<seed>] [--verbose] [--help]
 ```
 
+## Options
+
 **--times=\<n\>:**
 
 *Rolls the dice <n> times.*
@@ -40,6 +42,8 @@ Show subcommand help information.
 ```
 roll help [<subcommands>...]
 ```
+
+### Arguments
 
 **subcommands:**
 

--- a/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
+++ b/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
@@ -77,7 +77,8 @@ extension CommandInfoV0 {
       result += "\(discussion)\n\n"
     }
 
-    result += self.argumentListMarkdown(path: path, markdownStyle: markdownStyle)
+    result += self.argumentListMarkdown(
+      path: path, markdownStyle: markdownStyle)
 
     for subcommand in self.subcommands ?? [] {
       result +=

--- a/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
+++ b/Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift
@@ -77,34 +77,66 @@ extension CommandInfoV0 {
       result += "\(discussion)\n\n"
     }
 
-    if let args = self.arguments {
-      for arg in args {
-        guard arg.shouldDisplay else {
-          continue
-        }
-
-        switch markdownStyle {
-        case .docc:
-          result += "- term **\(arg.identity())**:\n\n"
-        case .github:
-          result += "**\(arg.identity()):**\n\n"
-        }
-
-        if let abstract = arg.abstract {
-          result += "*\(abstract)*\n\n"
-        }
-        if let discussion = arg.discussion {
-          result += discussion + "\n\n"
-        }
-        result += "\n"
-      }
-    }
+    result += self.argumentListMarkdown(path: path, markdownStyle: markdownStyle)
 
     for subcommand in self.subcommands ?? [] {
       result +=
         subcommand.toMarkdown(
           path + [self.commandName], markdownStyle: markdownStyle) + "\n\n"
     }
+
+    return result
+  }
+
+  /// Emits grouped argument documentation matching command-line help ordering:
+  /// Arguments, then custom section titles (definition order), then Options.
+  fileprivate func argumentListMarkdown(
+    path: [String],
+    markdownStyle: OutputStyle
+  ) -> String {
+    guard let args = self.arguments else {
+      return ""
+    }
+    let displayed = args.filter(\.shouldDisplay)
+    guard !displayed.isEmpty else {
+      return ""
+    }
+
+    var positional: [ArgumentInfoV0] = []
+    var titled: [String: [ArgumentInfoV0]] = [:]
+    var sectionOrder: [String] = []
+    var options: [ArgumentInfoV0] = []
+
+    for arg in displayed {
+      if let title = arg.sectionTitle, !title.isEmpty {
+        if !titled.keys.contains(title) {
+          sectionOrder.append(title)
+        }
+        titled[title, default: []].append(arg)
+      } else if arg.kind == .positional {
+        positional.append(arg)
+      } else {
+        options.append(arg)
+      }
+    }
+
+    var result = ""
+    let headingLevel = path.count + 2
+    let headingPrefix = String(repeating: "#", count: headingLevel)
+
+    func appendSection(title: String, arguments: [ArgumentInfoV0]) {
+      guard !arguments.isEmpty else { return }
+      result += "\(headingPrefix) \(title)\n\n"
+      for arg in arguments {
+        result += arg.markdownTermBody(markdownStyle: markdownStyle)
+      }
+    }
+
+    appendSection(title: "Arguments", arguments: positional)
+    for title in sectionOrder {
+      appendSection(title: title, arguments: titled[title] ?? [])
+    }
+    appendSection(title: "Options", arguments: options)
 
     return result
   }
@@ -208,5 +240,23 @@ extension ArgumentInfoV0 {
       inner = "--\(names.joined(separator: "|"))"
     }
     return inner
+  }
+
+  fileprivate func markdownTermBody(markdownStyle: OutputStyle) -> String {
+    var result = ""
+    switch markdownStyle {
+    case .docc:
+      result += "- term **\(identity())**:\n\n"
+    case .github:
+      result += "**\(identity()):**\n\n"
+    }
+    if let abstract = self.abstract {
+      result += "*\(abstract)*\n\n"
+    }
+    if let discussion = self.discussion {
+      result += discussion + "\n\n"
+    }
+    result += "\n"
+    return result
   }
 }


### PR DESCRIPTION
Partition dump-help arguments into Arguments, custom sectionTitle groups (first-seen order), and Options, and emit matching markdown headings. Update DocC reference snapshots.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This addresses [issue #722]: generated DocC/GitHub Markdown previously listed every argument in a single block. This change uses it so that the output matches the section order used by command-line help.

Implementation is confined to Tools/generate-docc-reference/Extensions/ArgumentParser+Markdown.swift. Existing GenerateDoccReferenceTests snapshot baselines were refreshed to reflect the new headings.

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary
