### PR TITLE
Display command aliases in generated man-pages

### DIFF
--- a/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathMultiPageManual().mdoc
+++ b/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathMultiPageManual().mdoc
@@ -77,7 +77,8 @@ and
 .Dt MATH.MULTIPLY 9
 .Os
 .Sh NAME
-.Nm "math multiply"
+.Nm "math multiply" ,
+.Nm mul
 .Nd "Print the product of the values."
 .Sh SYNOPSIS
 .Nm
@@ -150,7 +151,8 @@ and
 .Dt MATH.STATS.AVERAGE 9
 .Os
 .Sh NAME
-.Nm "math stats average"
+.Nm "math stats average" ,
+.Nm avg
 .Nd "Print the average of the values."
 .Sh SYNOPSIS
 .Nm

--- a/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathSinglePageManual().mdoc
+++ b/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathSinglePageManual().mdoc
@@ -28,7 +28,7 @@ Show the version.
 .It Fl h , -help
 Show help information.
 .El
-.It Em multiply
+.It Em "multiply, mul"
 Print the product of the values.
 .Bl -tag -width 6n
 .It Fl x , -hex-output
@@ -47,7 +47,7 @@ Calculate descriptive statistics.
 Show the version.
 .It Fl h , -help
 Show help information.
-.It Em average
+.It Em "average, avg"
 Print the average of the values.
 .Bl -tag -width 6n
 .It Fl -kind Ar kind

--- a/Tools/generate-manual/DSL/Name.swift
+++ b/Tools/generate-manual/DSL/Name.swift
@@ -16,8 +16,16 @@ struct Name: MDocComponent {
   var command: CommandInfoV0
 
   var body: MDocComponent {
+    let names = [command.manualPageName] + (command.aliases ?? [])
     Section(title: "name") {
-      MDocMacro.DocumentName(name: command.manualPageName)
+      for (index, name) in names.enumerated() {
+        if index < names.count - 1 {
+          MDocMacro.DocumentName(name: name)
+            .withUnsafeChildren(nodes: [","])
+        } else {
+          MDocMacro.DocumentName(name: name)
+        }
+      }
       if let abstract = command.abstract {
         MDocMacro.DocumentDescription(description: abstract)
       }

--- a/Tools/generate-manual/DSL/SinglePageDescription.swift
+++ b/Tools/generate-manual/DSL/SinglePageDescription.swift
@@ -67,7 +67,8 @@ struct SinglePageDescription: MDocComponent {
 
       for subcommand in command.subcommands ?? [] {
         MDocMacro.ListItem(
-          title: MDocMacro.Emphasis(arguments: [subcommand.commandName]))
+          title: MDocMacro.Emphasis(
+            arguments: [subcommand.manualPageSubcommandLabel]))
         SinglePageDescription(command: subcommand, root: false).core
       }
     }

--- a/Tools/generate-manual/Extensions/ArgumentParser+MDoc.swift
+++ b/Tools/generate-manual/Extensions/ArgumentParser+MDoc.swift
@@ -31,6 +31,11 @@ extension CommandInfoV0 {
     let parts = (superCommands ?? []) + [commandName]
     return parts.joined(separator: " ")
   }
+
+  var manualPageSubcommandLabel: String {
+    guard let aliases = aliases, !aliases.isEmpty else { return commandName }
+    return ([commandName] + aliases).joined(separator: ", ")
+  }
 }
 
 extension ArgumentInfoV0 {


### PR DESCRIPTION
Resolves #851 (and partially addresses the umbrella #849).

Subcommand aliases already flow through `CommandInfoV0.aliases` and surface in `--help` and dump-help output, but the `generate-manual` tool never consumed them.

## Changes

- `Tools/generate-manual/Extensions/ArgumentParser+MDoc.swift`: new `manualPageSubcommandLabel` helper that returns `commandName` alone, or `"commandName, alias1, alias2"` when aliases exist. Mirrors the format used by `HelpGenerator`.
- `Tools/generate-manual/DSL/SinglePageDescription.swift`: use the helper when rendering each subcommand list item.
- `Tools/generate-manual/DSL/Name.swift`: emit one `.Nm` macro per alias in the NAME section. This is the canonical BSD mdoc convention (see `ls(1)`, which lists `ls, dir` in NAME).
- Regenerated the two `testMath*Manual` snapshots. The other ten snapshots are unchanged because the `guard` in `manualPageSubcommandLabel` short-circuits for commands without aliases, so output for alias-less commands is byte-identical.

## Example output

Single-page (Math example, subcommand list):

```
.It Em "multiply, mul"
Print the product of the values.
...
.It Em "average, avg"
Print the average of the values.
```

Multi-page (NAME section on each subcommand page):

```
.Sh NAME
.Nm "math multiply"
.Nm mul
.Nd "Print the product of the values."
```

## Scope decisions

- `SeeAlso.swift`: left alone. It cross-references other man-pages, and aliases do not generate their own pages.
- `Synopsis.swift`: left alone. The bare `.Nm` auto-resolves to the first `.Nm` in the document, which remains the primary name.
- `MultiPageDescription.swift`: does not iterate subcommands, so no change needed.

## Test plan

- [x] `swift test --filter GenerateManualTests` passes (12/12)
- [x] Verified the existing Math example (which already declares `mul` and `avg` aliases via PR #627) now renders them in both single-page and multi-page output
- [x] Confirmed non-aliased commands produce byte-identical output (other 10 snapshots unchanged)