### PR TITLE
Improve diagnostic for @Flag Bool? without inversion:

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -251,6 +251,24 @@ extension Flag where Value == Bool? {
       exclusivity: exclusivity,
       help: help)
   }
+
+  /// Surfaces a clearer diagnostic when a user declares a `Bool?` flag without
+  /// the required `inversion:` parameter.
+  ///
+  /// Without this overload, the compiler falls back to the
+  /// `Flag where Value == Int` initializer and reports a confusing
+  /// "types 'Bool?' and 'Int' be equivalent" error.
+  @available(
+    *, unavailable,
+    message:
+      "An optional 'Bool?' @Flag requires an 'inversion:' parameter, such as '.prefixedNo' or '.prefixedEnableDisable'."
+  )
+  public init(
+    name: NameSpecification = .long,
+    help: ArgumentHelp? = nil
+  ) {
+    fatalError("unavailable")
+  }
 }
 
 extension Flag where Value == Bool {

--- a/Sources/ArgumentParser/Parsable Properties/Flag.swift
+++ b/Sources/ArgumentParser/Parsable Properties/Flag.swift
@@ -264,7 +264,7 @@ extension Flag where Value == Bool? {
       "An optional 'Bool?' @Flag requires an 'inversion:' parameter, such as '.prefixedNo' or '.prefixedEnableDisable'."
   )
   public init(
-    name: NameSpecification = .long,
+    name _name: NameSpecification = .long,
     help: ArgumentHelp? = nil
   ) {
     fatalError("unavailable")


### PR DESCRIPTION
Resolves #835.

## Problem

When a user writes the following, which looks reasonable:

```swift
@Flag(help: "Write empty files.")
var writeEmptyFiles: Bool?
```

the compiler produces a confusing diagnostic:

```
error: referencing initializer 'init(name:help:)' on 'Flag' requires the types 'Bool?' and 'Int' be equivalent
```

The actual cause is that every `Flag where Value == Bool?` init requires an `inversion:` parameter. Without one, overload resolution falls through to the `Flag where Value == Int` counter initializer at `Flag.swift:385`, which is the first `init(name:help:)` the compiler can see, and the `Bool?` vs `Int` mismatch surfaces from there.

## Fix

Add an `@available(*, unavailable)` init overload on `Flag where Value == Bool?` whose signature matches the offending call shape. Overload resolution now picks this one because its `where` clause is more specific, and the custom `message:` points the user at the real cause:

```
error: 'init(name:help:)' is unavailable: An optional 'Bool?' @Flag requires an 'inversion:' parameter, such as '.prefixedNo' or '.prefixedEnableDisable'.
```

This follows the same pattern used for the existing unavailable no-arg `Flag.init()` at `Flag.swift:94-101`, whose doc comment already explains this technique:

> Explicitly marking this initializer unavailable means that when `Value` is a type supported by `Flag` like `Bool` or `EnumerableFlag`, the appropriate overload will be selected instead.

## Test plan

- [x] `swift test` passes (495 tests, no failures)
- [x] Reproduced the original confusing error on `main`
- [x] Verified the new diagnostic message appears for `@Flag(help: "...") var x: Bool?`
- [x] Verified the legitimate usage `@Flag(inversion: .prefixedEnableDisable) var x: Bool?` still compiles and runs correctly