### PR TITLE
Fix: Use `visibility.base` consistently in `generateHelpNames` for `.longWithSingleDash`

### DIFF
--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -444,7 +444,7 @@ extension NameSpecification {
         case .long(let helpName):
           return .long("\(helpName)-\(visibility.base)")
         case .longWithSingleDash(let helpName):
-          return .longWithSingleDash("\(helpName)-\(visibility)")
+          return .longWithSingleDash("\(helpName)-\(visibility.base)")  // Fix: use .base for consistency with .long case
         case .short:
           // Cannot create a non-default help flag from a short name.
           return nil


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in `generateHelpNames(visibility:)` in `HelpGenerator.swift` where the `.longWithSingleDash` case used the full `visibility` description instead of `visibility.base`, while the `.long` case correctly used `visibility.base`.

**Fixes #901**

## The Bug

```swift
// BEFORE (inconsistent)
case .long(let helpName):
  return .long("\(helpName)-\(visibility.base)")           // ✅ uses .base
case .longWithSingleDash(let helpName):
  return .longWithSingleDash("\(helpName)-\(visibility)")  // ❌ uses full visibility
```

## The Fix

```swift
// AFTER (consistent)
case .long(let helpName):
  return .long("\(helpName)-\(visibility.base)")
case .longWithSingleDash(let helpName):
  return .longWithSingleDash("\(helpName)-\(visibility.base)")  // ✅ now matches .long
```

## Impact

- **One-line change** with no API breakage
- Affects only commands that configure `helpNames` with `.longWithSingleDash` at non-default (`hidden`/`private`) visibility levels
- Ensures `-help-hidden` and `--help-hidden` use the same suffix generation logic

## Testing

Existing tests for help generation should continue to pass. The affected code path is only triggered when:
1. `helpNames` includes `.longWithSingleDash`
2. `visibility.base != .default` (i.e., `.hidden` or `.private`)

No new tests are broken by this change.