### PR TITLE
Update PR 855 description in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 - `NameSpecification` and its elements now conform to `ExpressibleByStringLiteral`, allowing simplified option and flag name declarations. For example, `[.customLong("hex-output"), .customShort("x")]` can now be written as `"--hex-output -x"`. ([#745])
 - New `@Option` initializers accept a `defaultAsFlag:` parameter, creating options that work both as a bare flag (`--format`) and as an option with a value (`--format json`). ([#830])
-- Custom completion closures for `AsyncParsableCommand` types now support `async`/`await`. ([#855])
+- Custom completion closures for `AsyncParsableCommand` types are now implemented via `async`/`await` instead of via `DispatchSemaphore`. ([#855])
 
 ### Changes
 


### PR DESCRIPTION
Update PR 855 description in changelog.

Not to be pedantic, but I think this minor rewrite clarifies #855.

If possible, it would be useful to copy this minor change to the [1.8.0 release notes](https://github.com/apple/swift-argument-parser/releases/tag/1.8.0).

Thanks.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
