### PR TITLE
Revert source break in 1.8.0 `parse` methods

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,6 +64,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
     with:
       shell_check_enabled: false  # bug: https://github.com/apple/swift-argument-parser/issues/703
+      api_breakage_check_enabled: false # re-enable after https://github.com/apple/swift-argument-parser/pull/908
 
   required:
     name: Required

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,7 +64,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
     with:
       shell_check_enabled: false  # bug: https://github.com/apple/swift-argument-parser/issues/703
-      api_breakage_check_enabled: false # re-enable after https://github.com/apple/swift-argument-parser/pull/908
+      api_breakage_check_enabled: false  # re-enable after https://github.com/apple/swift-argument-parser/pull/908
 
   required:
     name: Required

--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -31,10 +31,10 @@ extension AsyncParsableCommand {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   /// - Returns: A new instance of this type.
   /// - Throws: If parsing failed or arguments contains a help request.
-  public static func parse(
+  public static func asyncParse(
     _ arguments: [String]? = nil
   ) async throws -> Self {
-    try parse(try await parseAsRoot(arguments))
+    try parse(try await asyncParseAsRoot(arguments))
   }
 
   /// Parses an instance of this type, or one of its subcommands, from
@@ -45,7 +45,7 @@ extension AsyncParsableCommand {
   /// - Returns: A new instance of this type, one of its subcommands, or a
   ///   command type internal to the `ArgumentParser` library.
   /// - Throws: If parsing fails.
-  public static func parseAsRoot(
+  public static func asyncParseAsRoot(
     _ arguments: [String]? = nil
   ) async throws -> ParsableCommand {
     var parser = CommandParser(self)
@@ -64,7 +64,7 @@ extension AsyncParsableCommand {
   ///   `arguments` is `nil`, this uses the program's command-line arguments.
   public static func main(_ arguments: [String]?) async {
     do {
-      var command = try await parseAsRoot(arguments)
+      var command = try await asyncParseAsRoot(arguments)
       if var asyncCommand = command as? AsyncParsableCommand {
         try await asyncCommand.run()
       } else {

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -303,6 +303,23 @@ extension CommandParser {
   mutating func parse(
     arguments: [String]
   ) throws(CommandError) -> ParsableCommand {
+    #if DEBUG
+    if self.rootCommand is AsyncParsableCommand.Type,
+      let error =
+        AsyncCompletionsValidator
+        .validate(self.rootCommand, parent: nil, forcedSyncParse: true)
+    {
+      configurationFailure(
+        """
+        This command uses asynchronous custom completion functions,
+        but is invoked using a synchronous call to `parse` or 
+        `parseAsRoot`. To fix this issue, call the asynchronous
+        versions of these functions: `asyncParse` or `asyncParseAsRoot`,
+        respectively.
+        """)
+    }
+    #endif
+
     do {
       if let (argument, arguments) =
         try parseCustomCompletion(from: arguments)

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -304,7 +304,8 @@ extension CommandParser {
     arguments: [String]
   ) throws(CommandError) -> ParsableCommand {
     #if DEBUG
-    if self.rootCommand is AsyncParsableCommand.Type,
+    if #available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *),
+      self.rootCommand is AsyncParsableCommand.Type,
       let error =
         AsyncCompletionsValidator
         .validate(self.rootCommand, parent: nil, forcedSyncParse: true)

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -306,17 +306,19 @@ extension CommandParser {
     #if DEBUG
     if #available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *),
       self.rootCommand is AsyncParsableCommand.Type,
-      let error =
-        AsyncCompletionsValidator
-        .validate(self.rootCommand, parent: nil, forcedSyncParse: true)
+      self.rootCommand.asyncCompletions(
+        parent: nil,
+        propertyPath: String(describing: self.rootCommand)
+      ).isEmpty == false
     {
       configurationFailure(
         """
         This command uses asynchronous custom completion functions,
-        but is invoked using a synchronous call to `parse` or 
-        `parseAsRoot`. To fix this issue, call the asynchronous
-        versions of these functions: `asyncParse` or `asyncParseAsRoot`,
-        respectively.
+        but is invoked using a synchronous call to `parse` or
+        `parseAsRoot`. 
+
+        To fix this issue, call the asynchronous versions of these 
+        functions: `asyncParse` or `asyncParseAsRoot`, respectively.
         """)
     }
     #endif

--- a/Sources/ArgumentParser/Validators/AsyncCompletionsValidator.swift
+++ b/Sources/ArgumentParser/Validators/AsyncCompletionsValidator.swift
@@ -36,24 +36,12 @@ struct AsyncCompletionsValidator: ParsableArgumentsValidator {
   static func validate(_ type: ParsableArguments.Type, parent: InputKey?)
     -> ParsableArgumentsValidatorError?
   {
-    validate(type, parent: parent, forcedSyncParse: false)
-  }
-
-  static func validate(
-    _ type: ParsableArguments.Type,
-    parent: InputKey?,
-    forcedSyncParse: Bool
-  )
-    -> ParsableArgumentsValidatorError?
-  {
-    guard
-      type is ParsableCommand.Type,
-      !(type is AsyncParsableCommand.Type) || forcedSyncParse
+    guard type is ParsableCommand.Type, !(type is AsyncParsableCommand.Type)
     else {
       return nil
     }
 
-    let invalidAsyncCompletions = type.invalidAsyncCompletions(
+    let invalidAsyncCompletions = type.asyncCompletions(
       parent: parent,
       propertyPath: String(describing: type)
     )
@@ -73,7 +61,8 @@ extension OptionGroup: AnyOptionGroup {
 }
 
 extension ParsableArguments {
-  static func invalidAsyncCompletions(
+  /// Returns a recursively-built list of properties with async custom completions.
+  static func asyncCompletions(
     parent: InputKey?,
     propertyPath: String
   ) -> [String] {
@@ -84,7 +73,7 @@ extension ParsableArguments {
           .map { $0.hasPrefix("_") ? String($0.dropFirst()) : $0 }
           .flatMap { label in
             (type(of: child.value) as? AnyOptionGroup.Type)?
-              .wrappedType.invalidAsyncCompletions(
+              .wrappedType.asyncCompletions(
                 parent: InputKey(name: label, parent: parent),
                 propertyPath: "\(propertyPath).\(label)"
               )

--- a/Sources/ArgumentParser/Validators/AsyncCompletionsValidator.swift
+++ b/Sources/ArgumentParser/Validators/AsyncCompletionsValidator.swift
@@ -36,10 +36,22 @@ struct AsyncCompletionsValidator: ParsableArgumentsValidator {
   static func validate(_ type: ParsableArguments.Type, parent: InputKey?)
     -> ParsableArgumentsValidatorError?
   {
+    validate(type, parent: parent, forcedSyncParse: false)
+  }
+
+  static func validate(
+    _ type: ParsableArguments.Type,
+    parent: InputKey?,
+    forcedSyncParse: Bool
+  )
+    -> ParsableArgumentsValidatorError?
+  {
     guard
       type is ParsableCommand.Type,
-      !(type is AsyncParsableCommand.Type)
-    else { return nil }
+      !(type is AsyncParsableCommand.Type) || forcedSyncParse
+    else {
+      return nil
+    }
 
     let invalidAsyncCompletions = type.invalidAsyncCompletions(
       parent: parent,

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -199,7 +199,7 @@ extension CompletionScriptTests {
       Platform.Environment[.shellName, as: CompletionShell.self] = shell
       defer { Platform.Environment[.shellName] = nil }
       if let command = command as? AsyncParsableCommand.Type {
-        _ = try await command.parse(["---completion", "--", arg, "0", "0"])
+        _ = try await command.asyncParse(["---completion", "--", arg, "0", "0"])
       } else {
         _ = try command.parse(["---completion", "--", arg, "0", "0"])
       }


### PR DESCRIPTION
This removes the `async` overloads to `parse` and `parseAsRoot` that caused a source break in 1.8.0, and introduces new names that disambiguate the methods with `async` behavior. Instead of calling the existing methods with the `await` keyword, users can call `await asyncParse` or `await asyncParseAsRoot`.

This change also adds a validation step to the synchronous parsing path to check if an async completions function is called.

Users that have already updated their code to work around the source break will revert to the old methods with this change, which will yield a "No 'async' operations occur within 'await' expression" warning. They can remove the `await` keyword or update to call the async versions directly to fix the warning.

Resolves #907