### PR TITLE
Add native response file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Add new items at the end of the relevant section under **Unreleased**.
 ### Additions
 
 - `CommandConfiguration` now accepts a `helpBanner`, a string printed verbatim above the overview on a command's help screen and inherited by its subcommands unless they provide their own banner or the empty string.
+- Commands can now opt in to response-file expansion by overriding the `ParsableCommand.responseFilePrefix` static property with the character that should introduce a response-file reference (for example, `static var responseFilePrefix: Character? { "@" }`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
+- Commands can now opt in to response-file expansion by overriding the `ParsableCommand.responseFilePrefix` static property with the character that should introduce a response-file reference (for example, `static var responseFilePrefix: Character? { "@" }`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ Add new items at the end of the relevant section under **Unreleased**.
 ### Additions
 
 - `CommandConfiguration` now accepts a `helpBanner`, a string printed verbatim above the overview on a command's help screen and inherited by its subcommands unless they provide their own banner or the empty string.
-- Commands can now opt in to response-file expansion by overriding the `ParsableCommand.responseFilePrefix` static property with the character that should introduce a response-file reference (for example, `static var responseFilePrefix: Character? { "@" }`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
-- Commands can now opt in to response-file expansion by overriding the `ParsableCommand.responseFilePrefix` static property with the character that should introduce a response-file reference (for example, `static var responseFilePrefix: Character? { "@" }`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
+- Commands can now opt in to response-file expansion by setting the `responseFilePrefix` property on their `CommandConfiguration` to the character that should introduce a response-file reference (for example, `static let configuration = CommandConfiguration(responseFilePrefix: "@")`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ OPTIONS:
   -h, --help              Show help for this command.
 ```
 
+## Response Files
+
+Swift Argument Parser can expand response files, letting you store command-line arguments in text files. This is especially useful for commands with many arguments or for reusable configurations. Opt in on your root command by overriding the `responseFilePrefix` static property with the character that should introduce a response-file reference (commonly `@`):
+
+```swift
+struct Repeat: ParsableCommand {
+    static var responseFilePrefix: Character? { "@" }
+    // ...
+}
+```
+
+```bash
+# Store arguments in a file
+$ echo "--count 5 --include-counter hello" > args.txt
+
+# Use the response file with @filename syntax
+$ repeat @args.txt
+1: hello
+2: hello
+3: hello
+4: hello
+5: hello
+```
+
+Response files support multiple formats, comments, quoted arguments, and can even reference other response files. See the [Response Files documentation](https://swiftpackageindex.com/apple/swift-argument-parser/documentation/argumentparser/responsefiles) for complete details.
+
 ## Documentation
 
 For guides, articles, and API documentation see the

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ OPTIONS:
 
 ## Response Files
 
-Swift Argument Parser can expand response files, letting you store command-line arguments in text files. This is especially useful for commands with many arguments or for reusable configurations. Opt in on your root command by overriding the `responseFilePrefix` static property with the character that should introduce a response-file reference (commonly `@`):
+Swift Argument Parser can expand response files, letting you store command-line arguments in text files. This is especially useful for commands with many arguments or for reusable configurations. Opt in on your root command by setting the `responseFilePrefix` property in its `CommandConfiguration` to the character that should introduce a response-file reference (commonly `@`):
 
 ```swift
 struct Repeat: ParsableCommand {
-    static var responseFilePrefix: Character? { "@" }
+    static let configuration = CommandConfiguration(responseFilePrefix: "@")
     // ...
 }
 ```

--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(ArgumentParser
   Parsing/Parsed.swift
   Parsing/ParsedValues.swift
   Parsing/ParserError.swift
+  Parsing/ResponseFileExpander.swift
   Parsing/SplitArguments.swift
 
   Usage/DumpHelpGenerator.swift

--- a/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
+++ b/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
@@ -10,7 +10,7 @@ Begin by declaring a type that defines
 the information that you need to collect from the command line.
 Decorate each stored property with one of `ArgumentParser`'s property wrappers,
 declare conformance to ``ParsableCommand``,
-and implement your command's logic in its `run()` method. 
+and implement your command's logic in its `run()` method.
 For `async` renditions of `run`, declare ``AsyncParsableCommand`` conformance instead.
 
 ```swift
@@ -33,7 +33,7 @@ struct Repeat: ParsableCommand {
 }
 ```
 
-When a user executes your command, 
+When a user executes your command,
 the `ArgumentParser` library parses the command-line arguments,
 instantiates your command type,
 and then either calls your `run()` method or exits with a useful message.
@@ -58,6 +58,7 @@ and then either calls your `run()` method or exits with a useful message.
 ### Arguments, Options, and Flags
 
 - <doc:DeclaringArguments>
+- <doc:ResponseFiles>
 - ``Argument``
 - ``Option``
 - ``Flag``

--- a/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
@@ -177,14 +177,14 @@ tokens):
 
 #### Common mistakes
 
-- **Unclosed quotes** are implicitly closed at end-of-line (matching the
-  gcc/LLVM tokenizer), so the token that follows the opening quote
-  absorbs the rest of the line verbatim. Watch out for this: a stray `"`
-  or `'` in the middle of a line will silently gobble everything up to
-  the next newline into one argument.
+- **Unclosed quotes** are implicitly closed at end-of-file: whatever
+  content follows the opening quote — including any intervening
+  newlines — becomes part of a single token. Watch out for this: a
+  stray `"` or `'` will silently gobble everything up to the end of the
+  file (or the matching quote) into one argument.
 - **Mismatched quotes** (opening with `"` and closing with `'`, or vice
   versa) behave the same way — the second quote is treated as literal
-  content, and the token terminates at end-of-line.
+  content inside the still-open segment.
 - **Escaping in the wrong style** — writing `'a\nb'` produces the literal
   four characters `a\nb`, not `a<newline>b`. Use double quotes if you want
   the newline.

--- a/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
@@ -1,0 +1,359 @@
+# Response Files
+
+Use response files to store command-line arguments in files for reuse and to handle commands with many arguments.
+
+## Overview
+
+Response files allow you to store command-line arguments in text files and reference them using the `@filename` syntax. This feature is particularly useful for:
+
+- Commands with many arguments that would be unwieldy on the command line
+- Reusable argument sets for different configurations
+- Build systems and automation scripts
+- Avoiding command-line length limitations
+
+Swift Argument Parser response file support is opt-in per command. To
+enable it, override the `responseFilePrefix` static property on your
+root `ParsableCommand` (or `AsyncParsableCommand`) with the character
+that should introduce a response-file reference. The default value is
+`nil`, meaning response files are disabled and any argument that would
+otherwise look like `@file` is passed through as a literal value.
+
+## Basic Usage
+
+Enable response files by declaring a prefix on the root command:
+
+```swift
+struct MyTool: ParsableCommand {
+    static var responseFilePrefix: Character? { "@" }
+    // ...
+}
+```
+
+Then reference a response file on the command line by prefixing the
+filename with the character you chose (`@` in this example):
+
+```bash
+mycommand @args.txt --verbose
+```
+
+This expands the contents of `args.txt` and includes them in the command-line arguments.
+
+### Customizing the Response File Prefix
+
+The `@` character is the most widely used convention (for example,
+`clang @args.txt`), but any single character works. If `@` conflicts
+with your command's own argument syntax, pick a different character
+instead. The root command's prefix applies to the entire invocation,
+including subcommand parsing.
+
+```swift
+struct MyTool: ParsableCommand {
+    static var responseFilePrefix: Character? { "+" }
+    // ...
+}
+```
+
+With this configuration, `mytool +args.txt` expands `args.txt` as a
+response file, while `mytool @foo` is passed through as a literal
+argument. The same doubling escape convention applies to the customized
+prefix — `++value` inside a response file produces the literal `+value`,
+mirroring the, implied response file prefix, `@@` → `@` behavior
+described in [Literal At Signs](#literal-at-signs).
+
+### Response File Format
+
+Response files support multiple formats:
+
+#### One Argument Per Line
+```
+--input
+input.txt
+--output
+output.txt
+--verbose
+```
+
+#### Space-Separated Arguments
+```
+--input input.txt --output output.txt --verbose
+```
+
+#### Mixed Format
+```
+--input input.txt
+--output output.txt
+--verbose --count 42
+```
+
+## Advanced Features
+
+### Quoted Arguments
+
+Response files support quoted arguments for values containing spaces, special
+characters, or characters that would otherwise be interpreted as part of the
+response-file syntax (like `#` starting a comment).
+
+```
+--input "file with spaces.txt"
+--message 'Hello, world!'
+--path "/Users/username/My Documents/file.txt"
+```
+
+#### Which quote style to use
+
+Both double quotes (`"..."`) and single quotes (`'...'`) are supported, and
+they behave differently:
+
+- **Double quotes (`"..."`)** — the *interpreting* quote. Escape sequences
+  inside the quotes are processed (see below), and the quote character can
+  itself be escaped with `\"`.
+- **Single quotes (`'...'`)** — the *literal* quote. Everything between the
+  quotes is taken verbatim; there is no escape processing. Use single quotes
+  when the value contains backslashes or double quotes that you want to
+  preserve exactly as written.
+- **Nested quotes** — a double-quoted string may contain unescaped single
+  quotes, and a single-quoted string may contain unescaped double quotes.
+  Only the outer quote style needs to be escaped or switched.
+
+Examples:
+
+```
+# Double-quoted: backslash escapes are processed.
+--message "line one\nline two"        # decoded as "line one<LF>line two"
+--path    "C:\\Users\\Bob\\file.txt"  # decoded as "C:\Users\Bob\file.txt"
+--quote   "she said \"hi\""           # decoded as 'she said "hi"'
+
+# Single-quoted: nothing is processed. Use this when you want backslashes
+# to reach the tool verbatim.
+--regex   'foo\d+\.bar'               # tool receives 'foo\d+\.bar' unchanged
+--json    '{"key": "value"}'          # tool receives '{"key": "value"}'
+
+# Mixing quote styles avoids escaping.
+--sql     "SELECT * FROM 'users'"
+--label   'the "special" one'
+```
+
+#### Recognized escape sequences (double quotes only)
+
+Inside double-quoted arguments, the following backslash escapes are
+recognized:
+
+| Escape | Decoded |
+|--------|---------|
+| `\n`   | newline |
+| `\t`   | tab     |
+| `\r`   | carriage return |
+| `\\`   | a single `\` |
+| `\"`   | a single `"` |
+
+Any other `\x` sequence (for an unrecognized `x`) is preserved verbatim as
+`\x`, so accidental escape characters don't silently disappear. Backslashes
+inside single-quoted arguments are always literal.
+
+#### Whitespace handling
+
+Whitespace inside a quoted value (of either style) is preserved and treated
+as part of the value — it does not split the argument. Outside of quotes,
+runs of spaces and tabs separate arguments as usual.
+
+```
+# Both --title and --tags receive a single value each.
+--title "Grand Total"
+--tags  '  keep   the   spaces  '
+```
+
+#### `@file` inside a quoted argument
+
+The response-file prefix is only interpreted when it starts an *unquoted*
+token. A quoted string that happens to begin with `@` is passed through as a
+literal value (this differs from the `@@`-escape mechanism described in
+[Literal At Signs](#literal-at-signs), which only applies to unquoted
+tokens):
+
+```
+--username "@admin"    # value is "@admin"; no file is opened
+--pattern  '@daily'    # value is "@daily"; single quotes protect it too
+```
+
+#### Common mistakes
+
+- **Unclosed quotes** are implicitly closed at end-of-line (matching the
+  gcc/LLVM tokenizer), so the token that follows the opening quote
+  absorbs the rest of the line verbatim. Watch out for this: a stray `"`
+  or `'` in the middle of a line will silently gobble everything up to
+  the next newline into one argument.
+- **Mismatched quotes** (opening with `"` and closing with `'`, or vice
+  versa) behave the same way — the second quote is treated as literal
+  content, and the token terminates at end-of-line.
+- **Escaping in the wrong style** — writing `'a\nb'` produces the literal
+  four characters `a\nb`, not `a<newline>b`. Use double quotes if you want
+  the newline.
+
+### Comments
+
+Use `#` to add comments to response files:
+
+```
+# Configuration for production build
+--release
+--optimize-for-size
+--output production.app  # Output directory
+```
+
+### Equals Format
+
+Arguments can use the equals format:
+
+```
+--input=input.txt
+--output=output.txt
+--count=42
+```
+
+### Nested Response Files
+
+Response files can reference other response files:
+
+```
+# main.txt
+@common-options.txt
+--specific-flag
+@environment-config.txt
+```
+
+```
+# common-options.txt
+--verbose
+--log-level debug
+```
+
+```
+# environment-config.txt
+--api-endpoint https://api.example.com
+--timeout 30
+```
+
+## Error Handling
+
+Swift Argument Parser provides clear error messages for response file issues:
+
+### File Not Found
+```
+Error: Response file not found: args.txt
+```
+
+### Malformed Content
+```
+Error: Malformed content in response file 'args.txt': Line 3: Unclosed quote in argument
+```
+
+### Recursive Inclusion
+```
+Error: Recursive response file inclusion detected: /path/to/recursive.txt
+```
+
+### Maximum Nesting Depth
+```
+Error: Maximum nesting depth (32) exceeded for response files
+```
+
+## Examples
+
+### Build Configuration
+
+Create different response files for different build configurations:
+
+```bash
+# debug.txt
+--configuration debug
+--enable-assertions
+--debug-info-format dwarf
+--output debug-build
+
+# release.txt
+--configuration release
+--optimize-for-speed
+--strip-debug-symbols
+--output release-build
+```
+
+Use them with your build command:
+
+```bash
+myBuild @debug.txt
+myBuild build @release.txt
+```
+
+### Testing with Multiple Inputs
+
+```bash
+# test-inputs.txt
+--input test1.swift
+--input test2.swift
+--input test3.swift
+--output-dir test-results
+--format junit
+--parallel
+```
+
+```bash
+myTest @test-inputs.txt
+```
+
+### Database Migration
+
+```bash
+# migration.txt
+--database-url postgresql://localhost/myapp
+--migration-dir migrations/
+--environment production
+--backup-before-migration
+--verbose
+```
+
+```bash
+migrate @migration.txt
+```
+
+## Mixing Response Files with Command-Line Arguments
+
+You can combine response files with regular command-line arguments:
+
+```bash
+mycommand @base-config.txt --override-setting value @additional-flags.txt
+```
+
+Arguments are processed in order, so later arguments can override earlier ones:
+
+```bash
+# If base-config.txt contains "--count 10"
+mycommand @base-config.txt --count 20  # Final count will be 20
+```
+
+## Literal At Signs
+
+To use a literal `@` character in an argument, escape it with `@@`:
+
+```bash
+mycommand --username @@admin  # Passes "@admin" as the username
+```
+
+In response files:
+
+```
+--message @@important: This is critical
+--email user@@example.com
+```
+
+Inside a response file, you can also protect a leading `@` by wrapping the
+value in quotes — see [Quoted Arguments](#quoted-arguments) for details on
+how quoted tokens beginning with `@` are passed through verbatim.
+
+## Performance Considerations
+
+Response files are processed efficiently:
+
+- Files are read once and cached during parsing
+- Large response files (thousands of arguments) are supported
+- Nested files are processed with recursion detection to prevent infinite loops
+- Memory usage scales linearly with the total number of arguments

--- a/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md
@@ -12,19 +12,20 @@ Response files allow you to store command-line arguments in text files and refer
 - Avoiding command-line length limitations
 
 Swift Argument Parser response file support is opt-in per command. To
-enable it, override the `responseFilePrefix` static property on your
-root `ParsableCommand` (or `AsyncParsableCommand`) with the character
-that should introduce a response-file reference. The default value is
-`nil`, meaning response files are disabled and any argument that would
-otherwise look like `@file` is passed through as a literal value.
+enable it, set the `responseFilePrefix` property on the
+`CommandConfiguration` of your root `ParsableCommand` (or
+`AsyncParsableCommand`) to the character that should introduce a
+response-file reference. The default value is `nil`, meaning response
+files are disabled and any argument that would otherwise look like
+`@file` is passed through as a literal value.
 
-## Basic Usage
+### Basic Usage
 
 Enable response files by declaring a prefix on the root command:
 
 ```swift
 struct MyTool: ParsableCommand {
-    static var responseFilePrefix: Character? { "@" }
+    static let configuration = CommandConfiguration(responseFilePrefix: "@")
     // ...
 }
 ```
@@ -38,7 +39,7 @@ mycommand @args.txt --verbose
 
 This expands the contents of `args.txt` and includes them in the command-line arguments.
 
-### Customizing the Response File Prefix
+#### Customizing the Response File Prefix
 
 The `@` character is the most widely used convention (for example,
 `clang @args.txt`), but any single character works. If `@` conflicts
@@ -48,7 +49,7 @@ including subcommand parsing.
 
 ```swift
 struct MyTool: ParsableCommand {
-    static var responseFilePrefix: Character? { "+" }
+    static let configuration = CommandConfiguration(responseFilePrefix: "+")
     // ...
 }
 ```
@@ -60,11 +61,11 @@ prefix — `++value` inside a response file produces the literal `+value`,
 mirroring the, implied response file prefix, `@@` → `@` behavior
 described in [Literal At Signs](#literal-at-signs).
 
-### Response File Format
+#### Response File Format
 
 Response files support multiple formats:
 
-#### One Argument Per Line
+##### One Argument Per Line
 ```
 --input
 input.txt
@@ -73,21 +74,21 @@ output.txt
 --verbose
 ```
 
-#### Space-Separated Arguments
+##### Space-Separated Arguments
 ```
 --input input.txt --output output.txt --verbose
 ```
 
-#### Mixed Format
+##### Mixed Format
 ```
 --input input.txt
 --output output.txt
 --verbose --count 42
 ```
 
-## Advanced Features
+### Advanced Features
 
-### Quoted Arguments
+#### Quoted Arguments
 
 Response files support quoted arguments for values containing spaces, special
 characters, or characters that would otherwise be interpreted as part of the
@@ -99,7 +100,7 @@ response-file syntax (like `#` starting a comment).
 --path "/Users/username/My Documents/file.txt"
 ```
 
-#### Which quote style to use
+##### Which quote style to use
 
 Both double quotes (`"..."`) and single quotes (`'...'`) are supported, and
 they behave differently:
@@ -133,7 +134,7 @@ Examples:
 --label   'the "special" one'
 ```
 
-#### Recognized escape sequences (double quotes only)
+##### Recognized escape sequences (double quotes only)
 
 Inside double-quoted arguments, the following backslash escapes are
 recognized:
@@ -150,7 +151,7 @@ Any other `\x` sequence (for an unrecognized `x`) is preserved verbatim as
 `\x`, so accidental escape characters don't silently disappear. Backslashes
 inside single-quoted arguments are always literal.
 
-#### Whitespace handling
+##### Whitespace handling
 
 Whitespace inside a quoted value (of either style) is preserved and treated
 as part of the value — it does not split the argument. Outside of quotes,
@@ -162,7 +163,7 @@ runs of spaces and tabs separate arguments as usual.
 --tags  '  keep   the   spaces  '
 ```
 
-#### `@file` inside a quoted argument
+##### `@file` inside a quoted argument
 
 The response-file prefix is only interpreted when it starts an *unquoted*
 token. A quoted string that happens to begin with `@` is passed through as a
@@ -175,7 +176,7 @@ tokens):
 --pattern  '@daily'    # value is "@daily"; single quotes protect it too
 ```
 
-#### Common mistakes
+##### Common mistakes
 
 - **Unclosed quotes** are implicitly closed at end-of-file: whatever
   content follows the opening quote — including any intervening
@@ -189,7 +190,7 @@ tokens):
   four characters `a\nb`, not `a<newline>b`. Use double quotes if you want
   the newline.
 
-### Comments
+#### Comments
 
 Use `#` to add comments to response files:
 
@@ -200,7 +201,7 @@ Use `#` to add comments to response files:
 --output production.app  # Output directory
 ```
 
-### Equals Format
+#### Equals Format
 
 Arguments can use the equals format:
 
@@ -210,7 +211,7 @@ Arguments can use the equals format:
 --count=42
 ```
 
-### Nested Response Files
+#### Nested Response Files
 
 Response files can reference other response files:
 
@@ -233,33 +234,33 @@ Response files can reference other response files:
 --timeout 30
 ```
 
-## Error Handling
+### Error Handling
 
 Swift Argument Parser provides clear error messages for response file issues:
 
-### File Not Found
+#### File Not Found
 ```
 Error: Response file not found: args.txt
 ```
 
-### Malformed Content
+#### Malformed Content
 ```
 Error: Malformed content in response file 'args.txt': Line 3: Unclosed quote in argument
 ```
 
-### Recursive Inclusion
+#### Recursive Inclusion
 ```
 Error: Recursive response file inclusion detected: /path/to/recursive.txt
 ```
 
-### Maximum Nesting Depth
+#### Maximum Nesting Depth
 ```
 Error: Maximum nesting depth (32) exceeded for response files
 ```
 
-## Examples
+### Examples
 
-### Build Configuration
+#### Build Configuration
 
 Create different response files for different build configurations:
 
@@ -284,7 +285,7 @@ myBuild @debug.txt
 myBuild build @release.txt
 ```
 
-### Testing with Multiple Inputs
+#### Testing with Multiple Inputs
 
 ```bash
 # test-inputs.txt
@@ -300,7 +301,7 @@ myBuild build @release.txt
 myTest @test-inputs.txt
 ```
 
-### Database Migration
+#### Database Migration
 
 ```bash
 # migration.txt
@@ -315,7 +316,7 @@ myTest @test-inputs.txt
 migrate @migration.txt
 ```
 
-## Mixing Response Files with Command-Line Arguments
+### Mixing Response Files with Command-Line Arguments
 
 You can combine response files with regular command-line arguments:
 
@@ -330,7 +331,7 @@ Arguments are processed in order, so later arguments can override earlier ones:
 mycommand @base-config.txt --count 20  # Final count will be 20
 ```
 
-## Literal At Signs
+### Literal At Signs
 
 To use a literal `@` character in an argument, escape it with `@@`:
 
@@ -349,7 +350,7 @@ Inside a response file, you can also protect a leading `@` by wrapping the
 value in quotes — see [Quoted Arguments](#quoted-arguments) for details on
 how quoted tokens beginning with `@` are passed through verbatim.
 
-## Performance Considerations
+### Performance Considerations
 
 Response files are processed efficiently:
 

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
@@ -4,7 +4,7 @@
 
 ### Creating a Configuration
 
-- ``init(commandName:abstract:usage:discussion:helpBanner:version:shouldDisplay:subcommands:groupedSubcommands:defaultSubcommand:helpNames:aliases:)``
+- ``init(commandName:abstract:usage:discussion:helpBanner:version:shouldDisplay:subcommands:groupedSubcommands:defaultSubcommand:helpNames:aliases:responseFilePrefix:)``
 
 ### Customizing the Help Screen
 

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -94,6 +94,31 @@ public struct CommandConfiguration: Sendable {
   /// or `commandName` itself if provided.
   public var aliases: [String]
 
+  /// The character used to introduce a response file argument for this
+  /// command.
+  ///
+  /// A command-line argument whose first character matches this prefix is
+  /// treated as a reference to a file whose contents should be expanded
+  /// in place. The default is `nil`, meaning response file expansion is
+  /// disabled.
+  ///
+  /// Set this on a root command to opt in to response file expansion
+  /// with the given character (for example, `"@"` matches the widely
+  /// used convention `mycommand @args.txt`). The root command's prefix
+  /// determines the prefix used for the entire invocation, including
+  /// subcommand parsing.
+  ///
+  ///     struct MyTool: ParsableCommand {
+  ///       static let configuration = CommandConfiguration(
+  ///         responseFilePrefix: "+")
+  ///       // ...
+  ///     }
+  ///
+  /// With the above configuration, `mytool +args.txt` expands `args.txt`
+  /// as a response file, while `mytool @foo` is treated as a literal
+  /// argument.
+  public var responseFilePrefix: Character?
+
   /// Creates the configuration for a command.
   ///
   /// - Parameters:
@@ -129,6 +154,10 @@ public struct CommandConfiguration: Sendable {
   ///   - aliases: An array of aliases for the command's name. All of the aliases
   ///     MUST not match the actual command name, whether that be the derived name
   ///     if `commandName` is not provided, or `commandName` itself if provided.
+  ///   - responseFilePrefix: The character that introduces a response-file
+  ///     argument on the command line, or `nil` to disable response-file
+  ///     expansion. The default is `nil`. Set this on a root command to opt
+  ///     in to expansion (for example, `"@"` for `mytool @args.txt`).
   public init(
     commandName: String? = nil,
     abstract: String = "",
@@ -141,7 +170,8 @@ public struct CommandConfiguration: Sendable {
     groupedSubcommands: [CommandGroup] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
     helpNames: NameSpecification? = nil,
-    aliases: [String] = []
+    aliases: [String] = [],
+    responseFilePrefix: Character? = nil
   ) {
     self.commandName = commandName
     self.abstract = abstract
@@ -155,6 +185,7 @@ public struct CommandConfiguration: Sendable {
     self.defaultSubcommand = defaultSubcommand
     self.helpNames = helpNames
     self.aliases = aliases
+    self.responseFilePrefix = responseFilePrefix
   }
 
   /// Creates the configuration for a command with a "super-command"
@@ -172,7 +203,8 @@ public struct CommandConfiguration: Sendable {
     groupedSubcommands: [CommandGroup] = [],
     defaultSubcommand: ParsableCommand.Type? = nil,
     helpNames: NameSpecification? = nil,
-    aliases: [String] = []
+    aliases: [String] = [],
+    responseFilePrefix: Character? = nil
   ) {
     self.commandName = commandName
     self._superCommandName = _superCommandName
@@ -187,6 +219,7 @@ public struct CommandConfiguration: Sendable {
     self.defaultSubcommand = defaultSubcommand
     self.helpNames = helpNames
     self.aliases = aliases
+    self.responseFilePrefix = responseFilePrefix
   }
 }
 

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -22,6 +22,30 @@ public protocol ParsableCommand: ParsableArguments {
   /// can pass through the wrapped type's name.
   static var _commandName: String { get }
 
+  /// The character used to introduce a response file argument for this
+  /// command.
+  ///
+  /// A command-line argument whose first character matches this prefix is
+  /// treated as a reference to a file whose contents should be expanded
+  /// in place. The default is `nil`, meaning response file expansion is
+  /// disabled.
+  ///
+  /// Override this property on a root command to opt in to response file
+  /// expansion with the given character (for example, `"@"` matches the
+  /// widely used convention `mycommand @args.txt`). The root command's
+  /// prefix determines the prefix used for the entire invocation,
+  /// including subcommand parsing.
+  ///
+  ///     struct MyTool: ParsableCommand {
+  ///       static var responseFilePrefix: Character? { "+" }
+  ///       // ...
+  ///     }
+  ///
+  /// With the above configuration, `mytool +args.txt` expands `args.txt`
+  /// as a response file, while `mytool @foo` is treated as a literal
+  /// argument.
+  static var responseFilePrefix: Character? { get }
+
   /// The behavior or functionality of this command.
   ///
   /// Implement this method in your `ParsableCommand`-conforming type with the
@@ -43,6 +67,8 @@ extension ParsableCommand {
   public static var configuration: CommandConfiguration {
     CommandConfiguration()
   }
+
+  public static var responseFilePrefix: Character? { nil }
 
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -22,30 +22,6 @@ public protocol ParsableCommand: ParsableArguments {
   /// can pass through the wrapped type's name.
   static var _commandName: String { get }
 
-  /// The character used to introduce a response file argument for this
-  /// command.
-  ///
-  /// A command-line argument whose first character matches this prefix is
-  /// treated as a reference to a file whose contents should be expanded
-  /// in place. The default is `nil`, meaning response file expansion is
-  /// disabled.
-  ///
-  /// Override this property on a root command to opt in to response file
-  /// expansion with the given character (for example, `"@"` matches the
-  /// widely used convention `mycommand @args.txt`). The root command's
-  /// prefix determines the prefix used for the entire invocation,
-  /// including subcommand parsing.
-  ///
-  ///     struct MyTool: ParsableCommand {
-  ///       static var responseFilePrefix: Character? { "+" }
-  ///       // ...
-  ///     }
-  ///
-  /// With the above configuration, `mytool +args.txt` expands `args.txt`
-  /// as a response file, while `mytool @foo` is treated as a literal
-  /// argument.
-  static var responseFilePrefix: Character? { get }
-
   /// The behavior or functionality of this command.
   ///
   /// Implement this method in your `ParsableCommand`-conforming type with the
@@ -67,8 +43,6 @@ extension ParsableCommand {
   public static var configuration: CommandConfiguration {
     CommandConfiguration()
   }
-
-  public static var responseFilePrefix: Character? { nil }
 
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -12,6 +12,11 @@
 struct CommandError: Error {
   var commandStack: [ParsableCommand.Type]
   var parserError: ParserError
+  /// Snapshot of the parser input metadata for source-location rendering.
+  ///
+  /// `nil` when the error was raised before `SplitArguments` was built
+  /// (e.g., a response-file read failure during expansion).
+  var formattingContext: InputOrigin.FormattingContext? = nil
 }
 
 struct HelpRequested: Error {
@@ -22,6 +27,10 @@ struct CommandParser {
   let commandTree: Tree<ParsableCommand.Type>
   var currentNode: Tree<ParsableCommand.Type>
   var decodedArguments: [DecodedArguments] = []
+
+  var responseFilePrefix: Character? {
+    self.currentNode.element.responseFilePrefix
+  }
 
   var rootCommand: ParsableCommand.Type {
     commandTree.element
@@ -87,7 +96,7 @@ extension CommandParser {
   ) -> Tree<ParsableCommand.Type>? {
     guard let (origin, element) = split.peekNext(),
       element.isValue,
-      let value = split.originalInput(at: origin),
+      case .value(let value) = element.value,
       let subcommandNode = currentNode.firstChild(withName: value)
     else { return nil }
     _ = split.popNextValue()
@@ -315,9 +324,9 @@ extension CommandParser {
         """
         This command uses asynchronous custom completion functions,
         but is invoked using a synchronous call to `parse` or
-        `parseAsRoot`. 
+        `parseAsRoot`.
 
-        To fix this issue, call the asynchronous versions of these 
+        To fix this issue, call the asynchronous versions of these
         functions: `asyncParse` or `asyncParseAsRoot`, respectively.
         """)
     }
@@ -391,7 +400,8 @@ extension CommandParser {
   ) throws(CommandError) -> ParsableCommand {
     var split: SplitArguments
     do {
-      split = try SplitArguments(arguments: arguments)
+      split = try SplitArguments(
+        arguments: arguments, responseFilePrefix: self.responseFilePrefix)
     } catch {
       throw CommandError(
         commandStack: [commandTree.element],
@@ -399,6 +409,7 @@ extension CommandParser {
       )
     }
 
+    let formattingContext = split.formattingContext
     do {
       try checkForCompletionScriptRequest(&split)
       try descendingParse(&split)
@@ -411,11 +422,17 @@ extension CommandParser {
         return helpResult
       }
       return result
-    } catch let error as CommandError {
+    } catch var error as CommandError {
+      if error.formattingContext == nil {
+        error.formattingContext = formattingContext
+      }
       throw error
     } catch let error as ParserError {
       let error = arguments.isEmpty ? ParserError.noArguments(error) : error
-      throw CommandError(commandStack: commandStack, parserError: error)
+      throw CommandError(
+        commandStack: commandStack,
+        parserError: error,
+        formattingContext: formattingContext)
     } catch let helpRequest as HelpRequested {
       return HelpCommand(
         commandStack: commandStack,
@@ -424,7 +441,8 @@ extension CommandParser {
     } catch {
       throw CommandError(
         commandStack: commandStack,
-        parserError: .invalidState
+        parserError: .invalidState,
+        formattingContext: formattingContext
       )
     }
   }

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -10,8 +10,16 @@
 //===----------------------------------------------------------------------===//
 
 struct CommandError: Error {
+  /// The chain of command types that were resolved before the error was
+  /// raised, root first.
+  ///
+  /// Used by error rendering to prefix messages with
+  /// the fully-qualified command name.
   var commandStack: [ParsableCommand.Type]
+
+  /// The underlying parser error that terminated parsing.
   var parserError: ParserError
+
   /// Snapshot of the parser input metadata for source-location rendering.
   ///
   /// `nil` when the error was raised before `SplitArguments` was built
@@ -20,6 +28,7 @@ struct CommandError: Error {
 }
 
 struct HelpRequested: Error {
+  /// The visibility level of arguments to include in the rendered help text.
   var visibility: ArgumentVisibility
 }
 
@@ -29,7 +38,7 @@ struct CommandParser {
   var decodedArguments: [DecodedArguments] = []
 
   var responseFilePrefix: Character? {
-    self.currentNode.element.responseFilePrefix
+    self.currentNode.element.configuration.responseFilePrefix
   }
 
   var rootCommand: ParsableCommand.Type {
@@ -95,7 +104,6 @@ extension CommandParser {
     split: inout SplitArguments
   ) -> Tree<ParsableCommand.Type>? {
     guard let (origin, element) = split.peekNext(),
-      element.isValue,
       case .value(let value) = element.value,
       let subcommandNode = currentNode.firstChild(withName: value)
     else { return nil }

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -36,9 +36,18 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
     /// The input value came from the specified index in the argument string.
     case argumentIndex(SplitArguments.Index)
 
+    /// The input value came from a response file. Carries the innermost
+    /// step (the file/line where the argument literally lives) and a
+    /// `referencedFrom` link to the origin that included this file —
+    /// forming a self-describing include chain terminated by an
+    /// `.argumentIndex` at the outermost level.
+    indirect case responseFile(
+      step: InputOrigin.ResponseFileStep,
+      referencedFrom: InputOrigin.Element)
+
     var baseIndex: Int? {
       switch self {
-      case .defaultValue:
+      case .defaultValue, .responseFile:
         return nil
       case .argumentIndex(let i):
         return i.inputIndex.rawValue
@@ -47,7 +56,7 @@ struct InputOrigin: Equatable, ExpressibleByArrayLiteral {
 
     var subIndex: Int? {
       switch self {
-      case .defaultValue:
+      case .defaultValue, .responseFile:
         return nil
       case .argumentIndex(let i):
         switch i.subIndex {
@@ -113,15 +122,131 @@ extension InputOrigin {
   }
 }
 
+extension InputOrigin {
+  /// One step in a response-file include chain.
+  ///
+  /// `SplitArguments` records a chain for every post-expansion argument:
+  /// the innermost step says where the argument literally lives (a file
+  /// and line number, or an argv index for arguments that came straight
+  /// from the command line), and successive steps describe the parent
+  /// includes — outermost step is always `.argv(_)`.
+  enum ResponseFileStep: Equatable, Hashable {
+    /// The argument came from `path` at 1-based `line`.
+    case file(path: String, line: Int)
+    /// The argument (or the outermost @file reference) came from
+    /// argv at this 0-based index.
+    case argv(index: Int)
+  }
+
+  /// Information snapshot taken from `SplitArguments` at parse time so
+  /// the error formatter can render the source location block on failure.
+  ///
+  /// Threaded into `ErrorMessageGenerator` via `CommandError`. The
+  /// `hasResponseFile` flag, when `false`, errors messages render exactly as
+  /// they did before the response file feature existed.
+  struct FormattingContext: Equatable {
+    /// True iff the input array contained at least one `@file` reference.
+    var hasResponseFile: Bool
+
+    /// Map from post-expansion `InputIndex` (raw value) to the chain that
+    /// produced the argument at that position.
+    ///
+    /// Argv-only positions hold a single-step chain `[.argv(N)]`;
+    /// response-file-origin positions hold a chain ordered
+    /// innermost-first ending in `.argv(_)`.
+    var responseFileChains: [Int: [ResponseFileStep]]
+
+    /// The post-expansion argv strings.
+    ///
+    /// Indexed by the same key space as `responseFileChains`. Used by
+    /// the dump generator to distinguish name-only tokens (`--tag`) from
+    /// value-carrying tokens (`--tag=value` or a bare value) when
+    /// pairing origins with array elements.
+    var originalInput: [String]
+
+    /// Returns the chain for an origin element, or `nil` if the element
+    /// is `.defaultValue` or no chain was recorded for it.
+    func responseFileChain(for origin: InputOrigin.Element)
+      -> [ResponseFileStep]?
+    {
+      guard case .argumentIndex(let index) = origin else { return nil }
+      return responseFileChains[index.inputIndex.rawValue]
+    }
+
+    /// Returns the raw argv token at the given origin's post-expansion
+    /// index, or `nil` if the origin isn't an `.argumentIndex` or the
+    /// index is out of range.
+    func rawToken(at origin: InputOrigin.Element) -> String? {
+      guard case .argumentIndex(let index) = origin else { return nil }
+      let raw = index.inputIndex.rawValue
+      guard raw < originalInput.count else { return nil }
+      return originalInput[raw]
+    }
+  }
+}
+
 extension InputOrigin.Element {
   static func < (lhs: Self, rhs: Self) -> Bool {
+    // Ordering (least → greatest):
+    //   .argumentIndex(a) < .argumentIndex(b) when a < b
+    //   .argumentIndex(_) < .responseFile(_,_) < .defaultValue
+    // Two `.responseFile` values are ordered by lexicographically
+    // comparing their flattened chain step arrays.
     switch (lhs, rhs) {
     case (.argumentIndex(let l), .argumentIndex(let r)):
       return l < r
-    case (.argumentIndex, .defaultValue):
+    case (.argumentIndex, .responseFile), (.argumentIndex, .defaultValue):
       return true
-    case (.defaultValue, _):
+    case (.responseFile, .defaultValue):
+      return true
+    case (.responseFile, .responseFile):
+      return lhs.chainAsSteps().lexicographicallyPrecedes(rhs.chainAsSteps())
+    case (.defaultValue, _), (.responseFile, .argumentIndex):
       return false
     }
+  }
+}
+
+extension InputOrigin.ResponseFileStep: Comparable {
+  /// Total-order comparison for stable placement in sorted collections.
+  ///
+  /// `.file` values compare by path, then line; `.argv` values compare
+  /// by index; `.file` sorts before `.argv` when the cases differ.
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.file(let lp, let ll), .file(let rp, let rl)):
+      if lp != rp { return lp < rp }
+      return ll < rl
+    case (.argv(let l), .argv(let r)):
+      return l < r
+    case (.file, .argv):
+      return true
+    case (.argv, .file):
+      return false
+    }
+  }
+}
+
+// MARK: - Response File Chain
+
+extension InputOrigin.Element {
+  /// Walks the linked `.responseFile` list and produces a flat array of
+  /// steps from innermost to outermost.
+  ///
+  /// The terminating `.argumentIndex(idx)` becomes a
+  /// `.argv(index: idx.inputIndex.rawValue)` step. Any non-`.responseFile`
+  /// terminator that isn't `.argumentIndex` (which shouldn't occur in
+  /// practice) is dropped from the output.
+  func chainAsSteps() -> [InputOrigin.ResponseFileStep] {
+    var steps: [InputOrigin.ResponseFileStep] = []
+    var current: InputOrigin.Element = self
+    while case .responseFile(let step, let ref) = current {
+      steps.append(step)
+      current = ref
+    }
+    if case .argumentIndex(let idx) = current {
+      steps.append(.argv(index: idx.inputIndex.rawValue))
+    }
+    return steps
   }
 }

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -9,6 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+internal import FoundationEssentials
+#else
+internal import Foundation
+#endif
+
 /// Gets thrown while parsing and will be handled by the error output generation.
 enum ParserError: Error {
   case helpRequested(visibility: ArgumentVisibility)
@@ -39,6 +45,13 @@ enum ParserError: Error {
   case userValidationError(Error)
   case noArguments(Error)
   case notParentCommand(String)
+
+  // Response file errors
+  case responseFileNotFound(URL)
+  case responseFileReadError(URL, Error)
+  case responseFileMalformedContent(URL, String)
+  case responseFileRecursiveInclude(URL)
+  case responseFileMaxNestingDepthExceeded(Int)
 }
 
 /// These are errors used internally to the parsing, and will not be exposed to the help generation.

--- a/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
+++ b/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
@@ -1,0 +1,530 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal import Foundation
+
+/// Expands response file arguments (@file) into their constituent arguments.
+///
+/// Response files allow users to specify command-line arguments in files,
+/// which is useful for commands with many arguments or for reusable argument sets.
+internal struct ResponseFileExpander {
+  /// The prefix used to identify response file arguments.
+  let prefix: Character
+
+  /// Maximum nesting depth for response files.
+  let maxNestingDepth: Int
+
+  /// Tracks currently processing files to detect recursion.
+  private var processingStack: [URL] = []
+
+  /// Initializer.
+  init(prefix: Character, maxNestingDepth: Int = 32) {
+    self.prefix = prefix
+    self.maxNestingDepth = maxNestingDepth
+  }
+
+  /// The result of expanding response file arguments.
+  ///
+  /// `arguments[i]` is a single expanded argument together with the
+  /// include chain that produced it. The chain is ordered innermost-first:
+  /// index 0 is the file/argv that the argument literally lives in; the
+  /// last entry is always `.argv(_)`.
+  ///
+  /// `hasResponseFile` reflects whether the *original* input array
+  /// contained at least one `@file` reference.
+  typealias ExpansionResult = (
+    arguments: [ExpandedArgument],
+    hasResponseFile: Bool
+  )
+
+  /// One expanded argument together with the include chain that produced it.
+  ///
+  /// See `ExpansionResult` for chain ordering.
+  ///
+  /// `wasQuoted` is `true` when the argument came from a token that was
+  /// wholly or partly enclosed in quotes inside a response file. The
+  /// argument parser uses this to force such tokens to be treated as
+  /// literal values, so that a response-file line like `"--not-a-flag"`
+  /// lands as a positional value instead of being interpreted as an
+  /// option — mirroring how a shell would pass a quoted argument through
+  /// to a program.
+  struct ExpandedArgument: Equatable {
+    var value: String
+    var chain: [InputOrigin.ResponseFileStep]
+    var wasQuoted: Bool = false
+  }
+
+  /// Expands response file arguments in the input array.
+  /// - Parameter arguments: The input arguments that may contain response file references
+  /// - Returns: The expanded arguments (each paired with its include
+  ///   chain), plus a flag indicating whether any `@file` reference was
+  ///   present in the original input.
+  /// - Throws: ResponseFileError if file operations fail or recursion is detected
+  mutating func expandArguments(_ arguments: [String]) throws
+    -> ExpansionResult
+  {
+    var result: [ExpandedArgument] = []
+    var hasResponseFile = false
+
+    for (argvIndex, argument) in arguments.enumerated() {
+      if isResponseFileArgument(argument) {
+        hasResponseFile = true
+        guard let fileName = extractResponseFileName(argument) else {
+          result.append(
+            .init(value: argument, chain: [.argv(index: argvIndex)]))
+          continue
+        }
+
+        // Check nesting depth
+        if processingStack.count >= maxNestingDepth {
+          throw ResponseFileError.maxNestingDepthExceeded(maxNestingDepth)
+        }
+
+        // Resolve relative paths relative to current working directory
+        let resolvedURL = resolveFileURL(fileName)
+
+        // Check for recursion
+        if processingStack.contains(resolvedURL) {
+          throw ResponseFileError.recursiveInclude(resolvedURL)
+        }
+
+        // Read and expand the file
+        processingStack.append(resolvedURL)
+        defer { processingStack.removeLast() }
+
+        let expanded = try expandResponseFile(
+          at: resolvedURL, parentChain: [.argv(index: argvIndex)])
+        result.append(contentsOf: expanded)
+      } else {
+        result.append(
+          .init(value: argument, chain: [.argv(index: argvIndex)]))
+      }
+    }
+
+    return (result, hasResponseFile)
+  }
+
+  /// Determines if an argument is a response file reference.
+  /// - Parameter argument: The argument to check
+  /// - Returns: True if the argument starts with the response file prefix
+  func isResponseFileArgument(_ argument: String) -> Bool {
+    guard argument.count > prefix.utf8.count else { return false }
+    guard argument.hasPrefix("\(prefix)") else { return false }
+
+    // Check for literal escaping ('<prefix><prefix>file' becomes '<prefix>file' literal)
+    if argument.hasPrefix("\(self.prefix)\(self.prefix)") {
+      return false
+    }
+
+    // Must have a filename after the prefix
+    let fileName = String(argument.dropFirst(prefix.utf8.count))
+    return !fileName.isEmpty
+  }
+
+  /// Extracts the filename from a response file argument.
+  /// - Parameter argument: The response file argument (e.g., "@file.txt")
+  /// - Returns: The filename portion, or nil if not a valid response file argument
+  func extractResponseFileName(_ argument: String) -> String? {
+    guard isResponseFileArgument(argument) else { return nil }
+    return String(argument.dropFirst(prefix.utf8.count))
+  }
+
+  /// Parses the contents of a response file.
+  /// - Parameters:
+  ///   - content: The file content to parse
+  ///   - fileURL: The file URL (for error reporting and relative-path
+  ///     resolution of nested `@file` references)
+  ///   - parentChain: The chain of includes that led to this file, ordered
+  ///     innermost (caller's file/line) first. For top-level parsing this
+  ///     is typically `[.argv(index:)]`.
+  /// - Returns: The parsed arguments, each paired with its include chain.
+  /// - Throws: ResponseFileError if parsing fails
+  mutating func parseFileContent(
+    _ content: String,
+    fileURL: URL,
+    parentChain: [InputOrigin.ResponseFileStep] = []
+  ) throws -> [ExpandedArgument] {
+    var result: [ExpandedArgument] = []
+    let lines = content.components(separatedBy: .newlines)
+    let filePath = fileURL.path
+
+    for (lineNumber, line) in lines.enumerated() {
+      let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+
+      // Skip empty lines and comments
+      if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") {
+        continue
+      }
+
+      // Strip end-of-line comments
+      let lineWithoutComments = stripComment(trimmedLine)
+      if lineWithoutComments.trimmingCharacters(in: .whitespaces).isEmpty {
+        continue
+      }
+
+      let lineChain: [InputOrigin.ResponseFileStep] =
+        [.file(path: filePath, line: lineNumber + 1)] + parentChain
+
+      // Parse arguments from the line
+      do {
+        let lineArgs = try parseArgumentsFromLine(
+          lineWithoutComments, from: fileURL)
+
+        // Recursively expand any nested response files. Quoted tokens
+        // are always taken as literal values — quoting is the escape
+        // mechanism for values that happen to start with `@`.
+        for parsed in lineArgs {
+          let arg = parsed.value
+          if parsed.wasQuoted {
+            result.append(
+              .init(value: arg, chain: lineChain, wasQuoted: true))
+          } else if arg.hasPrefix("\(self.prefix)\(self.prefix)") {
+            // Handle literal prefix escaping (e.g. `@@file` becomes
+            // `@file`, or with a custom prefix `++file` becomes `+file`).
+            result.append(
+              .init(value: String(arg.dropFirst(1)), chain: lineChain))
+          } else if isResponseFileArgument(arg) {
+            // Recursive response file expansion
+            guard let fileName = extractResponseFileName(arg) else {
+              result.append(.init(value: arg, chain: lineChain))
+              continue
+            }
+
+            let resolvedURL = resolveFileURL(fileName, relativeTo: fileURL)
+
+            // Check for recursion
+            if processingStack.contains(resolvedURL) {
+              throw ResponseFileError.recursiveInclude(resolvedURL)
+            }
+
+            // Check nesting depth
+            if processingStack.count >= maxNestingDepth {
+              throw ResponseFileError.maxNestingDepthExceeded(maxNestingDepth)
+            }
+
+            processingStack.append(resolvedURL)
+            defer { processingStack.removeLast() }
+
+            let nested = try expandResponseFile(
+              at: resolvedURL, parentChain: lineChain)
+            result.append(contentsOf: nested)
+          } else {
+            result.append(.init(value: arg, chain: lineChain))
+          }
+        }
+      } catch let error as ResponseFileError {
+        // Re-throw ResponseFileError types (recursion, nesting depth) as-is
+        throw error
+      } catch {
+        // Only wrap other parsing errors as malformed content
+        throw ResponseFileError.malformedContent(
+          fileURL, "Line \(lineNumber + 1): \(error.localizedDescription)")
+      }
+    }
+
+    return result
+  }
+
+  /// Strips comments from a line, respecting quoted strings.
+  /// - Parameter line: The line to process
+  /// - Returns: The line with comments removed
+  func stripComment(_ line: String) -> String {
+    var result = ""
+    var inDoubleQuotes = false
+    var inSingleQuotes = false
+    var escaped = false
+
+    for char in line {
+      if escaped {
+        result.append(char)
+        escaped = false
+        continue
+      }
+
+      switch char {
+      case "\\":
+        if inDoubleQuotes {
+          escaped = true
+        }
+        result.append(char)
+      case "\"":
+        if !inSingleQuotes {
+          inDoubleQuotes.toggle()
+        }
+        result.append(char)
+      case "'":
+        if !inDoubleQuotes {
+          inSingleQuotes.toggle()
+        }
+        result.append(char)
+      case "#":
+        if !inDoubleQuotes && !inSingleQuotes {
+          // Found unquoted comment, stop processing
+          return result.trimmingCharacters(in: .whitespaces)
+        }
+        result.append(char)
+      default:
+        result.append(char)
+      }
+    }
+
+    return result.trimmingCharacters(in: .whitespaces)
+  }
+}
+
+// MARK: - Error Types
+
+extension ResponseFileExpander {
+  enum ResponseFileError: Error, CustomStringConvertible {
+    case fileNotFound(URL)
+    case readError(URL, Error)
+    case malformedContent(URL, String)
+    case recursiveInclude(URL)
+    case maxNestingDepthExceeded(Int)
+
+    var description: String {
+      switch self {
+      case .fileNotFound(let url):
+        return "Response file not found: \(url.path)"
+      case .readError(let url, let error):
+        return
+          "Failed to read response file '\(url.path)': \(error.localizedDescription)"
+      case .malformedContent(let url, let message):
+        return "Malformed content in response file '\(url.path)': \(message)"
+      case .recursiveInclude(let url):
+        return "Recursive response file inclusion detected: \(url.path)"
+      case .maxNestingDepthExceeded(let depth):
+        return "Maximum nesting depth (\(depth)) exceeded for response files"
+      }
+    }
+  }
+}
+
+// MARK: - Private Implementation
+
+extension ResponseFileExpander {
+
+  /// Expands a response file by reading and parsing its contents.
+  /// - Parameters:
+  ///   - fileURL: The URL of the response file
+  ///   - parentChain: The chain of includes that led to this file, ordered
+  ///     innermost (caller's file/line) first.
+  /// - Returns: The expanded arguments, each paired with its include chain.
+  /// - Throws: ResponseFileError if file operations fail
+  fileprivate mutating func expandResponseFile(
+    at fileURL: URL,
+    parentChain: [InputOrigin.ResponseFileStep]
+  ) throws -> [ExpandedArgument] {
+    // Check if file exists
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      throw ResponseFileError.fileNotFound(fileURL)
+    }
+
+    // Read file content
+    let content: String
+    do {
+      content = try String(contentsOf: fileURL, encoding: .utf8)
+    } catch {
+      throw ResponseFileError.readError(fileURL, error)
+    }
+
+    // Parse and expand content
+    return try parseFileContent(
+      content, fileURL: fileURL, parentChain: parentChain)
+  }
+
+  /// Resolves a file name to an absolute `URL`, handling relative paths.
+  ///
+  /// - Parameters:
+  ///   - fileName: The file name to resolve
+  ///   - parentURL: Optional parent file `URL` for relative resolution
+  /// - Returns: The resolved absolute URL
+  fileprivate func resolveFileURL(
+    _ fileName: String,
+    relativeTo parentURL: URL? = nil
+  ) -> URL {
+    // If already absolute, use as-is
+    if Self.isAbsolutePath(fileName) {
+      return URL(fileURLWithPath: fileName)
+    }
+
+    // If we have a parent file, make relative to its directory
+    if let parentURL = parentURL {
+      return
+        parentURL
+        .deletingLastPathComponent()
+        .appendingPathComponent(fileName)
+    }
+
+    // Otherwise, relative to current working directory
+    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+      .appendingPathComponent(fileName)
+  }
+
+  /// Returns `true` if `path` is an absolute filesystem path.
+  ///
+  /// On POSIX, that means it starts with `/`. On Windows, that includes
+  /// drive-rooted paths (`C:\...` / `C:/...`), UNC paths (`\\server\...`),
+  /// and drive-relative-absolute paths (starting with `\` or `/`).
+  fileprivate static func isAbsolutePath(_ path: String) -> Bool {
+    #if os(Windows)
+    if path.hasPrefix("/") || path.hasPrefix("\\") {
+      return true
+    }
+    // Drive-rooted: "C:\" or "C:/".
+    let chars = Array(path)
+    if chars.count >= 3,
+      chars[0].isLetter,
+      chars[1] == ":",
+      chars[2] == "\\" || chars[2] == "/"
+    {
+      return true
+    }
+    return false
+    #else
+    return path.hasPrefix("/")
+    #endif
+  }
+
+  /// One token produced by `parseArgumentsFromLine`.
+  ///
+  /// `wasQuoted` records whether the raw token contained any quoted
+  /// portion. Quoted tokens are passed through verbatim as literal
+  /// values — the response-file prefix (`@`) is not interpreted for
+  /// them, so `"@name"` and `'@name'` do NOT trigger a nested lookup.
+  fileprivate struct ParsedLineArgument {
+    var value: String
+    var wasQuoted: Bool
+  }
+
+  /// Parses arguments from a single line, handling quotes and spaces.
+  ///
+  /// This is a single-pass GNU-style tokenizer, modelled on the
+  /// `TokenizeGNUCommandLine` implementation used by LLVM and gcc:
+  ///
+  /// - Double-quoted segments allow C-style backslash escapes
+  ///   (`\n`, `\t`, `\r`, `\\`, `\"`); any other escape sequence is
+  ///   preserved verbatim (backslash + character).
+  /// - Single-quoted segments are literal — nothing inside them is
+  ///   interpreted, including backslashes.
+  /// - Adjacent quoted or unquoted segments with no whitespace between
+  ///   them concatenate into a single token, so `"foo""bar"`, `a""a`,
+  ///   and `''''` all behave as gcc would.
+  /// - An empty quoted segment (`""` or `''`) still produces an empty
+  ///   token, which lets callers pass an empty string through a
+  ///   response file.
+  ///
+  /// - Parameters:
+  ///   - line: The line to parse
+  ///   - fileURL: The response file the line was read from, used for
+  ///     error reporting.
+  /// - Returns: Array of parsed arguments, each tagged with whether
+  ///   any portion of the raw token was quoted.
+  /// - Throws: ResponseFileError if parsing fails (e.g. unclosed quote).
+  fileprivate func parseArgumentsFromLine(_ line: String, from fileURL: URL)
+    throws -> [ParsedLineArgument]
+  {
+    var arguments: [ParsedLineArgument] = []
+    var currentArg = ""
+    var currentWasQuoted = false
+    // Distinguishes "we have a token in progress" from "currentArg is
+    // an empty string only because the token itself is empty (from
+    // e.g. `""`)". Without this we could not tell the two cases apart.
+    var hasContent = false
+    var inDoubleQuotes = false
+    var inSingleQuotes = false
+    var escaped = false
+
+    for char in line {
+      if escaped {
+        // Only reachable inside double quotes. Process a C-style escape
+        // sequence and consume both the backslash and this character.
+        switch char {
+        case "n":
+          currentArg.append("\n")
+        case "t":
+          currentArg.append("\t")
+        case "r":
+          currentArg.append("\r")
+        case "\\":
+          currentArg.append("\\")
+        case "\"":
+          currentArg.append("\"")
+        default:
+          // Unknown escape — preserve both characters verbatim so
+          // callers see the same bytes the file contained.
+          currentArg.append("\\")
+          currentArg.append(char)
+        }
+        hasContent = true
+        escaped = false
+        continue
+      }
+
+      switch char {
+      case "\\":
+        if inDoubleQuotes {
+          escaped = true
+        } else {
+          // Outside double quotes (including inside single quotes),
+          // backslash is a literal character. This matches gcc and
+          // LLVM's `TokenizeGNUCommandLine`.
+          currentArg.append(char)
+          hasContent = true
+        }
+      case "\"":
+        if inSingleQuotes {
+          currentArg.append(char)
+          hasContent = true
+        } else {
+          inDoubleQuotes.toggle()
+          currentWasQuoted = true
+          hasContent = true
+        }
+      case "'":
+        if inDoubleQuotes {
+          currentArg.append(char)
+          hasContent = true
+        } else {
+          inSingleQuotes.toggle()
+          currentWasQuoted = true
+          hasContent = true
+        }
+      case " ", "\t":
+        if inDoubleQuotes || inSingleQuotes {
+          currentArg.append(char)
+          hasContent = true
+        } else if hasContent {
+          arguments.append(
+            .init(value: currentArg, wasQuoted: currentWasQuoted))
+          currentArg = ""
+          currentWasQuoted = false
+          hasContent = false
+        }
+      default:
+        currentArg.append(char)
+        hasContent = true
+      }
+    }
+
+    // An unterminated quote is implicitly closed at end-of-line,
+    // matching gcc / LLVM `TokenizeGNUCommandLine`. Whatever was
+    // accumulated between the opening quote and EOL becomes the final
+    // token — including the case where nothing at all was accumulated
+    // (a bare `'` or `"` at end-of-line produces one empty argument).
+    if hasContent {
+      arguments.append(
+        .init(value: currentArg, wasQuoted: currentWasQuoted))
+    }
+
+    return arguments
+  }
+}

--- a/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
+++ b/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
@@ -152,81 +152,53 @@ internal struct ResponseFileExpander {
     fileURL: URL,
     parentChain: [InputOrigin.ResponseFileStep] = []
   ) throws -> [ExpandedArgument] {
-    var result: [ExpandedArgument] = []
-    let lines = content.components(separatedBy: .newlines)
     let filePath = fileURL.path
 
-    for (lineNumber, line) in lines.enumerated() {
-      let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+    // Whole-file tokenization: quote state carries across newlines, so
+    // a token that opens on one line and closes on a later line lands
+    // as a single value with the intervening newlines preserved.
+    let tokens = tokenizeContent(content)
 
-      // Skip empty lines and comments
-      if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") {
-        continue
-      }
+    var result: [ExpandedArgument] = []
+    for token in tokens {
+      let tokenChain: [InputOrigin.ResponseFileStep] =
+        [.file(path: filePath, line: token.line)] + parentChain
+      let arg = token.value
 
-      // Strip end-of-line comments
-      let lineWithoutComments = stripComment(trimmedLine)
-      if lineWithoutComments.trimmingCharacters(in: .whitespaces).isEmpty {
-        continue
-      }
-
-      let lineChain: [InputOrigin.ResponseFileStep] =
-        [.file(path: filePath, line: lineNumber + 1)] + parentChain
-
-      // Parse arguments from the line
-      do {
-        let lineArgs = try parseArgumentsFromLine(
-          lineWithoutComments, from: fileURL)
-
-        // Recursively expand any nested response files. Quoted tokens
-        // are always taken as literal values — quoting is the escape
-        // mechanism for values that happen to start with `@`.
-        for parsed in lineArgs {
-          let arg = parsed.value
-          if parsed.wasQuoted {
-            result.append(
-              .init(value: arg, chain: lineChain, wasQuoted: true))
-          } else if arg.hasPrefix("\(self.prefix)\(self.prefix)") {
-            // Handle literal prefix escaping (e.g. `@@file` becomes
-            // `@file`, or with a custom prefix `++file` becomes `+file`).
-            result.append(
-              .init(value: String(arg.dropFirst(1)), chain: lineChain))
-          } else if isResponseFileArgument(arg) {
-            // Recursive response file expansion
-            guard let fileName = extractResponseFileName(arg) else {
-              result.append(.init(value: arg, chain: lineChain))
-              continue
-            }
-
-            let resolvedURL = resolveFileURL(fileName, relativeTo: fileURL)
-
-            // Check for recursion
-            if processingStack.contains(resolvedURL) {
-              throw ResponseFileError.recursiveInclude(resolvedURL)
-            }
-
-            // Check nesting depth
-            if processingStack.count >= maxNestingDepth {
-              throw ResponseFileError.maxNestingDepthExceeded(maxNestingDepth)
-            }
-
-            processingStack.append(resolvedURL)
-            defer { processingStack.removeLast() }
-
-            let nested = try expandResponseFile(
-              at: resolvedURL, parentChain: lineChain)
-            result.append(contentsOf: nested)
-          } else {
-            result.append(.init(value: arg, chain: lineChain))
-          }
+      if token.wasQuoted {
+        // Quoted tokens are always literal — quoting is the escape
+        // mechanism for values that happen to start with the response
+        // file prefix.
+        result.append(
+          .init(value: arg, chain: tokenChain, wasQuoted: true))
+      } else if arg.hasPrefix("\(self.prefix)\(self.prefix)") {
+        // Literal prefix escape: `@@file` -> `@file`, `++file` -> `+file`.
+        result.append(
+          .init(value: String(arg.dropFirst(1)), chain: tokenChain))
+      } else if isResponseFileArgument(arg) {
+        guard let fileName = extractResponseFileName(arg) else {
+          result.append(.init(value: arg, chain: tokenChain))
+          continue
         }
-      } catch let error as ResponseFileError {
-        // Re-throw ResponseFileError types (recursion, nesting depth) as-is
-        throw error
-      } catch {
-        // Only wrap other parsing errors as malformed content
-        throw ResponseFileError.malformedContent(
-          fileURL, "Line \(lineNumber + 1): \(error.localizedDescription)")
+
+        let resolvedURL = resolveFileURL(fileName, relativeTo: fileURL)
+
+        if processingStack.contains(resolvedURL) {
+          throw ResponseFileError.recursiveInclude(resolvedURL)
+        }
+
+        if processingStack.count >= maxNestingDepth {
+          throw ResponseFileError.maxNestingDepthExceeded(maxNestingDepth)
+        }
+
+        processingStack.append(resolvedURL)
+        defer { processingStack.removeLast() }
+
+        let nested = try expandResponseFile(
+          at: resolvedURL, parentChain: tokenChain)
+        result.append(contentsOf: nested)
+      } else {
+        result.append(.init(value: arg, chain: tokenChain))
       }
     }
 
@@ -394,21 +366,24 @@ extension ResponseFileExpander {
     #endif
   }
 
-  /// One token produced by `parseArgumentsFromLine`.
+  /// One token produced by `tokenizeContent`.
   ///
   /// `wasQuoted` records whether the raw token contained any quoted
   /// portion. Quoted tokens are passed through verbatim as literal
   /// values — the response-file prefix (`@`) is not interpreted for
   /// them, so `"@name"` and `'@name'` do NOT trigger a nested lookup.
-  fileprivate struct ParsedLineArgument {
+  ///
+  /// `line` is the 1-indexed line number where the token started, used
+  /// for building the include chain and for error messages.
+  fileprivate struct TokenizedArgument {
     var value: String
     var wasQuoted: Bool
+    var line: Int
   }
 
-  /// Parses arguments from a single line, handling quotes and spaces.
+  /// Tokenizes the entire content of a response file in a single pass.
   ///
-  /// This is a single-pass GNU-style tokenizer, modelled on the
-  /// `TokenizeGNUCommandLine` implementation used by LLVM and gcc:
+  /// Behaviors implemented:
   ///
   /// - Double-quoted segments allow C-style backslash escapes
   ///   (`\n`, `\t`, `\r`, `\\`, `\"`); any other escape sequence is
@@ -417,33 +392,38 @@ extension ResponseFileExpander {
   ///   interpreted, including backslashes.
   /// - Adjacent quoted or unquoted segments with no whitespace between
   ///   them concatenate into a single token, so `"foo""bar"`, `a""a`,
-  ///   and `''''` all behave as gcc would.
+  ///   and `''''` all form a single token.
   /// - An empty quoted segment (`""` or `''`) still produces an empty
   ///   token, which lets callers pass an empty string through a
   ///   response file.
-  ///
-  /// - Parameters:
-  ///   - line: The line to parse
-  ///   - fileURL: The response file the line was read from, used for
-  ///     error reporting.
-  /// - Returns: Array of parsed arguments, each tagged with whether
-  ///   any portion of the raw token was quoted.
-  /// - Throws: ResponseFileError if parsing fails (e.g. unclosed quote).
-  fileprivate func parseArgumentsFromLine(_ line: String, from fileURL: URL)
-    throws -> [ParsedLineArgument]
-  {
-    var arguments: [ParsedLineArgument] = []
+  /// - An unterminated quote is implicitly closed at end-of-file; the
+  ///   accumulated content becomes the final token.
+  /// - A `#` outside of any quoted segment starts a comment that runs
+  ///   to the next newline.
+  /// - A newline **outside** a quoted segment separates tokens; a
+  ///   newline **inside** a quoted segment is preserved as a literal
+  ///   part of the token's value.
+  fileprivate func tokenizeContent(_ content: String) -> [TokenizedArgument] {
+    var result: [TokenizedArgument] = []
     var currentArg = ""
     var currentWasQuoted = false
-    // Distinguishes "we have a token in progress" from "currentArg is
-    // an empty string only because the token itself is empty (from
-    // e.g. `""`)". Without this we could not tell the two cases apart.
     var hasContent = false
+    var currentTokenLine = 1
+    var lineNumber = 1
     var inDoubleQuotes = false
     var inSingleQuotes = false
     var escaped = false
+    var inLineComment = false
 
-    for char in line {
+    for char in content {
+      if inLineComment {
+        if char == "\n" {
+          inLineComment = false
+          lineNumber += 1
+        }
+        continue
+      }
+
       if escaped {
         // Only reachable inside double quotes. Process a C-style escape
         // sequence and consume both the backslash and this character.
@@ -464,10 +444,15 @@ extension ResponseFileExpander {
           currentArg.append("\\")
           currentArg.append(char)
         }
-        hasContent = true
+        if !hasContent {
+          currentTokenLine = lineNumber
+          hasContent = true
+        }
         escaped = false
         continue
       }
+
+      let inQuotes = inDoubleQuotes || inSingleQuotes
 
       switch char {
       case "\\":
@@ -475,56 +460,119 @@ extension ResponseFileExpander {
           escaped = true
         } else {
           // Outside double quotes (including inside single quotes),
-          // backslash is a literal character. This matches gcc and
-          // LLVM's `TokenizeGNUCommandLine`.
+          // backslash is a literal character.
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           currentArg.append(char)
-          hasContent = true
         }
       case "\"":
         if inSingleQuotes {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           currentArg.append(char)
-          hasContent = true
         } else {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           inDoubleQuotes.toggle()
           currentWasQuoted = true
-          hasContent = true
         }
       case "'":
         if inDoubleQuotes {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           currentArg.append(char)
-          hasContent = true
         } else {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           inSingleQuotes.toggle()
           currentWasQuoted = true
-          hasContent = true
         }
-      case " ", "\t":
-        if inDoubleQuotes || inSingleQuotes {
+      case "#":
+        if inQuotes {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
           currentArg.append(char)
-          hasContent = true
+        } else {
+          if hasContent {
+            result.append(
+              .init(
+                value: currentArg,
+                wasQuoted: currentWasQuoted,
+                line: currentTokenLine))
+            currentArg = ""
+            currentWasQuoted = false
+            hasContent = false
+          }
+          inLineComment = true
+        }
+      case "\n":
+        if inQuotes {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
+          currentArg.append(char)
         } else if hasContent {
-          arguments.append(
-            .init(value: currentArg, wasQuoted: currentWasQuoted))
+          result.append(
+            .init(
+              value: currentArg,
+              wasQuoted: currentWasQuoted,
+              line: currentTokenLine))
+          currentArg = ""
+          currentWasQuoted = false
+          hasContent = false
+        }
+        lineNumber += 1
+      case " ", "\t":
+        if inQuotes {
+          if !hasContent {
+            currentTokenLine = lineNumber
+            hasContent = true
+          }
+          currentArg.append(char)
+        } else if hasContent {
+          result.append(
+            .init(
+              value: currentArg,
+              wasQuoted: currentWasQuoted,
+              line: currentTokenLine))
           currentArg = ""
           currentWasQuoted = false
           hasContent = false
         }
       default:
+        if !hasContent {
+          currentTokenLine = lineNumber
+          hasContent = true
+        }
         currentArg.append(char)
-        hasContent = true
       }
     }
 
-    // An unterminated quote is implicitly closed at end-of-line,
-    // matching gcc / LLVM `TokenizeGNUCommandLine`. Whatever was
-    // accumulated between the opening quote and EOL becomes the final
-    // token — including the case where nothing at all was accumulated
-    // (a bare `'` or `"` at end-of-line produces one empty argument).
+    // An unterminated quote is implicitly closed at end-of-file.
+    // Whatever was accumulated becomes the final token — including the
+    // case where nothing was accumulated (a bare `'` or `"` at EOF
+    // still produces one empty argument).
     if hasContent {
-      arguments.append(
-        .init(value: currentArg, wasQuoted: currentWasQuoted))
+      result.append(
+        .init(
+          value: currentArg,
+          wasQuoted: currentWasQuoted,
+          line: currentTokenLine))
     }
 
-    return arguments
+    return result
   }
 }

--- a/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
+++ b/Sources/ArgumentParser/Parsing/ResponseFileExpander.swift
@@ -9,7 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+internal import FoundationEssentials
+#else
 internal import Foundation
+#endif
 
 /// Expands response file arguments (@file) into their constituent arguments.
 ///
@@ -75,13 +79,8 @@ internal struct ResponseFileExpander {
     var hasResponseFile = false
 
     for (argvIndex, argument) in arguments.enumerated() {
-      if isResponseFileArgument(argument) {
+      if let fileName = extractResponseFileName(argument) {
         hasResponseFile = true
-        guard let fileName = extractResponseFileName(argument) else {
-          result.append(
-            .init(value: argument, chain: [.argv(index: argvIndex)]))
-          continue
-        }
 
         // Check nesting depth
         if processingStack.count >= maxNestingDepth {
@@ -116,7 +115,6 @@ internal struct ResponseFileExpander {
   /// - Parameter argument: The argument to check
   /// - Returns: True if the argument starts with the response file prefix
   func isResponseFileArgument(_ argument: String) -> Bool {
-    guard argument.count > prefix.utf8.count else { return false }
     guard argument.hasPrefix("\(prefix)") else { return false }
 
     // Check for literal escaping ('<prefix><prefix>file' becomes '<prefix>file' literal)
@@ -125,7 +123,7 @@ internal struct ResponseFileExpander {
     }
 
     // Must have a filename after the prefix
-    let fileName = String(argument.dropFirst(prefix.utf8.count))
+    let fileName = String(argument.dropFirst(String(prefix).count))
     return !fileName.isEmpty
   }
 
@@ -134,7 +132,7 @@ internal struct ResponseFileExpander {
   /// - Returns: The filename portion, or nil if not a valid response file argument
   func extractResponseFileName(_ argument: String) -> String? {
     guard isResponseFileArgument(argument) else { return nil }
-    return String(argument.dropFirst(prefix.utf8.count))
+    return String(argument.dropFirst(String(prefix).count))
   }
 
   /// Parses the contents of a response file.
@@ -175,12 +173,7 @@ internal struct ResponseFileExpander {
         // Literal prefix escape: `@@file` -> `@file`, `++file` -> `+file`.
         result.append(
           .init(value: String(arg.dropFirst(1)), chain: tokenChain))
-      } else if isResponseFileArgument(arg) {
-        guard let fileName = extractResponseFileName(arg) else {
-          result.append(.init(value: arg, chain: tokenChain))
-          continue
-        }
-
+      } else if let fileName = extractResponseFileName(arg) {
         let resolvedURL = resolveFileURL(fileName, relativeTo: fileURL)
 
         if processingStack.contains(resolvedURL) {
@@ -240,7 +233,7 @@ internal struct ResponseFileExpander {
       case "#":
         if !inDoubleQuotes && !inSingleQuotes {
           // Found unquoted comment, stop processing
-          return result.trimmingCharacters(in: .whitespaces)
+          return result.trimmed()
         }
         result.append(char)
       default:
@@ -248,7 +241,7 @@ internal struct ResponseFileExpander {
       }
     }
 
-    return result.trimmingCharacters(in: .whitespaces)
+    return result.trimmed()
   }
 }
 
@@ -268,7 +261,7 @@ extension ResponseFileExpander {
         return "Response file not found: \(url.path)"
       case .readError(let url, let error):
         return
-          "Failed to read response file '\(url.path)': \(error.localizedDescription)"
+          "Failed to read response file '\(url.path)': \(error.describe())"
       case .malformedContent(let url, let message):
         return "Malformed content in response file '\(url.path)': \(message)"
       case .recursiveInclude(let url):
@@ -295,20 +288,15 @@ extension ResponseFileExpander {
     at fileURL: URL,
     parentChain: [InputOrigin.ResponseFileStep]
   ) throws -> [ExpandedArgument] {
-    // Check if file exists
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-      throw ResponseFileError.fileNotFound(fileURL)
-    }
-
-    // Read file content
     let content: String
     do {
       content = try String(contentsOf: fileURL, encoding: .utf8)
+    } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+      throw ResponseFileError.fileNotFound(fileURL)
     } catch {
       throw ResponseFileError.readError(fileURL, error)
     }
 
-    // Parse and expand content
     return try parseFileContent(
       content, fileURL: fileURL, parentChain: parentChain)
   }
@@ -323,47 +311,10 @@ extension ResponseFileExpander {
     _ fileName: String,
     relativeTo parentURL: URL? = nil
   ) -> URL {
-    // If already absolute, use as-is
-    if Self.isAbsolutePath(fileName) {
-      return URL(fileURLWithPath: fileName)
-    }
-
-    // If we have a parent file, make relative to its directory
-    if let parentURL = parentURL {
-      return
-        parentURL
-        .deletingLastPathComponent()
-        .appendingPathComponent(fileName)
-    }
-
-    // Otherwise, relative to current working directory
-    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-      .appendingPathComponent(fileName)
-  }
-
-  /// Returns `true` if `path` is an absolute filesystem path.
-  ///
-  /// On POSIX, that means it starts with `/`. On Windows, that includes
-  /// drive-rooted paths (`C:\...` / `C:/...`), UNC paths (`\\server\...`),
-  /// and drive-relative-absolute paths (starting with `\` or `/`).
-  fileprivate static func isAbsolutePath(_ path: String) -> Bool {
-    #if os(Windows)
-    if path.hasPrefix("/") || path.hasPrefix("\\") {
-      return true
-    }
-    // Drive-rooted: "C:\" or "C:/".
-    let chars = Array(path)
-    if chars.count >= 3,
-      chars[0].isLetter,
-      chars[1] == ":",
-      chars[2] == "\\" || chars[2] == "/"
-    {
-      return true
-    }
-    return false
-    #else
-    return path.hasPrefix("/")
-    #endif
+    URL(
+      fileURLWithPath: fileName,
+      relativeTo: parentURL?.deletingLastPathComponent()
+    ).absoluteURL
   }
 
   /// One token produced by `tokenizeContent`.

--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -180,6 +180,25 @@ struct SplitArguments {
   /// The original array of arguments that was used to generate this instance.
   var originalInput: [String]
 
+  /// Per-`InputIndex` response-file include chain for every post-expansion argument.
+  ///
+  /// Argv-origin args carry a single-step chain `[.argv(N)]`; args
+  /// expanded from a response file carry a chain ordered
+  /// innermost-first (the file the argument literally lives in is at
+  /// index 0; the last entry is always `.argv(_)`).
+  ///
+  /// Sparse — entries are populated by `init(arguments:)` when chains are
+  /// available, and are absent when `SplitArguments` is constructed via
+  /// `init(originalInput:)` directly.
+  var responseFileChains: [InputIndex: [InputOrigin.ResponseFileStep]] = [:]
+
+  /// `true` if, and only if, the original input array passed to
+  /// `init(arguments:)` contained at least one response-file reference.
+  ///
+  /// `ErrorMessageGenerator` consults this when deciding whether to
+  /// append the `at … included from …` location block to a message.
+  var hasResponseFile: Bool = false
+
   /// The unused arguments represented by this instance.
   var elements: ArraySlice<Element> {
     _elements[firstUnused...]
@@ -281,6 +300,34 @@ extension SplitArguments {
       return nil
     }
     return originalInput[index.inputIndex.rawValue]
+  }
+
+  /// Returns the response-file include chain for the argument at the
+  /// given `origin`, or `nil` if `origin` does not refer to an argument
+  /// position (e.g., `.defaultValue`) or no chain was recorded for it.
+  ///
+  /// The chain is ordered innermost-first: `chain[0]` is the file/argv
+  /// the argument literally lives in; the last entry is always
+  /// `.argv(_)`.
+  func responseFileChain(at origin: InputOrigin.Element)
+    -> [InputOrigin.ResponseFileStep]?
+  {
+    guard case .argumentIndex(let index) = origin else { return nil }
+    return responseFileChains[index.inputIndex]
+  }
+
+  /// Snapshot of the parts of `SplitArguments` that the error formatter
+  /// needs in order to render the source location block.
+  var formattingContext: InputOrigin.FormattingContext {
+    var byRaw: [Int: [InputOrigin.ResponseFileStep]] = [:]
+    byRaw.reserveCapacity(responseFileChains.count)
+    for (key, value) in responseFileChains {
+      byRaw[key.rawValue] = value
+    }
+    return .init(
+      hasResponseFile: hasResponseFile,
+      responseFileChains: byRaw,
+      originalInput: originalInput)
   }
 
   /// Returns the position in `elements` of the given input origin.
@@ -684,29 +731,82 @@ func parseIndividualArg(_ arg: String, at position: Int) throws(ParserError)
 extension SplitArguments {
   /// Parses the given input into an array of `Element`.
   ///
-  /// - Parameter arguments: The input from the command line.
+  /// - Parameters:
+  ///     - arguments: The input from the command line.
+  ///     - responseFilePrefix: A leading character representing a response
+  ///       file argument, or `nil` to disable response file expansion.
   ///
   /// - Throws: If parsing fails.
-  init(arguments: [String]) throws {
-    self.init(originalInput: arguments)
+  init(
+    arguments: [String],
+    responseFilePrefix: Character?
+  ) throws {
+    // Expand response files first
+    let expanded: ResponseFileExpander.ExpansionResult
+    if let responseFilePrefix {
+      do {
+        var expander = ResponseFileExpander(prefix: responseFilePrefix)
+        expanded = try expander.expandArguments(arguments)
+      } catch let error as ResponseFileExpander.ResponseFileError {
+        // Convert ResponseFileExpander errors to ParserError
+        switch error {
+        case .fileNotFound(let url):
+          throw ParserError.responseFileNotFound(url)
+        case .readError(let url, let underlyingError):
+          throw ParserError.responseFileReadError(url, underlyingError)
+        case .malformedContent(let url, let message):
+          throw ParserError.responseFileMalformedContent(url, message)
+        case .recursiveInclude(let url):
+          throw ParserError.responseFileRecursiveInclude(url)
+        case .maxNestingDepthExceeded(let depth):
+          throw ParserError.responseFileMaxNestingDepthExceeded(depth)
+        }
+      }
+    } else {
+      expanded = (
+        arguments.enumerated().map { index, value in
+          .init(value: value, chain: [.argv(index: index)])
+        },
+        false
+      )
+    }
+
+    let expandedValues = expanded.arguments.map { $0.value }
+    self.init(originalInput: expandedValues)
+    self.hasResponseFile = expanded.hasResponseFile
+
+    // Populate the chain lookup table keyed by post-expansion InputIndex.
+    for (idx, expandedArg) in expanded.arguments.enumerated() {
+      self.responseFileChains[InputIndex(rawValue: idx)] = expandedArg.chain
+    }
 
     var position = 0
-    var args = arguments[...]
-    argLoop: while let arg = args.popFirst() {
+    var expandedArgs = expanded.arguments[...]
+    argLoop: while let expArg = expandedArgs.popFirst() {
       defer {
         position += 1
       }
 
-      let parsedElements = try parseIndividualArg(arg, at: position)
+      let parsedElements: [Element]
+      if expArg.wasQuoted {
+        // A quoted token from a response file is always a literal
+        // value: quoting is how callers escape a token that would
+        // otherwise be interpreted (as an option, as `--`, or as an
+        // `@file` reference).
+        let index = Index(inputIndex: InputIndex(rawValue: position))
+        parsedElements = [.value(expArg.value, index: index)]
+      } else {
+        parsedElements = try parseIndividualArg(expArg.value, at: position)
+      }
       _elements.append(contentsOf: parsedElements)
       if parsedElements.first?.isTerminator ?? false {
         break
       }
     }
 
-    for arg in args {
+    for expArg in expandedArgs {
       let i = Index(inputIndex: InputIndex(rawValue: position))
-      _elements.append(.value(arg, index: i))
+      _elements.append(.value(expArg.value, index: i))
       position += 1
     }
   }

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -17,11 +17,13 @@ enum MessageInfo {
   init(error: Error, type: ParsableArguments.Type, columns: Int? = nil) {
     var commandStack: [ParsableCommand.Type]
     var parserError: ParserError? = nil
+    var formattingContext: InputOrigin.FormattingContext? = nil
 
     switch error {
     case let e as CommandError:
       commandStack = e.commandStack
       parserError = e.parserError
+      formattingContext = e.formattingContext
 
       // Exit early on built-in requests
       switch e.parserError {
@@ -138,7 +140,11 @@ enum MessageInfo {
       // unwrap is safe
       let argumentSet = ArgumentSet(
         commandStack.last!, visibility: .default, parent: nil)
-      let message = argumentSet.errorDescription(error: parserError) ?? ""
+      let message =
+        argumentSet.errorDescription(
+          error: parserError,
+          formattingContext: formattingContext)
+        ?? ""
       let helpAbstract = argumentSet.helpDescription(error: parserError) ?? ""
       self = .validation(message: message, usage: usage, help: helpAbstract)
     } else {

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -9,6 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+internal import FoundationEssentials
+#else
+internal import Foundation
+#endif
+
 struct UsageGenerator {
   var toolName: String
   var definition: ArgumentSet
@@ -138,18 +144,31 @@ extension ArgumentSet {
   ///
   /// If no descriptive help message can be generated, `nil` will be returned.
   ///
-  /// - Parameter error: the parse error that occurred.
+  /// - Parameters:
+  ///   - error: The parse error that occurred.
+  ///   - formattingContext: Snapshot of parser input metadata used to
+  ///     render the source-location block. Pass `nil` when the gete (contains
+  ///     response file) cannot be evaluated (e.g., the error was raised before
+  ///     `SplitArguments` existed).
   /// - Returns: An error description.
-  func errorDescription(error: Swift.Error) -> String? {
+  func errorDescription(
+    error: Swift.Error,
+    formattingContext: InputOrigin.FormattingContext? = nil
+  ) -> String? {
     switch error {
     case let parserError as ParserError:
-      return ErrorMessageGenerator(arguments: self, error: parserError)
-        .makeErrorMessage()
+      return ErrorMessageGenerator(
+        arguments: self,
+        error: parserError,
+        formattingContext: formattingContext
+      ).makeErrorMessage()
     case let commandError as CommandError:
       return ErrorMessageGenerator(
-        arguments: self, error: commandError.parserError
-      )
-      .makeErrorMessage()
+        arguments: self,
+        error: commandError.parserError,
+        formattingContext: commandError.formattingContext
+          ?? formattingContext
+      ).makeErrorMessage()
     default:
       return nil
     }
@@ -174,6 +193,17 @@ extension ArgumentSet {
 struct ErrorMessageGenerator {
   var arguments: ArgumentSet
   var error: ParserError
+  var formattingContext: InputOrigin.FormattingContext?
+
+  init(
+    arguments: ArgumentSet,
+    error: ParserError,
+    formattingContext: InputOrigin.FormattingContext? = nil
+  ) {
+    self.arguments = arguments
+    self.error = error
+    self.formattingContext = formattingContext
+  }
 }
 
 extension ErrorMessageGenerator {
@@ -232,6 +262,18 @@ extension ErrorMessageGenerator {
       }
     case .notParentCommand(let parent):
       return "Command '\(parent)' is not a parent of the current command."
+
+    // Response file error cases
+    case .responseFileNotFound(let url):
+      return "Response file not found: \(url.path)"
+    case .responseFileReadError(let path, let error):
+      return "Failed to read response file '\(path)': \(error.describe())"
+    case .responseFileMalformedContent(let path, let message):
+      return "Malformed content in response file '\(path)': \(message)"
+    case .responseFileRecursiveInclude(let path):
+      return "Recursive response file inclusion detected: \(path)"
+    case .responseFileMaxNestingDepthExceeded(let depth):
+      return "Maximum nesting depth (\(depth)) exceeded for response files"
     }
   }
 
@@ -247,6 +289,48 @@ extension ErrorMessageGenerator {
       return noValueHelpMessage(key: k)
     default:
       return nil
+    }
+  }
+}
+
+extension ErrorMessageGenerator {
+  /// Renders the multi-line source location block for a single origin
+  /// element, returning `""` when the response-file gate is inactive
+  /// or no chain is recorded for the element.
+  func formatLocation(for element: InputOrigin.Element) -> String {
+    guard let ctx = formattingContext, ctx.hasResponseFile,
+      let chain = ctx.responseFileChain(for: element)
+    else { return "" }
+    return "\n" + formatChain(chain)
+  }
+
+  /// Renders location blocks for every element in an `InputOrigin` that has a recorded chain.
+  ///
+  /// Returns `""` when the gate is inactive.
+  func formatLocation(for origin: InputOrigin) -> String {
+    guard let ctx = formattingContext, ctx.hasResponseFile else { return "" }
+    var blocks: [String] = []
+    for element in origin.elements {
+      if let chain = ctx.responseFileChain(for: element) {
+        blocks.append(formatChain(chain))
+      }
+    }
+    return blocks.isEmpty ? "" : "\n" + blocks.joined(separator: "\n")
+  }
+
+  private func formatChain(_ chain: [InputOrigin.ResponseFileStep]) -> String {
+    guard let first = chain.first else { return "" }
+    var lines = ["  at \(formatStep(first))"]
+    for step in chain.dropFirst() {
+      lines.append("  included from \(formatStep(step))")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private func formatStep(_ step: InputOrigin.ResponseFileStep) -> String {
+    switch step {
+    case .file(let path, let line): return "\(path):\(line)"
+    case .argv(let index): return "argv[\(index)]"
     }
   }
 }
@@ -295,8 +379,9 @@ extension ErrorMessageGenerator {
   }
 
   func unknownOptionMessage(origin: InputOrigin.Element, name: Name) -> String {
+    let suffix = formatLocation(for: origin)
     if case .short = name {
-      return "Unknown option '\(name.synopsisString)'"
+      return "Unknown option '\(name.synopsisString)'" + suffix
     }
 
     // An empirically derived magic number
@@ -325,16 +410,19 @@ extension ErrorMessageGenerator {
     if let suggestion = suggestion {
       return
         "Unknown option '\(name.synopsisString)'. Did you mean '\(suggestion.synopsisString)'?"
+        + suffix
     }
-    return "Unknown option '\(name.synopsisString)'"
+    return "Unknown option '\(name.synopsisString)'" + suffix
   }
 
   func missingValueForOptionMessage(origin: InputOrigin, name: Name) -> String {
+    let base: String
     if let valueName = valueName(for: name) {
-      return "Missing value for '\(name.synopsisString) <\(valueName)>'"
+      base = "Missing value for '\(name.synopsisString) <\(valueName)>'"
     } else {
-      return "Missing value for '\(name.synopsisString)'"
+      base = "Missing value for '\(name.synopsisString)'"
     }
+    return base + formatLocation(for: origin)
   }
 
   func missingValueOrUnknownCompositeOptionMessage(
@@ -342,6 +430,8 @@ extension ErrorMessageGenerator {
     shortName: Name,
     compositeName: Name
   ) -> String {
+    // The component messages already append their own location suffixes
+    // (one per origin element). The composite message just joins them.
     let unknownOptionMessage = unknownOptionMessage(
       origin: origin.firstElement,
       name: compositeName)
@@ -358,21 +448,29 @@ extension ErrorMessageGenerator {
     origin: InputOrigin.Element, name: Name, value: String
   ) -> String? {
     "The option '\(name.synopsisString)' does not take any value, but '\(value)' was specified."
+      + formatLocation(for: origin)
   }
 
   func unexpectedExtraValuesMessage(values: [(InputOrigin, String)]) -> String?
   {
+    let base: String
     switch values.count {
     case 0:
       return nil
     case 1:
       // swift-format-ignore: NeverForceUnwrap
       // We know that `values` is not empty.
-      return "Unexpected argument '\(values.first!.1)'"
+      base = "Unexpected argument '\(values.first!.1)'"
     default:
       let v = values.map { $0.1 }.joined(separator: "', '")
-      return "\(values.count) unexpected arguments: '\(v)'"
+      base = "\(values.count) unexpected arguments: '\(v)'"
     }
+    // Append a location block for each value's origin.
+    var combined = base
+    for (origin, _) in values {
+      combined += formatLocation(for: origin)
+    }
+    return combined
   }
 
   func duplicateExclusiveValues(
@@ -401,6 +499,8 @@ extension ErrorMessageGenerator {
     //TODO: review this message once environment values are supported.
     return
       "Value to be set with \(dupeString) had already been set with \(origString)"
+      + formatLocation(for: previous)
+      + formatLocation(for: duplicate)
   }
 
   func noValueMessage(key: InputKey) -> String? {
@@ -480,18 +580,21 @@ extension ErrorMessageGenerator {
       customErrorMessage = argumentValue?.formattedValueList ?? ""
     }
 
+    let base: String
     switch (name, valueName) {
     case (let n?, let v?):
-      return
+      base =
         "The value '\(value)' is invalid for '\(n.synopsisString) <\(v)>'\(customErrorMessage)"
     case (_, let v?):
-      return "The value '\(value)' is invalid for '<\(v)>'\(customErrorMessage)"
+      base =
+        "The value '\(value)' is invalid for '<\(v)>'\(customErrorMessage)"
     case (let n?, _):
-      return
+      base =
         "The value '\(value)' is invalid for '\(n.synopsisString)'\(customErrorMessage)"
     case (nil, nil):
-      return "The value '\(value)' is invalid.\(customErrorMessage)"
+      base = "The value '\(value)' is invalid.\(customErrorMessage)"
     }
+    return base + formatLocation(for: origin)
   }
 }
 

--- a/Sources/ArgumentParser/Utilities/StringExtensions.swift
+++ b/Sources/ArgumentParser/Utilities/StringExtensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -254,6 +254,25 @@ extension StringProtocol where SubSequence == Substring {
 
   var nonEmpty: Self? {
     isEmpty ? nil : self
+  }
+
+  /// Returns a new string with leading and trailing whitespace removed.
+  ///
+  /// A character is considered whitespace when `Character.isWhitespace` is
+  /// `true`, which covers spaces, tabs, and newline-family characters.
+  ///
+  /// Examples:
+  ///
+  ///     "  hello  ".trimmed()
+  ///     // "hello"
+  ///     "\n\tvalue\n".trimmed()
+  ///     // "value"
+  func trimmed() -> String {
+    let head = self.drop(while: \.isWhitespace)
+    guard let tail = head.lastIndex(where: { !$0.isWhitespace }) else {
+      return ""
+    }
+    return String(head[...tail])
   }
 }
 

--- a/Sources/ArgumentParserTestHelpers/CMakeLists.txt
+++ b/Sources/ArgumentParserTestHelpers/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ArgumentParserTestHelpers
+  TemporaryFileFixture.swift
   TestHelpers.swift
   TestHelpers+SwiftTesting.swift)
 set_target_properties(ArgumentParserTestHelpers PROPERTIES

--- a/Sources/ArgumentParserTestHelpers/TemporaryFileFixture.swift
+++ b/Sources/ArgumentParserTestHelpers/TemporaryFileFixture.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Scoped scratch directory for Swift Testing suites.
+///
+/// Prefer the `withTemporaryFile` / `withTemporaryDirectory` free
+/// functions over instantiating this type directly — the free functions
+/// own the directory's lifetime and remove it when the closure returns
+/// (success *or* failure).
+public struct TemporaryFileFixture {
+  /// The per-invocation temporary directory.
+  public let temporaryDirectory: URL
+
+  fileprivate init(temporaryDirectory: URL) {
+    self.temporaryDirectory = temporaryDirectory
+  }
+
+  /// Writes `content` to a file named `name` inside the temporary
+  /// directory and returns its absolute path.
+  public func writeTemporaryFile(_ name: String, content: String) throws
+    -> String
+  {
+    let fileURL = self.temporaryDirectory.appendingPathComponent(name)
+    try content.write(to: fileURL, atomically: true, encoding: .utf8)
+    return fileURL.path
+  }
+
+  public func createTestFile(_ name: String, content: String) throws -> String {
+    try writeTemporaryFile(name, content: content)
+  }
+}
+
+/// Runs `body` with a fresh UUID-suffixed scratch directory, then
+/// removes the directory when `body` returns — including when it throws.
+///
+/// Use this variant when the test needs to create *multiple* files that
+/// share a single parent directory (e.g., response files that reference
+/// each other by relative name).
+///
+///     try await withTemporaryDirectory { dir in
+///       let a = try dir.createTestFile("a.txt", content: "...")
+///       let b = try dir.createTestFile("b.txt", content: "@a.txt")
+///       // ...
+///     }
+public func withTemporaryDirectory<Result>(
+  _ body: (TemporaryFileFixture) async throws -> Result
+) async throws -> Result {
+  let fileManager = FileManager()
+  let temporaryDirectory =
+    fileManager
+    .temporaryDirectory
+    .appendingPathComponent("SAP")
+    .appendingPathComponent(UUID().uuidString)
+
+  try fileManager.createDirectory(
+    at: temporaryDirectory,
+    withIntermediateDirectories: true,
+    attributes: nil)
+
+  defer {
+    try? fileManager.removeItem(at: temporaryDirectory)
+  }
+
+  let fixture = TemporaryFileFixture(temporaryDirectory: temporaryDirectory)
+  return try await body(fixture)
+}
+
+/// Runs `body` with a single temporary file whose lifetime is scoped to
+/// the closure.
+///
+/// The file — and its enclosing per-invocation temporary
+/// directory — is removed when `body` returns.
+///
+///     try await withTemporaryFile("args.txt", content: "--name a") { path in
+///       // ...
+///     }
+public func withTemporaryFile<Result>(
+  _ name: String,
+  content: String,
+  _ body: (String) async throws -> Result
+) async throws -> Result {
+  try await withTemporaryDirectory { fixture in
+    let path = try fixture.createTestFile(name, content: content)
+    return try await body(path)
+  }
+}

--- a/Sources/ArgumentParserTestHelpers/TemporaryFileFixture.swift
+++ b/Sources/ArgumentParserTestHelpers/TemporaryFileFixture.swift
@@ -8,8 +8,11 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
-
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Scoped scratch directory for Swift Testing suites.
 ///

--- a/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
+++ b/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
@@ -13,9 +13,12 @@ add_library(EndToEndTests
   RawRepresentableEndToEndTests.swift
   RepeatingEndToEndTests.swift
   RepeatingEndToEndTests+ParsingStrategy.swift
+  ResponseFileEndToEndTests.swift
   ShortNameEndToEndTests.swift
   SimpleEndToEndTests.swift
   SingleValueParsingStrategyTests.swift
+  SourceLocationEndToEndTestSupport.swift
+  SourceLocationErrorEndToEndTests.swift
   SubcommandEndToEndTests.swift
   ValidationEndToEndTests.swift)
 target_link_libraries(EndToEndTests PUBLIC

--- a/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
@@ -288,11 +288,9 @@ extension ResponseFileEndToEndTests {
 
 // Response files must preserve empty string arguments produced by quoted
 // empty tokens (`""` or `''`) when they land in an `@Argument` collection.
-// Silently dropping them would diverge from how `gcc` and other tools
-// expand response files, and would make it impossible to pass an empty
+// Silently dropping them would make it impossible to pass an empty
 // positional value through a response file. See the discussion on
-// apple/swift-argument-parser#909, which references the analogous LLVM
-// fix in llvm/llvm-project#187566.
+// apple/swift-argument-parser#909.
 extension ResponseFileEndToEndTests {
   @Test func doubleQuotedEmptyPositionalPreservedOnOwnLine() async throws {
     try await withTemporaryFile(
@@ -685,7 +683,8 @@ extension ResponseFileEndToEndTests {
         """#
     ) { responseFile in
       expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
-        #expect(command.files == ["double quoted", "single quoted", "unquoted"])
+        #expect(
+          command.files == ["double quoted", "single quoted", "unquoted"])
       }
     }
   }
@@ -714,10 +713,10 @@ extension ResponseFileEndToEndTests {
 
   // MARK: Juxtaposed quoted segments
 
-  // In gcc / LLVM response-file syntax, adjacent quoted segments with no
-  // whitespace between them concatenate into a single token. `""` and
-  // `''` next to other segments contribute nothing except forcing the
-  // resulting token to exist (and to be quoted).
+  // Adjacent quoted segments with no whitespace between them concatenate
+  // into a single token. An empty quoted segment (`""` or `''`) next to
+  // other segments contributes nothing to the string content, but still
+  // forces the resulting token to exist (and to be marked as quoted).
 
   @Test func juxtaposedEmptyDoubleQuotesOnOwnLine() async throws {
     // `""""` is two empty double-quoted segments juxtaposed — still one
@@ -752,7 +751,6 @@ extension ResponseFileEndToEndTests {
   @Test func multipleJuxtaposedEmptyQuoteRunsOnSameLine() async throws {
     // Each whitespace-separated group of juxtaposed empty quotes is one
     // empty positional argument; three groups → three empty arguments.
-    // Mirrors the LLVM `TokenizeGNUCommandLineEmptyQuotes` case.
     try await withTemporaryFile(
       "positional_juxta_empty_multi.txt",
       content: #"""
@@ -808,11 +806,12 @@ extension ResponseFileEndToEndTests {
     }
   }
 
-  @Test func complexJuxtaposedSegmentsMatchLLVM() async throws {
-    // Direct port of the LLVM
-    // `TokenizeGNUCommandLineJuxtaposedQuotedSegments` first case.
+  @Test func complexJuxtaposedSegmentsWithinAndBetweenTokens() async throws {
+    // A single line combining empty and non-empty juxtaposed segments of
+    // both quote styles: each whitespace-separated group forms one
+    // token, with adjacent segments concatenated.
     try await withTemporaryFile(
-      "positional_juxta_llvm.txt",
+      "positional_juxta_complex.txt",
       content: #"""
         a""a ""b c"" d''d ''e f''
         """#
@@ -824,11 +823,10 @@ extension ResponseFileEndToEndTests {
   }
 
   @Test func juxtaposedMixedQuoteStyles() async throws {
-    // Direct port of the LLVM
-    // `TokenizeGNUCommandLineJuxtaposedQuotedSegments` second case:
-    // a single token composed of double-then-single-then-double
+    // A single token composed of double-then-single-then-double
     // segments must produce a single string that preserves the inner
-    // quote characters that were themselves quoted by the *other* style.
+    // quote characters that were themselves quoted by the *other*
+    // style.
     try await withTemporaryFile(
       "positional_juxta_mixed.txt",
       content: #"""
@@ -844,9 +842,9 @@ extension ResponseFileEndToEndTests {
   // MARK: Line-level whitespace
 
   @Test func leadingAndTrailingWhitespaceOnLineIsIgnored() async throws {
-    // Mirrors LLVM's `TokenizeGNUCommandLineWhitespace`: extra whitespace
-    // at the start/end of a line, and the runs of spaces between
-    // arguments, must not produce spurious empty arguments.
+    // Extra whitespace at the start/end of a line, and the runs of
+    // spaces between arguments, must not produce spurious empty
+    // arguments.
     try await withTemporaryFile(
       "positional_ws.txt",
       content: #"""
@@ -859,17 +857,15 @@ extension ResponseFileEndToEndTests {
     }
   }
 
-  // MARK: Unterminated quotes (gcc/LLVM behavior)
+  // MARK: Unterminated quotes
 
-  // Following gcc's and LLVM's `TokenizeGNUCommandLine`, a quote that
-  // is opened but never closed is implicitly terminated at end-of-line.
-  // The trailing content becomes a single argument, with everything up
-  // to the closing whitespace or EOF included verbatim.
+  // A quote that is opened but never closed absorbs input until end of
+  // file. Any content between the opening quote and EOF (including
+  // newlines) becomes part of the resulting token.
 
   @Test func unterminatedSingleQuoteAloneProducesEmptyArg() async throws {
-    // `a b '` → three arguments, the last of which is an empty string
-    // (the opening `'` with no content). Mirrors LLVM
-    // `TokenizeGNUCommandLineUnterminatedQuotes` first case.
+    // `a b '` at EOF → three arguments, the last of which is an empty
+    // string (the opening `'` with no content).
     try await withTemporaryFile(
       "positional_unterm_empty.txt",
       content: #"""
@@ -885,10 +881,9 @@ extension ResponseFileEndToEndTests {
   @Test func unterminatedSingleQuoteWithContentProducesLiteralTail()
     async throws
   {
-    // `a b 'c d` → `["a","b","c d"]`. The opening `'` starts a quoted
-    // segment that runs to end-of-line, absorbing the intervening
-    // whitespace as literal content. Mirrors LLVM
-    // `TokenizeGNUCommandLineUnterminatedQuotes` second case.
+    // `a b 'c d` at EOF → `["a","b","c d"]`. The opening `'` starts a
+    // quoted segment that runs to EOF, absorbing the intervening
+    // whitespace as literal content.
     try await withTemporaryFile(
       "positional_unterm_content.txt",
       content: #"""
@@ -916,9 +911,12 @@ extension ResponseFileEndToEndTests {
     }
   }
 
-  @Test func unterminatedQuoteAcrossOtherLinesIsPerLine() async throws {
-    // Termination happens at end-of-line — the second line is a fresh
-    // context, so its `'` starts and ends its own token.
+  @Test func unterminatedQuoteAbsorbsSubsequentLines() async throws {
+    // With whole-file tokenization, an unterminated quote keeps
+    // absorbing input past the newline — the intervening newline is
+    // literal content inside the still-open quoted segment, and the
+    // next line's opening `'` closes the segment. That means what
+    // looks like three tokens across two lines is actually just two.
     try await withTemporaryFile(
       "positional_unterm_multi.txt",
       content: #"""
@@ -927,7 +925,98 @@ extension ResponseFileEndToEndTests {
         """#
     ) { responseFile in
       expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
-        #expect(command.files == ["first", "unterminated", "second closed"])
+        #expect(
+          command.files == [
+            "first",
+            "unterminated\nsecond",
+            "closed",
+          ])
+      }
+    }
+  }
+
+  // MARK: Literal newlines inside quoted strings
+
+  // A newline character that appears *inside* a quoted segment must be
+  // preserved as part of that token instead of terminating it. This
+  // requires a whole-file tokenizer (rather than a naive line-based one)
+  // so that quote state carries across the newline.
+
+  @Test func literalNewlineInsideSingleQuotesSpansLines() async throws {
+    // `a 'b\nc' d` (with `\n` being a real newline byte) →
+    // `["a", "b\nc", "d"]`.
+    try await withTemporaryFile(
+      "positional_newline_single.txt",
+      content: "a 'b\nc' d\n"
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a", "b\nc", "d"])
+      }
+    }
+  }
+
+  @Test func literalNewlineInsideDoubleQuotesSpansLines() async throws {
+    try await withTemporaryFile(
+      "positional_newline_double.txt",
+      content: "a \"b\nc\" d\n"
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a", "b\nc", "d"])
+      }
+    }
+  }
+
+  @Test func quotedTokenSpansManyLines() async throws {
+    // A token whose opening quote appears on one line and closing quote
+    // appears several lines later must land in `files` as a single
+    // multi-line string.
+    let content = "\"first line\nsecond line\nthird line\" tail\n"
+    try await withTemporaryFile(
+      "positional_multiline_token.txt",
+      content: content
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "first line\nsecond line\nthird line",
+            "tail",
+          ])
+      }
+    }
+  }
+
+  @Test func multipleTokensSurroundingMultilineQuotedToken() async throws {
+    // Tokens before and after a multi-line quoted token are still
+    // parsed normally, and the multi-line token is exactly one
+    // positional value.
+    let content = "head \"line1\nline2\" tail\n"
+    try await withTemporaryFile(
+      "positional_multiline_surrounded.txt",
+      content: content
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["head", "line1\nline2", "tail"])
+      }
+    }
+  }
+
+  @Test func hashInsideMultilineQuoteIsLiteral() async throws {
+    // `#` inside a quoted token — even when it's the first character of
+    // a line inside the token — is a literal, not the start of a
+    // comment. Guards against a naive "start-of-line `#` is a comment"
+    // check that could break multi-line quotes.
+    let content = "before \"start\n# not a comment\nend\" after\n"
+    try await withTemporaryFile(
+      "positional_hash_in_multiline.txt",
+      content: content
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "before",
+            "start\n# not a comment\nend",
+            "after",
+          ])
       }
     }
   }

--- a/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
@@ -1,0 +1,1553 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ArgumentParserTestHelpers
+import Foundation
+import Testing
+
+@Suite struct ResponseFileEndToEndTests {}
+
+// MARK: - Test Commands
+
+private struct SimpleCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "@" }
+
+  @Option var name: String
+  @Option var count: Int = 1
+  @Flag var verbose = false
+}
+
+private struct MultipleArgsCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "@" }
+
+  @Option var input: String
+  @Option var output: String
+  @Option var format: String = "json"
+  @Flag var force = false
+  @Flag var quiet = false
+}
+
+private struct PositionalCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "@" }
+
+  @Argument var files: [String] = []
+  @Option var output: String?
+}
+
+private struct PlusPrefixCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "+" }
+
+  @Option var name: String
+  @Option var count: Int = 1
+  @Flag var verbose = false
+  @Argument var files: [String] = []
+}
+
+private struct HashPrefixCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "#" }
+
+  @Argument var files: [String] = []
+}
+
+private struct PlusPrefixSubcommandParent: ParsableCommand {
+  static var responseFilePrefix: Character? { "+" }
+  static let configuration = CommandConfiguration(
+    subcommands: [SubcommandChild.self]
+  )
+}
+
+private struct SubcommandParent: ParsableCommand {
+  static var responseFilePrefix: Character? { "@" }
+  static let configuration = CommandConfiguration(
+    subcommands: [SubcommandChild.self]
+  )
+
+  @Flag var verbose: Bool = false
+}
+
+private struct SubcommandChild: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "subcommand-child")
+  @Option var value: String
+}
+
+// MARK: - Basic Response File Tests
+
+extension ResponseFileEndToEndTests {
+  @Test func basicResponseFile() async throws {
+    try await withTemporaryFile(
+      "args.txt",
+      content: """
+        --name
+        TestName
+        --count
+        42
+        --verbose
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.name == "TestName")
+        #expect(command.count == 42)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+
+  @Test func responseFileWithMixedArgs() async throws {
+    try await withTemporaryFile(
+      "partial.txt",
+      content: """
+        --name
+        FromFile
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)", "--count", "100"]) {
+        command in
+        #expect(command.name == "FromFile")
+        #expect(command.count == 100)
+        #expect(command.verbose == false)
+      }
+    }
+  }
+
+  @Test func responseFileWithMixedArgsLastWinsCLI() async throws {
+    try await withTemporaryFile(
+      "partial.txt",
+      content: """
+        --name
+        FromFile
+        --count
+        2
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)", "--count", "100"]) {
+        command in
+        #expect(command.name == "FromFile")
+        #expect(command.count == 100)
+        #expect(command.verbose == false)
+      }
+    }
+  }
+
+  @Test func responseFileWithMixedArgsLastWinsResponseFile() async throws {
+    try await withTemporaryFile(
+      "partial.txt",
+      content: """
+        --name
+        FromFile
+        --count
+        2
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["--count", "100", "@\(responseFile)"]) {
+        command in
+        #expect(command.name == "FromFile")
+        #expect(command.count == 2)
+        #expect(command.verbose == false)
+      }
+    }
+  }
+
+  @Test func multipleResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let file1 = try dir.createTestFile(
+        "file1.txt",
+        content: """
+          --name
+          TestName
+          """)
+
+      let file2 = try dir.createTestFile(
+        "file2.txt",
+        content: """
+          --count
+          50
+          --verbose
+          """)
+
+      expectParse(SimpleCommand.self, ["@\(file1)", "@\(file2)"]) { command in
+        #expect(command.name == "TestName")
+        #expect(command.count == 50)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+}
+
+// MARK: - Response File Formats
+
+extension ResponseFileEndToEndTests {
+  @Test func responseFileOneArgPerLine() async throws {
+    try await withTemporaryFile(
+      "oneline.txt",
+      content: """
+        --input
+        input.txt
+        --output
+        output.txt
+        --format
+        xml
+        --force
+        """
+    ) { responseFile in
+      expectParse(MultipleArgsCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.input == "input.txt")
+        #expect(command.output == "output.txt")
+        #expect(command.format == "xml")
+        #expect(command.force == true)
+        #expect(command.quiet == false)
+      }
+    }
+  }
+
+  @Test func responseFileSpaceSeparated() async throws {
+    try await withTemporaryFile(
+      "spaced.txt",
+      content: """
+        --input input.txt --output output.txt --force
+        """
+    ) { responseFile in
+      expectParse(MultipleArgsCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.input == "input.txt")
+        #expect(command.output == "output.txt")
+        #expect(command.force == true)
+      }
+    }
+  }
+
+  @Test func responseFileWithQuotedArguments() async throws {
+    try await withTemporaryFile(
+      "quoted.txt",
+      content: #"""
+        --input "file with spaces.txt"
+        --output 'another file.txt'
+        """#
+    ) { responseFile in
+      expectParse(MultipleArgsCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.input == "file with spaces.txt")
+        #expect(command.output == "another file.txt")
+      }
+    }
+  }
+
+  @Test func responseFileWithComments() async throws {
+    try await withTemporaryFile(
+      "commented.txt",
+      content: """
+        # This is a comment
+        --input
+        input.txt
+        # Another comment
+        --output
+        output.txt
+        --force  # End of line comment
+        """
+    ) { responseFile in
+      expectParse(MultipleArgsCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.input == "input.txt")
+        #expect(command.output == "output.txt")
+        #expect(command.force == true)
+      }
+    }
+  }
+
+  @Test func responseFileWithEmptyLines() async throws {
+    try await withTemporaryFile(
+      "empty_lines.txt",
+      content: """
+        --input
+        input.txt
+
+
+        --output
+        output.txt
+
+        --force
+
+        """
+    ) { responseFile in
+      expectParse(MultipleArgsCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.input == "input.txt")
+        #expect(command.output == "output.txt")
+        #expect(command.force == true)
+      }
+    }
+  }
+}
+
+// MARK: - Quoted Empty String Positional Arguments
+
+// Response files must preserve empty string arguments produced by quoted
+// empty tokens (`""` or `''`) when they land in an `@Argument` collection.
+// Silently dropping them would diverge from how `gcc` and other tools
+// expand response files, and would make it impossible to pass an empty
+// positional value through a response file. See the discussion on
+// apple/swift-argument-parser#909, which references the analogous LLVM
+// fix in llvm/llvm-project#187566.
+extension ResponseFileEndToEndTests {
+  @Test func doubleQuotedEmptyPositionalPreservedOnOwnLine() async throws {
+    try await withTemporaryFile(
+      "positional_empty_double_line.txt",
+      content: #"""
+        first.txt
+        ""
+        last.txt
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["first.txt", "", "last.txt"])
+      }
+    }
+  }
+
+  @Test func singleQuotedEmptyPositionalPreservedOnOwnLine() async throws {
+    try await withTemporaryFile(
+      "positional_empty_single_line.txt",
+      content: #"""
+        first.txt
+        ''
+        last.txt
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["first.txt", "", "last.txt"])
+      }
+    }
+  }
+
+  @Test func multipleEmptyQuotedPositionalsOnSameLine() async throws {
+    try await withTemporaryFile(
+      "positional_many_empties.txt",
+      content: #"""
+        "" '' ""
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["", "", ""])
+      }
+    }
+  }
+
+  @Test func emptyQuotedPositionalsInterleavedWithValues() async throws {
+    try await withTemporaryFile(
+      "positional_interleaved.txt",
+      content: #"""
+        a.txt "" b.txt '' c.txt
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a.txt", "", "b.txt", "", "c.txt"])
+      }
+    }
+  }
+
+  @Test func emptyQuotedPositionalAtStartOfLine() async throws {
+    try await withTemporaryFile(
+      "positional_empty_leading.txt",
+      content: #"""
+        "" a.txt b.txt
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["", "a.txt", "b.txt"])
+      }
+    }
+  }
+
+  @Test func emptyQuotedPositionalAtEndOfLine() async throws {
+    try await withTemporaryFile(
+      "positional_empty_trailing.txt",
+      content: #"""
+        a.txt b.txt ""
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a.txt", "b.txt", ""])
+      }
+    }
+  }
+
+  // An unquoted blank line is treated as whitespace and skipped, but a
+  // line that is *only* a quoted empty string must still contribute an
+  // argument. This regression-guards the boundary between the two.
+  @Test func blankLineSkippedButEmptyQuotedLinePreserved() async throws {
+    try await withTemporaryFile(
+      "positional_blank_vs_quoted.txt",
+      content: #"""
+        first.txt
+
+        ""
+
+        last.txt
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["first.txt", "", "last.txt"])
+      }
+    }
+  }
+}
+
+// MARK: - Quoted String Content Positional Arguments
+
+// The remaining `@Argument`-focused response-file coverage: verify that
+// quoting preserves whitespace, escape sequences, and characters that
+// would otherwise be interpreted by the response-file parser (comment
+// markers, response-file prefix, option-looking tokens). These exercise
+// the full quoting contract advertised by `parseQuotedArgument` /
+// `unescapeString`, not just the empty-string edge case above.
+extension ResponseFileEndToEndTests {
+
+  // MARK: Whitespace preservation
+
+  @Test func doubleQuotedPositionalPreservesInternalSpaces() async throws {
+    try await withTemporaryFile(
+      "positional_spaces_double.txt",
+      content: #"""
+        "hello world"
+        "a b c"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["hello world", "a b c"])
+      }
+    }
+  }
+
+  @Test func singleQuotedPositionalPreservesInternalSpaces() async throws {
+    try await withTemporaryFile(
+      "positional_spaces_single.txt",
+      content: #"""
+        'hello world'
+        'a b c'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["hello world", "a b c"])
+      }
+    }
+  }
+
+  @Test func quotedPositionalPreservesLeadingAndTrailingSpaces() async throws {
+    try await withTemporaryFile(
+      "positional_pad.txt",
+      content: #"""
+        "  leading and trailing  "
+        '  and here too  '
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "  leading and trailing  ",
+            "  and here too  ",
+          ])
+      }
+    }
+  }
+
+  @Test func quotedPositionalWithTabCharacter() async throws {
+    // A literal tab character (not the `\t` escape) between two words
+    // must survive the parser intact when inside quotes.
+    try await withTemporaryFile(
+      "positional_tab.txt",
+      content: "\"col1\tcol2\"\n'col3\tcol4'\n"
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["col1\tcol2", "col3\tcol4"])
+      }
+    }
+  }
+
+  // MARK: Escape sequences inside double quotes
+
+  // `\"` is the only reliable way to embed a literal double quote inside
+  // a double-quoted token, since a bare `"` would end the quoted region.
+  @Test func doubleQuotedEscapedDoubleQuote() async throws {
+    try await withTemporaryFile(
+      "positional_escaped_quote.txt",
+      content: #"""
+        "say \"hello\" now"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == [#"say "hello" now"#])
+      }
+    }
+  }
+
+  @Test func doubleQuotedEscapedBackslash() async throws {
+    // `\\` inside double quotes produces a single literal backslash.
+    try await withTemporaryFile(
+      "positional_escaped_backslash.txt",
+      content: #"""
+        "path\\to\\file"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == [#"path\to\file"#])
+      }
+    }
+  }
+
+  // The example called out in the PR feedback: a `\n` escape inside a
+  // double-quoted token must yield an actual newline character in the
+  // resulting positional argument.
+  @Test func doubleQuotedEscapedNewline() async throws {
+    try await withTemporaryFile(
+      "positional_escaped_newline.txt",
+      content: #"""
+        "line1\nline2"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["line1\nline2"])
+      }
+    }
+  }
+
+  @Test func doubleQuotedEscapedTab() async throws {
+    try await withTemporaryFile(
+      "positional_escaped_tab.txt",
+      content: #"""
+        "col1\tcol2"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["col1\tcol2"])
+      }
+    }
+  }
+
+  @Test func doubleQuotedEscapedCarriageReturn() async throws {
+    try await withTemporaryFile(
+      "positional_escaped_cr.txt",
+      content: #"""
+        "before\rafter"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["before\rafter"])
+      }
+    }
+  }
+
+  @Test func doubleQuotedMixedEscapeSequences() async throws {
+    try await withTemporaryFile(
+      "positional_mixed_escapes.txt",
+      content: #"""
+        "tab\there\nnewline\\backslash\"quote"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["tab\there\nnewline\\backslash\"quote"])
+      }
+    }
+  }
+
+  // MARK: Escape sequences inside single quotes
+
+  // Single quotes are literal — no escape processing at all — so a
+  // backslash sequence must be preserved character-for-character.
+  @Test func singleQuotedPreservesBackslashEscapesLiterally() async throws {
+    try await withTemporaryFile(
+      "positional_single_literal.txt",
+      content: #"""
+        'line1\nline2'
+        'tab\there'
+        'back\\slash'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            #"line1\nline2"#,
+            #"tab\there"#,
+            #"back\\slash"#,
+          ])
+      }
+    }
+  }
+
+  // MARK: Reserved characters preserved inside quotes
+
+  // `#` normally starts an end-of-line comment; inside quotes it must be
+  // treated as a plain character.
+  @Test func quotedHashDoesNotStartComment() async throws {
+    try await withTemporaryFile(
+      "positional_quoted_hash.txt",
+      content: #"""
+        "issue #42 fixed"
+        'tag: #urgent'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["issue #42 fixed", "tag: #urgent"])
+      }
+    }
+  }
+
+  // A quoted token that starts with the response-file prefix must pass
+  // through as a literal positional value rather than triggering a
+  // nested response-file expansion. This is the escape mechanism callers
+  // rely on to pass an argument value that legitimately begins with `@`.
+  @Test func quotedResponseFilePrefixIsLiteralPositional() async throws {
+    try await withTemporaryFile(
+      "positional_quoted_prefix.txt",
+      content: #"""
+        "@not-a-response-file.txt"
+        '@also-not-one.txt'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "@not-a-response-file.txt",
+            "@also-not-one.txt",
+          ])
+      }
+    }
+  }
+
+  // A quoted token that looks like an option (`--flag`, `-x`) must reach
+  // the argument parser as a plain positional string. Positional args in
+  // `PositionalCommand` accept anything, so option-looking values should
+  // land in `files` untouched rather than being treated as unknown flags.
+  @Test func quotedOptionSyntaxIsPositional() async throws {
+    try await withTemporaryFile(
+      "positional_quoted_option.txt",
+      content: #"""
+        "--not-a-flag"
+        '-x'
+        "--"
+        """#
+    ) { responseFile in
+      expectParse(
+        PositionalCommand.self, ["@\(responseFile)", "--output", "o.txt"]
+      ) { command in
+        #expect(command.files == ["--not-a-flag", "-x", "--"])
+        #expect(command.output == "o.txt")
+      }
+    }
+  }
+
+  // MARK: Non-ASCII content
+
+  @Test func quotedPositionalWithUnicode() async throws {
+    try await withTemporaryFile(
+      "positional_unicode.txt",
+      content: #"""
+        "café ☕ résumé"
+        '日本語 🇯🇵'
+        "emoji: 👋🌍"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "café ☕ résumé",
+            "日本語 🇯🇵",
+            "emoji: 👋🌍",
+          ])
+      }
+    }
+  }
+
+  // MARK: Mixed and adjacent quoting
+
+  @Test func multipleQuotedPositionalsOnSameLine() async throws {
+    try await withTemporaryFile(
+      "positional_many_quoted.txt",
+      content: #"""
+        "first arg" "second arg" "third arg"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["first arg", "second arg", "third arg"])
+      }
+    }
+  }
+
+  @Test func mixedQuoteStylesOnSameLine() async throws {
+    try await withTemporaryFile(
+      "positional_mixed_quotes.txt",
+      content: #"""
+        "double quoted" 'single quoted' unquoted
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["double quoted", "single quoted", "unquoted"])
+      }
+    }
+  }
+
+  @Test func quotedTokensAcrossMultipleLines() async throws {
+    try await withTemporaryFile(
+      "positional_multiline.txt",
+      content: #"""
+        "first quoted"
+        second-unquoted
+        'third quoted'
+        "fourth quoted"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(
+          command.files == [
+            "first quoted",
+            "second-unquoted",
+            "third quoted",
+            "fourth quoted",
+          ])
+      }
+    }
+  }
+
+  // MARK: Juxtaposed quoted segments
+
+  // In gcc / LLVM response-file syntax, adjacent quoted segments with no
+  // whitespace between them concatenate into a single token. `""` and
+  // `''` next to other segments contribute nothing except forcing the
+  // resulting token to exist (and to be quoted).
+
+  @Test func juxtaposedEmptyDoubleQuotesOnOwnLine() async throws {
+    // `""""` is two empty double-quoted segments juxtaposed — still one
+    // empty positional argument.
+    try await withTemporaryFile(
+      "positional_juxta_empty_double.txt",
+      content: #"""
+        """"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == [""])
+      }
+    }
+  }
+
+  @Test func juxtaposedEmptySingleQuotesOnOwnLine() async throws {
+    // `''''` is two empty single-quoted segments juxtaposed — still one
+    // empty positional argument.
+    try await withTemporaryFile(
+      "positional_juxta_empty_single.txt",
+      content: #"""
+        ''''
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == [""])
+      }
+    }
+  }
+
+  @Test func multipleJuxtaposedEmptyQuoteRunsOnSameLine() async throws {
+    // Each whitespace-separated group of juxtaposed empty quotes is one
+    // empty positional argument; three groups → three empty arguments.
+    // Mirrors the LLVM `TokenizeGNUCommandLineEmptyQuotes` case.
+    try await withTemporaryFile(
+      "positional_juxta_empty_multi.txt",
+      content: #"""
+        '''' """" ''""
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["", "", ""])
+      }
+    }
+  }
+
+  @Test func juxtaposedUnquotedAndDoubleQuotedConcatenates() async throws {
+    // `a""a` → `aa`: the empty double-quoted segment is a no-op, but the
+    // surrounding unquoted characters join into one token.
+    try await withTemporaryFile(
+      "positional_juxta_a_empty_a.txt",
+      content: #"""
+        a""a
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["aa"])
+      }
+    }
+  }
+
+  @Test func juxtaposedDoubleQuotedSegmentsConcatenate() async throws {
+    // `"foo""bar"` → `foobar`: two adjacent double-quoted segments merge
+    // into a single positional argument.
+    try await withTemporaryFile(
+      "positional_juxta_double.txt",
+      content: #"""
+        "foo""bar"
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["foobar"])
+      }
+    }
+  }
+
+  @Test func juxtaposedSingleQuotedSegmentsConcatenate() async throws {
+    try await withTemporaryFile(
+      "positional_juxta_single.txt",
+      content: #"""
+        'foo''bar'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["foobar"])
+      }
+    }
+  }
+
+  @Test func complexJuxtaposedSegmentsMatchLLVM() async throws {
+    // Direct port of the LLVM
+    // `TokenizeGNUCommandLineJuxtaposedQuotedSegments` first case.
+    try await withTemporaryFile(
+      "positional_juxta_llvm.txt",
+      content: #"""
+        a""a ""b c"" d''d ''e f''
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["aa", "b", "c", "dd", "e", "f"])
+      }
+    }
+  }
+
+  @Test func juxtaposedMixedQuoteStyles() async throws {
+    // Direct port of the LLVM
+    // `TokenizeGNUCommandLineJuxtaposedQuotedSegments` second case:
+    // a single token composed of double-then-single-then-double
+    // segments must produce a single string that preserves the inner
+    // quote characters that were themselves quoted by the *other* style.
+    try await withTemporaryFile(
+      "positional_juxta_mixed.txt",
+      content: #"""
+        "'a'"'"b"'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == [#"'a'"b""#])
+      }
+    }
+  }
+
+  // MARK: Line-level whitespace
+
+  @Test func leadingAndTrailingWhitespaceOnLineIsIgnored() async throws {
+    // Mirrors LLVM's `TokenizeGNUCommandLineWhitespace`: extra whitespace
+    // at the start/end of a line, and the runs of spaces between
+    // arguments, must not produce spurious empty arguments.
+    try await withTemporaryFile(
+      "positional_ws.txt",
+      content: #"""
+          a b c '' d
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a", "b", "c", "", "d"])
+      }
+    }
+  }
+
+  // MARK: Unterminated quotes (gcc/LLVM behavior)
+
+  // Following gcc's and LLVM's `TokenizeGNUCommandLine`, a quote that
+  // is opened but never closed is implicitly terminated at end-of-line.
+  // The trailing content becomes a single argument, with everything up
+  // to the closing whitespace or EOF included verbatim.
+
+  @Test func unterminatedSingleQuoteAloneProducesEmptyArg() async throws {
+    // `a b '` → three arguments, the last of which is an empty string
+    // (the opening `'` with no content). Mirrors LLVM
+    // `TokenizeGNUCommandLineUnterminatedQuotes` first case.
+    try await withTemporaryFile(
+      "positional_unterm_empty.txt",
+      content: #"""
+        a b '
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a", "b", ""])
+      }
+    }
+  }
+
+  @Test func unterminatedSingleQuoteWithContentProducesLiteralTail()
+    async throws
+  {
+    // `a b 'c d` → `["a","b","c d"]`. The opening `'` starts a quoted
+    // segment that runs to end-of-line, absorbing the intervening
+    // whitespace as literal content. Mirrors LLVM
+    // `TokenizeGNUCommandLineUnterminatedQuotes` second case.
+    try await withTemporaryFile(
+      "positional_unterm_content.txt",
+      content: #"""
+        a b 'c d
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["a", "b", "c d"])
+      }
+    }
+  }
+
+  @Test func unterminatedDoubleQuoteBehavesTheSame() async throws {
+    // Double quotes get the same implicit-terminator treatment as
+    // single quotes.
+    try await withTemporaryFile(
+      "positional_unterm_double.txt",
+      content: #"""
+        x y "z with spaces
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["x", "y", "z with spaces"])
+      }
+    }
+  }
+
+  @Test func unterminatedQuoteAcrossOtherLinesIsPerLine() async throws {
+    // Termination happens at end-of-line — the second line is a fresh
+    // context, so its `'` starts and ends its own token.
+    try await withTemporaryFile(
+      "positional_unterm_multi.txt",
+      content: #"""
+        first 'unterminated
+        'second closed'
+        """#
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["first", "unterminated", "second closed"])
+      }
+    }
+  }
+}
+
+// MARK: - Nested Response Files
+
+extension ResponseFileEndToEndTests {
+  @Test func nestedResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let innerFile = try dir.createTestFile(
+        "inner.txt",
+        content: """
+          --count
+          42
+          --verbose
+          """)
+
+      let outerFile = try dir.createTestFile(
+        "outer.txt",
+        content: """
+          --name
+          TestName
+          @\(innerFile)
+          """)
+
+      expectParse(SimpleCommand.self, ["@\(outerFile)"]) { command in
+        #expect(command.name == "TestName")
+        #expect(command.count == 42)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+
+  @Test func recursiveResponseFileDetection() async throws {
+    try await withTemporaryDirectory { dir in
+      let file1 = try dir.createTestFile(
+        "recursive1.txt",
+        content: """
+          --name
+          Test
+          @recursive2.txt
+          """)
+
+      _ = try dir.createTestFile(
+        "recursive2.txt",
+        content: """
+          --count
+          10
+          @recursive1.txt
+          """)
+
+      // This should throw an error for recursive response files
+      #expect(throws: (any Error).self) {
+        try SimpleCommand.parse(["@\(file1)"])
+      }
+    }
+  }
+
+  @Test func deepNestedResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let level3 = try dir.createTestFile(
+        "level3.txt",
+        content: """
+          --verbose
+          """)
+
+      let level2 = try dir.createTestFile(
+        "level2.txt",
+        content: """
+          --count
+          100
+          @\(level3)
+          """)
+
+      let level1 = try dir.createTestFile(
+        "level1.txt",
+        content: """
+          --name
+          DeepNested
+          @\(level2)
+          """)
+
+      expectParse(SimpleCommand.self, ["@\(level1)"]) { command in
+        #expect(command.name == "DeepNested")
+        #expect(command.count == 100)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+}
+
+// MARK: - Positional Arguments
+
+extension ResponseFileEndToEndTests {
+  @Test func responseFileWithPositionalArgs() async throws {
+    try await withTemporaryFile(
+      "positional.txt",
+      content: """
+        file1.txt
+        file2.txt
+        file3.txt
+        --output
+        result.txt
+        """
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["file1.txt", "file2.txt", "file3.txt"])
+        #expect(command.output == "result.txt")
+      }
+    }
+  }
+
+  @Test func responseFileWithPositionalAndRegularArgs() async throws {
+    try await withTemporaryFile(
+      "mixed_pos.txt",
+      content: """
+        fromfile1.txt
+        fromfile2.txt
+        """
+    ) { responseFile in
+      expectParse(
+        PositionalCommand.self,
+        ["regular1.txt", "@\(responseFile)", "regular2.txt"]
+      ) { command in
+        #expect(
+          command.files
+            == [
+              "regular1.txt", "fromfile1.txt", "fromfile2.txt", "regular2.txt",
+            ]
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Subcommands
+
+extension ResponseFileEndToEndTests {
+  @Test func responseFileWithSubcommands() async throws {
+    try await withTemporaryFile(
+      "subcommand.txt",
+      content: """
+        subcommand-child
+        --value
+        TestValue
+        """
+    ) { responseFile in
+      expectParseCommand(
+        SubcommandParent.self, SubcommandChild.self, ["@\(responseFile)"]
+      ) { command in
+        #expect(command.value == "TestValue")
+      }
+    }
+  }
+
+  @Test func responseFileBeforeSubcommand() async throws {
+    try await withTemporaryFile(
+      "before_sub.txt",
+      content: """
+        # Global options would go here if SubcommandParent had any
+        """
+    ) { responseFile in
+      expectParseCommand(
+        SubcommandParent.self, SubcommandChild.self,
+        ["@\(responseFile)", "subcommand-child", "--value", "Test"]
+      ) { command in
+        #expect(command.value == "Test")
+      }
+    }
+  }
+}
+
+// MARK: - Error Cases
+
+extension ResponseFileEndToEndTests {
+  @Test func nonexistentResponseFile() throws {
+    #expect(throws: (any Error).self) {
+      try SimpleCommand.parse(["@/nonexistent/file.txt"])
+    }
+  }
+
+  @Test func invalidResponseFilePermissions() async throws {
+    try await withTemporaryFile(
+      "noaccess.txt", content: "--name Test"
+    ) { responseFile in
+      // Remove read permissions (this may not work in all test environments)
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o000],
+        ofItemAtPath: responseFile
+      )
+      defer {
+        // Restore permissions for cleanup
+        try? FileManager.default.setAttributes(
+          [.posixPermissions: 0o644],
+          ofItemAtPath: responseFile
+        )
+      }
+
+      // Skip on platforms/environments where POSIX permissions don't
+      // actually restrict reads — most notably root inside a Docker
+      // container (root bypasses mode bits) and Windows (NTFS ACLs, not
+      // POSIX modes, gate access).
+      guard !FileManager.default.isReadableFile(atPath: responseFile) else {
+        return
+      }
+
+      #expect(throws: (any Error).self) {
+        try SimpleCommand.parse(["@\(responseFile)"])
+      }
+    }
+  }
+
+  @Test func emptyResponseFile() async throws {
+    try await withTemporaryFile("empty.txt", content: "") { responseFile in
+      // Empty response file should be valid and not add any arguments
+      expectParse(SimpleCommand.self, ["@\(responseFile)", "--name", "Test"]) {
+        command in
+        #expect(command.name == "Test")
+        #expect(command.count == 1)  // default value
+        #expect(command.verbose == false)
+      }
+    }
+  }
+
+  @Test func malformedArgumentsInResponseFile() async throws {
+    try await withTemporaryFile(
+      "malformed.txt",
+      content: """
+        --name
+        # Missing value for --name
+        --count
+        notanumber
+        """
+    ) { responseFile in
+      #expect(throws: (any Error).self) {
+        try SimpleCommand.parse(["@\(responseFile)"])
+      }
+    }
+  }
+}
+
+// MARK: - Edge Cases
+
+extension ResponseFileEndToEndTests {
+  @Test func responseFileNameWithSpaces() async throws {
+    try await withTemporaryFile(
+      "file with spaces.txt",
+      content: """
+        --name
+        Test
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.name == "Test")
+      }
+    }
+  }
+
+  @Test func literalAtSignArgument() async throws {
+    // Test that we can still pass literal @something arguments
+    // This would need special escaping mechanism, like @@file.txt for literal @file.txt
+    try await withTemporaryFile(
+      "literal.txt",
+      content: """
+        --name
+        @@notafile
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.name == "@notafile")
+      }
+    }
+  }
+
+  @Test func responseFileWithTerminator() async throws {
+    try await withTemporaryFile(
+      "terminator.txt",
+      content: """
+        --output
+        result.txt
+        --
+        file1.txt
+        file2.txt
+        """
+    ) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files == ["file1.txt", "file2.txt"])
+        #expect(command.output == "result.txt")
+      }
+    }
+  }
+
+  @Test func responseFileWithEqualsFormat() async throws {
+    try await withTemporaryFile(
+      "equals.txt",
+      content: """
+        --name=TestName
+        --count=42
+        """
+    ) { responseFile in
+      expectParse(SimpleCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.name == "TestName")
+        #expect(command.count == 42)
+      }
+    }
+  }
+
+  @Test func veryLargeResponseFile() async throws {
+    // Test with a response file containing many arguments
+    var content = ""
+    for i in 1...1000 {
+      content += "arg\(i).txt\n"
+    }
+
+    try await withTemporaryFile("large.txt", content: content) { responseFile in
+      expectParse(PositionalCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.files.count == 1000)
+        #expect(command.files.first == "arg1.txt")
+        #expect(command.files.last == "arg1000.txt")
+      }
+    }
+  }
+}
+
+// MARK: - Configuration Options
+
+extension ResponseFileEndToEndTests {
+  // These tests will verify that response file support can be configured
+  // The actual configuration mechanism will be defined during implementation
+
+  @Test func disableResponseFileSupport() throws {
+    // Test that response file support can be disabled per command
+    // This would be implemented as a configuration option
+    // For now, this is a placeholder for the feature
+
+    // When disabled, @file should be treated as a literal argument
+    // Implementation details TBD
+  }
+
+  @Test func responseFileSearchPaths() throws {
+    // Test that response files can be searched in multiple directories
+    // Implementation details TBD
+  }
+}
+
+// MARK: - AsyncParsableCommand Support Tests
+
+extension ResponseFileEndToEndTests {
+  @Test func responseFileWithAsyncParsableCommand() async throws {
+    try await withTemporaryFile(
+      "async-args.txt",
+      content: """
+        --name
+        AsyncTest
+        --count
+        42
+        """
+    ) { responseFile in
+      struct AsyncTestCommand: AsyncParsableCommand {
+        static var responseFilePrefix: Character? { "@" }
+
+        @Option var name: String
+        @Option var count: Int
+
+        func run() async throws {
+          // Test command that uses async
+        }
+      }
+
+      expectParse(AsyncTestCommand.self, ["@\(responseFile)"]) { command in
+        #expect(command.name == "AsyncTest")
+        #expect(command.count == 42)
+      }
+    }
+  }
+
+  @Test func responseFileWithAsyncSubcommand() async throws {
+    try await withTemporaryFile(
+      "async-sub-args.txt",
+      content: """
+        sub
+        --value
+        AsyncSubTest
+        """
+    ) { responseFile in
+      struct AsyncParentCommand: AsyncParsableCommand {
+        static var responseFilePrefix: Character? { "@" }
+        static let configuration = CommandConfiguration(
+          commandName: "async-parent",
+          subcommands: [AsyncSubCommand.self]
+        )
+      }
+
+      struct AsyncSubCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "sub")
+        @Option var value: String
+
+        func run() async throws {
+          // Async subcommand implementation
+        }
+      }
+
+      expectParseCommand(
+        AsyncParentCommand.self, AsyncSubCommand.self, ["@\(responseFile)"]
+      ) { command in
+        #expect(command.value == "AsyncSubTest")
+      }
+    }
+  }
+
+  @Test func responseFileWithMixedAsyncArgs() async throws {
+    try await withTemporaryFile(
+      "mixed-async.txt",
+      content: """
+        --input
+        input.txt
+        --async-flag
+        """
+    ) { responseFile in
+      struct MixedAsyncCommand: AsyncParsableCommand {
+        static var responseFilePrefix: Character? { "@" }
+
+        @Option var input: String
+        @Option var output: String = "default.txt"
+        @Flag var asyncFlag: Bool = false
+
+        func run() async throws {
+          // Mixed args async command
+        }
+      }
+
+      expectParse(
+        MixedAsyncCommand.self,
+        ["@\(responseFile)", "--output", "override.txt"]
+      ) { command in
+        #expect(command.input == "input.txt")
+        // CLI arg overrides default
+        #expect(command.output == "override.txt")
+        #expect(command.asyncFlag)
+      }
+    }
+  }
+}
+
+// MARK: - Custom Response File Prefix
+
+extension ResponseFileEndToEndTests {
+  @Test func defaultResponseFilePrefixIsNil() {
+    struct DefaultPrefixCommand: ParsableCommand {}
+    struct DefaultPrefixSubcommandParent: ParsableCommand {
+      static let configuration = CommandConfiguration(
+        subcommands: [SubcommandChild.self]
+      )
+    }
+
+    #expect(DefaultPrefixCommand.responseFilePrefix == nil)
+    #expect(DefaultPrefixSubcommandParent.responseFilePrefix == nil)
+    #expect(SubcommandChild.responseFilePrefix == nil)
+  }
+
+  @Test func commandCanOverrideResponseFilePrefix() {
+    #expect(PlusPrefixCommand.responseFilePrefix == "+")
+    #expect(HashPrefixCommand.responseFilePrefix == "#")
+    #expect(PlusPrefixSubcommandParent.responseFilePrefix == "+")
+  }
+
+  @Test func customPrefixExpandsResponseFile() async throws {
+    try await withTemporaryFile(
+      "custom-prefix.txt",
+      content: """
+        --name
+        FromCustomPrefix
+        --count
+        7
+        --verbose
+        """
+    ) { responseFile in
+      expectParse(PlusPrefixCommand.self, ["+\(responseFile)"]) { command in
+        #expect(command.name == "FromCustomPrefix")
+        #expect(command.count == 7)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+
+  @Test func customPrefixDoesNotExpandAtSignArgument() async throws {
+    // With the `+` prefix set, `@something` must be treated as a
+    // literal positional value rather than a response file reference.
+    try await withTemporaryFile(
+      "custom-prefix-args.txt",
+      content: """
+        --name
+        Sam
+        """
+    ) { responseFile in
+      expectParse(
+        PlusPrefixCommand.self,
+        ["+\(responseFile)", "@not-a-response-file.txt"]
+      ) { command in
+        #expect(command.name == "Sam")
+        #expect(command.files == ["@not-a-response-file.txt"])
+      }
+    }
+  }
+
+  @Test func defaultPrefixDoesNotExpandCustomPrefixArgument() async throws {
+    // with the default `@` prefix, `+something` is an ordinary positional value.
+    expectParse(
+      PositionalCommand.self, ["+not-a-response-file.txt"]
+    ) { command in
+      #expect(command.files == ["+not-a-response-file.txt"])
+    }
+  }
+
+  @Test func customPrefixQuotedIsLiteral() async throws {
+    // Quoting a token in a response file passes it through verbatim,
+    // so `"+file"` is treated as the literal value `+file` even though
+    // the active response-file prefix is `+`.
+    try await withTemporaryFile(
+      "custom-escape.txt",
+      content: """
+        --name
+        Escaped
+        "+literal.txt"
+        """
+    ) { responseFile in
+      expectParse(PlusPrefixCommand.self, ["+\(responseFile)"]) { command in
+        #expect(command.name == "Escaped")
+        #expect(command.files == ["+literal.txt"])
+      }
+    }
+  }
+
+  @Test func customPrefixDoubledIsLiteral() async throws {
+    // Doubling the configured prefix escapes it: with `+` in effect,
+    // `++file` becomes the literal `+file` (parallel to the built-in
+    // `@@file` -> `@file` handling for the default prefix).
+    try await withTemporaryFile(
+      "custom-doubled.txt",
+      content: """
+        --name
+        Escaped
+        ++literal.txt
+        """
+    ) { responseFile in
+      expectParse(PlusPrefixCommand.self, ["+\(responseFile)"]) { command in
+        #expect(command.name == "Escaped")
+        #expect(command.files == ["+literal.txt"])
+      }
+    }
+  }
+
+  @Test func customPrefixNestedResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let inner = try dir.createTestFile(
+        "inner.txt",
+        content: """
+          --count
+          99
+          --verbose
+          """
+      )
+      let outer = try dir.createTestFile(
+        "outer.txt",
+        content: """
+          --name
+          Nested
+          +\(inner)
+          """
+      )
+
+      expectParse(PlusPrefixCommand.self, ["+\(outer)"]) { command in
+        #expect(command.name == "Nested")
+        #expect(command.count == 99)
+        #expect(command.verbose == true)
+      }
+    }
+  }
+
+  @Test func customPrefixWithSubcommand() async throws {
+    // The root command's prefix determines the response-file prefix
+    // used for the entire invocation, including subcommand arguments.
+    try await withTemporaryFile(
+      "subcommand.txt",
+      content: """
+        subcommand-child
+        --value
+        FromCustomPrefix
+        """
+    ) { responseFile in
+      expectParseCommand(
+        PlusPrefixSubcommandParent.self, SubcommandChild.self,
+        ["+\(responseFile)"]
+      ) { command in
+        #expect(command.value == "FromCustomPrefix")
+      }
+    }
+  }
+
+  @Test func customPrefixMissingFileThrows() throws {
+    #expect(throws: (any Error).self) {
+      try PlusPrefixCommand.parse(["+/nonexistent/file.txt"])
+    }
+  }
+
+  @Test func customPrefixNonHashArgumentTreatedAsValue() async throws {
+    // The `#` prefix is a common comment character in response file
+    // content; verify overriding to `#` still triggers expansion when
+    // used as an argument prefix on the command line.
+    try await withTemporaryFile(
+      "hash-prefix.txt",
+      content: """
+        a.txt
+        b.txt
+        """
+    ) { responseFile in
+      expectParse(HashPrefixCommand.self, ["#\(responseFile)"]) { command in
+        #expect(command.files == ["a.txt", "b.txt"])
+      }
+    }
+  }
+}

--- a/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift
@@ -19,7 +19,7 @@ import Testing
 // MARK: - Test Commands
 
 private struct SimpleCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "@" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "@")
 
   @Option var name: String
   @Option var count: Int = 1
@@ -27,7 +27,7 @@ private struct SimpleCommand: ParsableCommand {
 }
 
 private struct MultipleArgsCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "@" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "@")
 
   @Option var input: String
   @Option var output: String
@@ -37,14 +37,14 @@ private struct MultipleArgsCommand: ParsableCommand {
 }
 
 private struct PositionalCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "@" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "@")
 
   @Argument var files: [String] = []
   @Option var output: String?
 }
 
 private struct PlusPrefixCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "+" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "+")
 
   @Option var name: String
   @Option var count: Int = 1
@@ -53,22 +53,22 @@ private struct PlusPrefixCommand: ParsableCommand {
 }
 
 private struct HashPrefixCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "#" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "#")
 
   @Argument var files: [String] = []
 }
 
 private struct PlusPrefixSubcommandParent: ParsableCommand {
-  static var responseFilePrefix: Character? { "+" }
   static let configuration = CommandConfiguration(
-    subcommands: [SubcommandChild.self]
+    subcommands: [SubcommandChild.self],
+    responseFilePrefix: "+"
   )
 }
 
 private struct SubcommandParent: ParsableCommand {
-  static var responseFilePrefix: Character? { "@" }
   static let configuration = CommandConfiguration(
-    subcommands: [SubcommandChild.self]
+    subcommands: [SubcommandChild.self],
+    responseFilePrefix: "@"
   )
 
   @Flag var verbose: Bool = false
@@ -1310,6 +1310,34 @@ extension ResponseFileEndToEndTests {
     }
   }
 
+  @Test func inlineArgsAfterResponseFileWithTerminatorAreTreatedAsPositional()
+    async throws
+  {
+    // Response-file expansion is in-place, so tokens that appear on the
+    // command line after the `@file` reference land after the file's
+    // arguments in the flat stream. When the file itself ends by
+    // switching into positional-only mode with `--`, subsequent CLI
+    // tokens inherit that state and are captured as positional values,
+    // even if they look like options.
+    try await withTemporaryFile(
+      "terminator-first.txt",
+      content: """
+        --output
+        result.txt
+        --
+        file1.txt
+        """
+    ) { responseFile in
+      expectParse(
+        PositionalCommand.self,
+        ["@\(responseFile)", "--output", "ignored.txt"]
+      ) { command in
+        #expect(command.output == "result.txt")
+        #expect(command.files == ["file1.txt", "--output", "ignored.txt"])
+      }
+    }
+  }
+
   @Test func responseFileWithEqualsFormat() async throws {
     try await withTemporaryFile(
       "equals.txt",
@@ -1377,7 +1405,8 @@ extension ResponseFileEndToEndTests {
         """
     ) { responseFile in
       struct AsyncTestCommand: AsyncParsableCommand {
-        static var responseFilePrefix: Character? { "@" }
+        static let configuration = CommandConfiguration(
+          responseFilePrefix: "@")
 
         @Option var name: String
         @Option var count: Int
@@ -1404,10 +1433,10 @@ extension ResponseFileEndToEndTests {
         """
     ) { responseFile in
       struct AsyncParentCommand: AsyncParsableCommand {
-        static var responseFilePrefix: Character? { "@" }
         static let configuration = CommandConfiguration(
           commandName: "async-parent",
-          subcommands: [AsyncSubCommand.self]
+          subcommands: [AsyncSubCommand.self],
+          responseFilePrefix: "@"
         )
       }
 
@@ -1438,7 +1467,8 @@ extension ResponseFileEndToEndTests {
         """
     ) { responseFile in
       struct MixedAsyncCommand: AsyncParsableCommand {
-        static var responseFilePrefix: Character? { "@" }
+        static let configuration = CommandConfiguration(
+          responseFilePrefix: "@")
 
         @Option var input: String
         @Option var output: String = "default.txt"
@@ -1473,15 +1503,17 @@ extension ResponseFileEndToEndTests {
       )
     }
 
-    #expect(DefaultPrefixCommand.responseFilePrefix == nil)
-    #expect(DefaultPrefixSubcommandParent.responseFilePrefix == nil)
-    #expect(SubcommandChild.responseFilePrefix == nil)
+    #expect(DefaultPrefixCommand.configuration.responseFilePrefix == nil)
+    #expect(
+      DefaultPrefixSubcommandParent.configuration.responseFilePrefix == nil)
+    #expect(SubcommandChild.configuration.responseFilePrefix == nil)
   }
 
   @Test func commandCanOverrideResponseFilePrefix() {
-    #expect(PlusPrefixCommand.responseFilePrefix == "+")
-    #expect(HashPrefixCommand.responseFilePrefix == "#")
-    #expect(PlusPrefixSubcommandParent.responseFilePrefix == "+")
+    #expect(PlusPrefixCommand.configuration.responseFilePrefix == "+")
+    #expect(HashPrefixCommand.configuration.responseFilePrefix == "#")
+    #expect(
+      PlusPrefixSubcommandParent.configuration.responseFilePrefix == "+")
   }
 
   @Test func customPrefixExpandsResponseFile() async throws {

--- a/Tests/ArgumentParserEndToEndTests/SourceLocationEndToEndTestSupport.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceLocationEndToEndTestSupport.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import Testing
+
+// Shared helpers for the source-location tracking test suites.
+
+/// Drives `T.parse(arguments)` expecting failure, then returns the short error message produced by the framework.
+///
+/// Records an issue if parsing unexpectedly succeeded.
+func errorMessage<T: ParsableArguments>(
+  for type: T.Type,
+  arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws -> String {
+  #if compiler(>=6.1)
+  let error = try #require(
+    throws: (any Error).self,
+    "Parsing should have failed for \(arguments).",
+    sourceLocation: sourceLocation,
+  ) {
+    _ = try T.parse(arguments)
+  }
+  return T.message(for: error)
+  #else
+  do {
+    _ = try T.parse(arguments)
+    Issue.record(
+      "Parsing should have failed for \(arguments).",
+      sourceLocation: sourceLocation)
+    return ""
+  } catch {
+    return T.message(for: error)
+  }
+  #endif
+}
+
+/// Drives `T.parseAsRoot(arguments)` expecting the framework to throw (either a real parse error or a clean-exit signal such as a dump request), then returns the full rendered message.
+///
+/// Records an issue if parsing succeeded.
+func fullMessage<T: ParsableCommand>(
+  for type: T.Type,
+  arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws -> String {
+  #if compiler(>=6.1)
+  let error = try #require(
+    throws: (any Error).self,
+    "Parsing should have thrown for \(arguments).",
+    sourceLocation: sourceLocation,
+  ) {
+    _ = try type.parseAsRoot(arguments)
+  }
+  return type.fullMessage(for: error)
+  #else
+  do {
+    _ = try type.parseAsRoot(arguments)
+    Issue.record(
+      "Parsing should have thrown for \(arguments).",
+      sourceLocation: sourceLocation)
+    return ""
+  } catch {
+    return type.fullMessage(for: error)
+  }
+  #endif
+}
+
+/// Drives `T.parseAsRoot(arguments)` expecting failure, then returns the short error message.
+///
+/// Records an issue if parsing succeeded.
+func rootErrorMessage<T: ParsableCommand>(
+  for type: T.Type,
+  arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws -> String {
+  #if compiler(>=6.1)
+  let error = try #require(
+    throws: (any Error).self,
+    "Parsing should have failed for \(arguments).",
+    sourceLocation: sourceLocation,
+  ) {
+    _ = try type.parseAsRoot(arguments)
+  }
+  return type.message(for: error)
+  #else
+  do {
+    _ = try type.parseAsRoot(arguments)
+    Issue.record(
+      "Parsing should have failed for \(arguments).",
+      sourceLocation: sourceLocation)
+    return ""
+  } catch {
+    return type.message(for: error)
+  }
+  #endif
+}

--- a/Tests/ArgumentParserEndToEndTests/SourceLocationErrorEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceLocationErrorEndToEndTests.swift
@@ -1,0 +1,323 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ArgumentParserTestHelpers
+import Foundation
+import Testing
+
+// Behavior tests - CLI Failure Source Location, response-file-gated.
+//
+// These tests verify that:
+//   * When the input contains NO @file reference, error messages are
+//     byte-for-byte identical to the legacy behavior (no location block).
+//   * When the input contains AT LEAST ONE @file reference, error messages
+//     include a multi-line `at … included from …` location block per the
+//     plan in `plans/source-location-tracking-architecture.md`.
+//
+// The "gate inactive" tests act as a regression guard — they should pass
+// today and continue to pass after the feature lands. The "gate active"
+// tests are expected to FAIL until the feature is implemented.
+//
+// Shared message-extraction helpers live in
+// `SourceLocationEndToEndTestSupport.swift`.
+
+@Suite struct SourceLocationErrorEndToEndTests {}
+
+// MARK: - Test Commands
+
+private struct ErrorCommand: ParsableCommand {
+  static var responseFilePrefix: Character? { "@" }
+  @Option var name: String
+  @Option var count: Int = 1
+  @Flag var verbose = false
+}
+
+// MARK: - Gate Inactive (regression guard)
+//
+// These tests assert that argv-only invocations produce the same error
+// messages as today. They should pass both before and after the feature
+// lands. If any of these tests fails after the feature ships, the gate
+// has leaked.
+
+extension SourceLocationErrorEndToEndTests {
+
+  @Test func gateInactiveUnknownOptionMessageUnchanged() async throws {
+    expectErrorMessage(
+      ErrorCommand.self,
+      ["--name", "a", "--bogus"],
+      "Unknown option '--bogus'"
+    )
+  }
+
+  @Test func gateInactiveMissingValueForOptionMessageUnchanged() async throws {
+    expectErrorMessage(
+      ErrorCommand.self,
+      ["--name", "a", "--count"],
+      "Missing value for '--count <count>'")
+  }
+
+  @Test func gateInactiveUnableToParseValueMessageUnchanged() async throws {
+    expectErrorMessage(
+      ErrorCommand.self,
+      ["--name", "a", "--count", "not-a-number"],
+      "The value 'not-a-number' is invalid for '--count <count>'")
+  }
+
+  @Test func gateInactiveUnexpectedExtraValuesMessageUnchanged() async throws {
+    expectErrorMessage(
+      ErrorCommand.self,
+      ["--name", "a", "extra"],
+      "Unexpected argument 'extra'")
+  }
+
+  @Test func gateInactiveNoLocationBlockSubstrings() async throws {
+    // Defensive: the rendered string must never contain the new location
+    // markers when the gate is inactive.
+    let m = try errorMessage(
+      for: ErrorCommand.self, arguments: ["--name", "a", "--bogus"])
+    #expect(
+      !m.contains("at argv["),
+      "argv-only invocation should not emit `at argv[N]`: got \(m)")
+    #expect(
+      !m.contains("included from"),
+      "argv-only invocation should not emit `included from`: got \(m)")
+  }
+}
+
+// MARK: - Gate Active — single response file
+//
+// These tests are expected to FAIL today. They will pass once the
+// `at <file>:<line>` location block is appended to gated error messages.
+
+extension SourceLocationErrorEndToEndTests {
+
+  @Test func gateActiveSingleFileUnknownOptionIncludesFileLine() async throws {
+    try await withTemporaryFile(
+      "unknown-opt.txt",
+      content: """
+        --name
+        a
+        --bogus
+        """
+    ) { responseFile in
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(responseFile)"])
+
+      #expect(
+        m.contains("Unknown option '--bogus'"),
+        "Should still include the original error text: got \(m)")
+      #expect(
+        m.contains("at \(responseFile):3"),
+        "Should include `at <file>:<line>` for the offending arg: got \(m)")
+    }
+  }
+
+  @Test func gateActiveSingleFileMissingValueIncludesFileLine() async throws {
+    try await withTemporaryFile(
+      "missing-value.txt",
+      content: """
+        --name
+        a
+        --count
+        """
+    ) { responseFile in
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(responseFile)"])
+
+      #expect(
+        m.contains("Missing value for '--count <count>'"),
+        "Should still include the original error text: got \(m)")
+      #expect(
+        m.contains("at \(responseFile):3"),
+        "Should pinpoint the offending `--count` to line 3: got \(m)")
+    }
+  }
+
+  @Test func gateActiveSingleFileUnableToParseValueIncludesFileLine()
+    async throws
+  {
+    try await withTemporaryFile(
+      "bad-value.txt",
+      content: """
+        --name
+        a
+        --count
+        not-a-number
+        """
+    ) { responseFile in
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(responseFile)"])
+
+      #expect(
+        m.contains("not-a-number"),
+        "Should still include the offending value: got \(m)")
+      #expect(
+        m.contains("at \(responseFile):4"),
+        "Should pinpoint the bad value to line 4: got \(m)")
+    }
+  }
+
+  @Test func gateActiveSingleFileUnexpectedExtraValueIncludesFileLine()
+    async throws
+  {
+    try await withTemporaryFile(
+      "extra.txt",
+      content: """
+        --name
+        a
+        extra
+        """
+    ) { responseFile in
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(responseFile)"])
+
+      #expect(
+        m.contains("Unexpected argument 'extra'"),
+        "Should still include the original error text: got \(m)")
+      #expect(
+        m.contains("at \(responseFile):3"),
+        "Should pinpoint the extra value to line 3: got \(m)")
+    }
+  }
+}
+
+// MARK: - Gate Active — nested response files
+//
+// Verifies the `at … included from …` chain rendering. Expected to FAIL
+// until the feature lands.
+
+extension SourceLocationErrorEndToEndTests {
+
+  @Test func gateActiveNestedFilesIncludeChainOuterMostLast() async throws {
+    try await withTemporaryDirectory { dir in
+      let inner = try dir.createTestFile(
+        "inner.txt",
+        content: """
+          --name
+          a
+          --bogus
+          """)
+
+      let outer = try dir.createTestFile(
+        "outer.txt",
+        content: """
+          @\(inner)
+          """)
+
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(outer)"])
+
+      #expect(
+        m.contains("Unknown option '--bogus'"),
+        "Should still include the original error text: got \(m)")
+      #expect(
+        m.contains("at \(inner):3"),
+        "Innermost frame should be the file the arg literally lives in: got \(m)"
+      )
+      #expect(
+        m.contains("included from \(outer):1"),
+        "Outer file should appear as an `included from` line: got \(m)")
+
+      // The innermost frame must appear BEFORE the outer frame in the rendered
+      // text — chain is rendered innermost first, outermost last.
+      if let innerRange = m.range(of: "at \(inner):3"),
+        let outerRange = m.range(of: "included from \(outer):1")
+      {
+        #expect(
+          innerRange.lowerBound < outerRange.lowerBound,
+          "Innermost `at` must precede `included from` lines: got \(m)")
+      }
+    }
+  }
+
+  @Test func gateActiveThreeLevelNestingChainHasAllFrames() async throws {
+    try await withTemporaryDirectory { dir in
+      let level3 = try dir.createTestFile(
+        "lvl3.txt",
+        content: """
+          --name
+          a
+          --bogus
+          """)
+      let level2 = try dir.createTestFile(
+        "lvl2.txt",
+        content: """
+          @\(level3)
+          """)
+      let level1 = try dir.createTestFile(
+        "lvl1.txt",
+        content: """
+          @\(level2)
+          """)
+
+      let m = try errorMessage(
+        for: ErrorCommand.self, arguments: ["@\(level1)"])
+
+      #expect(m.contains("at \(level3):3"), "Missing innermost frame: \(m)")
+      #expect(
+        m.contains("included from \(level2):1"),
+        "Missing middle frame: \(m)")
+      #expect(
+        m.contains("included from \(level1):1"),
+        "Missing outermost file frame: \(m)")
+
+      // The innermost frame must appear BEFORE the outer frame in the rendered
+      // text — chain is rendered innermost first, outermost last.
+      if let topRange = m.range(of: "at \(level3):3"),
+        let midRange = m.range(of: "included from \(level2):1"),
+        let outerRange = m.range(of: "included from \(level1):1")
+      {
+        #expect(
+          topRange.lowerBound < midRange.lowerBound,
+          "topRange `at` must precede middle `included from` lines: got \(m)"
+        )
+        #expect(
+          midRange.lowerBound < outerRange.lowerBound,
+          "middle `included from` must precede outer `included from` lines: got \(m)"
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Gate Active — mixed argv + response file
+//
+// When the gate is active because there's a response file in the input,
+// argv-origin errors should also be annotated (with `at argv[N]` rather
+// than a file:line). Expected to FAIL until the feature lands.
+
+extension SourceLocationErrorEndToEndTests {
+
+  @Test func gateActiveMixedInputArgvErrorShowsArgvIndex() async throws {
+    // Put a valid response file early in argv, then an argv-origin error.
+    try await withTemporaryFile(
+      "valid.txt",
+      content: """
+        --name
+        a
+        """
+    ) { validFile in
+      let m = try errorMessage(
+        for: ErrorCommand.self,
+        arguments: ["@\(validFile)", "--bogus"])
+
+      #expect(
+        m.contains("Unknown option '--bogus'"),
+        "Should still include the original error text: got \(m)")
+      // The error came from argv[1] (post the @file at argv[0]).
+      #expect(
+        m.contains("at argv[1]"),
+        "Argv-origin error should be annotated with `at argv[N]` when the gate is active: got \(m)"
+      )
+    }
+  }
+}

--- a/Tests/ArgumentParserEndToEndTests/SourceLocationErrorEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceLocationErrorEndToEndTests.swift
@@ -35,7 +35,7 @@ import Testing
 // MARK: - Test Commands
 
 private struct ErrorCommand: ParsableCommand {
-  static var responseFilePrefix: Character? { "@" }
+  static let configuration = CommandConfiguration(responseFilePrefix: "@")
   @Option var name: String
   @Option var count: Int = 1
   @Flag var verbose = false

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(UnitTests
   HelpGenerationTests+HelpBanner.swift
   NameSpecificationTests.swift
   SerializedCompletionSuites.swift
+  ResponseFileExpanderTests.swift
   SplitArgumentTests.swift
   StringSnakeCaseTests.swift
   StringWrappingTests.swift

--- a/Tests/ArgumentParserUnitTests/InputOriginTests.swift
+++ b/Tests/ArgumentParserUnitTests/InputOriginTests.swift
@@ -17,7 +17,7 @@ import Testing
 
 extension InputOriginTests {
 
-  struct IsDefaultTestData: CustomTestStringConvertible {
+  struct IsDefaultTestData: CustomTestStringConvertible, @unchecked Sendable {
     let id: String
     let elements: [InputOrigin.Element]
     let expectedIsDefaultValue: Bool

--- a/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
+++ b/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
@@ -1,0 +1,853 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParserTestHelpers
+import Foundation
+import Testing
+
+@testable import ArgumentParser
+
+extension ResponseFileExpander {
+  fileprivate init(maxNestingDepth: Int = 32) {
+    self.init(prefix: "@", maxNestingDepth: maxNestingDepth)
+  }
+
+  /// Test helper: tokenize `input` as a single response-file line and
+  /// return the first token's value. Preserves the ergonomics of the
+  /// removed `parseQuotedArgument` for the quote-focused tests below,
+  /// while routing through the actual production entry point.
+  fileprivate mutating func firstToken(
+    _ input: String, from fileURL: URL
+  ) throws -> String {
+    guard let token = try parseFileContent(input, fileURL: fileURL).first
+    else { return "" }
+    return token.value
+  }
+}
+
+@Suite struct ResponseFileExpanderTests {}
+
+// MARK: - ResponseFileExpander Unit Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func expandArgumentsWithNoResponseFiles() throws {
+    var expander = ResponseFileExpander()
+    let input = ["--name", "test", "--count", "42"]
+    let result = try expander.expandArguments(input)
+
+    #expect(
+      result.arguments.map { $0.value } == input,
+      "Arguments without @ prefix should remain unchanged")
+    #expect(
+      !result.hasResponseFile,
+      "hasResponseFile should be false when no @file is present")
+    #expect(
+      result.arguments.map { $0.chain }
+        == [
+          [.argv(index: 0)], [.argv(index: 1)], [.argv(index: 2)],
+          [.argv(index: 3)],
+        ],
+      "Argv-only args should each carry a single-step argv chain")
+  }
+
+  @Test func expandArgumentsWithSingleResponseFile() async throws {
+    try await withTemporaryFile(
+      "simple.txt",
+      content: """
+        --name
+        TestName
+        --count
+        42
+        """
+    ) { responseFile in
+      var expander = ResponseFileExpander()
+      let input = ["@\(responseFile)"]
+      let result = try expander.expandArguments(input)
+
+      #expect(
+        result.arguments.map { $0.value }
+          == ["--name", "TestName", "--count", "42"])
+      #expect(result.hasResponseFile)
+      // Every expanded arg should carry a chain ending in argv[0].
+      #expect(result.arguments.count == 4)
+      for arg in result.arguments {
+        #expect(arg.chain.last == .argv(index: 0))
+      }
+    }
+  }
+
+  @Test func expandArgumentsMixedResponseFileAndRegular() async throws {
+    try await withTemporaryFile(
+      "mixed.txt",
+      content: """
+        --name
+        FromFile
+        """
+    ) { responseFile in
+      var expander = ResponseFileExpander()
+      let input = ["--verbose", "@\(responseFile)", "--count", "100"]
+      let result = try expander.expandArguments(input)
+
+      #expect(
+        result.arguments.map { $0.value }
+          == ["--verbose", "--name", "FromFile", "--count", "100"])
+      #expect(result.hasResponseFile)
+    }
+  }
+}
+
+// MARK: - File Content Parsing Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func parseFileContentOneArgumentPerLine() throws {
+    let content = """
+      --input
+      input.txt
+      --output
+      output.txt
+      --force
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentSpaceSeparated() throws {
+    let content = "--input input.txt --output output.txt --force"
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithQuotes() throws {
+    let content = #"""
+      --input "file with spaces.txt"
+      --output 'another file.txt'
+      --message "hello world"
+      """#
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == [
+          "--input", "file with spaces.txt",
+          "--output", "another file.txt",
+          "--message", "hello world",
+        ])
+  }
+
+  @Test func parseFileContentWithComments() throws {
+    let content = """
+      # This is a comment
+      --input
+      input.txt  # End of line comment
+      # Another comment
+      --output
+      output.txt
+      --force
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithEmptyLines() throws {
+    let content = """
+      --input
+      input.txt
+
+
+      --output
+      output.txt
+
+      --force
+
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithEqualsFormat() throws {
+    let content = """
+      --input=input.txt
+      --output=output.txt
+      --count=42
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input=input.txt", "--output=output.txt", "--count=42"])
+  }
+
+  @Test func parseFileContentWithEscapedAtSign() throws {
+    let content = """
+      --name
+      @@literal
+      --value
+      @@@another
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--name", "@literal", "--value", "@@another"])
+  }
+}
+
+// MARK: - Nested Response File Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func expandNestedResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let innerFile = try dir.createTestFile(
+        "inner.txt",
+        content: """
+          --count
+          42
+          --verbose
+          """)
+
+      let outerFile = try dir.createTestFile(
+        "outer.txt",
+        content: """
+          --name
+          TestName
+          @\(innerFile)
+          """)
+
+      var expander = ResponseFileExpander()
+      let input = ["@\(outerFile)"]
+      let result = try expander.expandArguments(input)
+
+      #expect(
+        result.arguments.map { $0.value }
+          == ["--name", "TestName", "--count", "42", "--verbose"])
+    }
+  }
+
+  @Test func expandDeepNestedResponseFiles() async throws {
+    try await withTemporaryDirectory { dir in
+      let level3 = try dir.createTestFile("level3.txt", content: "--verbose")
+      let level2 = try dir.createTestFile(
+        "level2.txt",
+        content: """
+          --count
+          100
+          @\(level3)
+          """)
+      let level1 = try dir.createTestFile(
+        "level1.txt",
+        content: """
+          --name
+          DeepTest
+          @\(level2)
+          """)
+
+      var expander = ResponseFileExpander()
+      let input = ["@\(level1)"]
+      let result = try expander.expandArguments(input)
+
+      #expect(
+        result.arguments.map { $0.value }
+          == ["--name", "DeepTest", "--count", "100", "--verbose"])
+    }
+  }
+
+  @Test func recursiveResponseFileDetection() async throws {
+    try await withTemporaryDirectory { dir in
+      let file1 = try dir.createTestFile(
+        "recursive1.txt",
+        content: """
+          --name
+          Test
+          @recursive2.txt
+          """)
+
+      _ = try dir.createTestFile(
+        "recursive2.txt",
+        content: """
+          --count
+          10
+          @recursive1.txt
+          """)
+
+      var expander = ResponseFileExpander()
+      let input = ["@\(file1)"]
+
+      #expect(throws: (any Error).self) {
+        try expander.expandArguments(input)
+      }
+
+      do {
+        _ = try expander.expandArguments(input)
+        Issue.record("Expected ResponseFileError")
+      } catch let responseError as ResponseFileExpander.ResponseFileError {
+        if case .recursiveInclude(let url) = responseError {
+          #expect(url.path.contains("recursive"))
+        } else {
+          Issue.record("Expected recursiveInclude error, got \(responseError)")
+        }
+      } catch {
+        Issue.record("Expected ResponseFileError, got \(type(of: error))")
+      }
+    }
+  }
+
+  @Test func selfRecursiveResponseFile() async throws {
+    try await withTemporaryFile(
+      "self.txt",
+      content: """
+        --name
+        Test
+        @self.txt
+        """
+    ) { selfFile in
+      var expander = ResponseFileExpander()
+      let input = ["@\(selfFile)"]
+
+      do {
+        _ = try expander.expandArguments(input)
+        Issue.record("Expected ResponseFileError")
+      } catch let responseError as ResponseFileExpander.ResponseFileError {
+        if case .recursiveInclude = responseError {
+          // Expected behavior
+        } else {
+          Issue.record("Expected recursiveInclude error, got \(responseError)")
+        }
+      } catch {
+        Issue.record("Expected ResponseFileError, got \(type(of: error))")
+      }
+    }
+  }
+}
+
+// MARK: - Error Handling Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func fileNotFoundError() throws {
+    var expander = ResponseFileExpander()
+    let input = ["@/nonexistent/file.txt"]
+
+    do {
+      _ = try expander.expandArguments(input)
+      Issue.record("Expected ResponseFileError")
+    } catch let responseError as ResponseFileExpander.ResponseFileError {
+      if case .fileNotFound = responseError {
+        // Expected behavior
+      } else {
+        Issue.record("Expected fileNotFound error, got \(responseError)")
+      }
+    } catch {
+      Issue.record("Expected ResponseFileError, got \(type(of: error))")
+    }
+  }
+
+  @Test func filePermissionError() async throws {
+    try await withTemporaryFile(
+      "restricted.txt", content: "--name Test"
+    ) { restrictedFile in
+      // Remove read permissions
+      try FileManager.default.setAttributes(
+        [.posixPermissions: 0o000],
+        ofItemAtPath: restrictedFile
+      )
+      defer {
+        // Restore permissions for cleanup
+        try? FileManager.default.setAttributes(
+          [.posixPermissions: 0o644],
+          ofItemAtPath: restrictedFile
+        )
+      }
+
+      // Skip on platforms/environments where POSIX permissions don't
+      // actually restrict reads — most notably root inside a Docker
+      // container (root bypasses mode bits) and Windows (NTFS ACLs, not
+      // POSIX modes, gate access).
+      guard !FileManager.default.isReadableFile(atPath: restrictedFile) else {
+        return
+      }
+
+      var expander = ResponseFileExpander()
+      let input = ["@\(restrictedFile)"]
+
+      do {
+        _ = try expander.expandArguments(input)
+        Issue.record("Expected ResponseFileError")
+      } catch let responseError as ResponseFileExpander.ResponseFileError {
+        if case .readError = responseError {
+          // Expected behavior
+        } else {
+          Issue.record("Expected readError, got \(responseError)")
+        }
+      } catch {
+        Issue.record("Expected ResponseFileError, got \(type(of: error))")
+      }
+    }
+  }
+
+  @Test func emptyResponseFile() async throws {
+    try await withTemporaryFile("empty.txt", content: "") { emptyFile in
+      var expander = ResponseFileExpander()
+      let input = ["@\(emptyFile)", "--name", "test"]
+      let result = try expander.expandArguments(input)
+
+      #expect(result.arguments.map { $0.value } == ["--name", "test"])
+    }
+  }
+
+  @Test func unclosedQuotesTerminateAtEndOfLine() throws {
+    // Matches gcc / LLVM's `TokenizeGNUCommandLine`: an unterminated
+    // quote is implicitly closed at end-of-line, so the content after
+    // the opening quote becomes a single token verbatim.
+    let content = #"""
+      --input "unclosed quote
+      --output 'another unclosed
+      """#
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == [
+          "--input", "unclosed quote",
+          "--output", "another unclosed",
+        ])
+  }
+}
+
+// MARK: - Quote Parsing Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func parseQuotedArguments() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test double quotes
+    let doubleQuoted = #""hello world""#
+    let result1 = try expander.firstToken(doubleQuoted, from: fileUrl)
+    #expect(result1 == "hello world")
+
+    // Test single quotes
+    let singleQuoted = "'hello world'"
+    let result2 = try expander.firstToken(singleQuoted, from: fileUrl)
+    #expect(result2 == "hello world")
+
+    // Test unquoted
+    let unquoted = "hello"
+    let result3 = try expander.firstToken(unquoted, from: fileUrl)
+    #expect(result3 == "hello")
+  }
+
+  @Test func parseQuotedArgumentsWithEscapes() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test escaped quotes within double quotes
+    let escaped = #""hello \"world\"""#
+    let result = try expander.firstToken(escaped, from: fileUrl)
+    #expect(result == #"hello "world""#)
+  }
+
+  @Test func parseQuotedArgumentsWithInternalQuotes() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test single quotes within double quotes
+    let mixed = #""hello 'world'""#
+    let result = try expander.firstToken(mixed, from: fileUrl)
+    #expect(result == "hello 'world'")
+  }
+}
+
+// MARK: - Quote parsing — documented behaviors
+//
+// These tests pin the behaviors promised by
+// `Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md`
+// under "Quoted Arguments". Each test corresponds to one bullet or
+// example in that section.
+
+extension ResponseFileExpanderTests {
+  private var fileUrl: URL {
+    URL(fileURLWithPath: "usedForReporting.txt")
+  }
+
+  // MARK: Escape sequences (double quotes only)
+
+  @Test func doubleQuotesDecodeNewlineEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""line one\nline two""#, from: fileUrl)
+    #expect(result == "line one\nline two")
+  }
+
+  @Test func doubleQuotesDecodeTabEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""col1\tcol2""#, from: fileUrl)
+    #expect(result == "col1\tcol2")
+  }
+
+  @Test func doubleQuotesDecodeCarriageReturnEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""left\rright""#, from: fileUrl)
+    #expect(result == "left\rright")
+  }
+
+  @Test func doubleQuotesDecodeBackslashEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""C:\\Users\\Bob\\file.txt""#, from: fileUrl)
+    #expect(result == #"C:\Users\Bob\file.txt"#)
+  }
+
+  @Test func doubleQuotesPreserveUnknownEscapeVerbatim() throws {
+    // `\d` isn't a recognized escape, so it should survive verbatim
+    // rather than silently dropping the backslash.
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""foo\dbar""#, from: fileUrl)
+    #expect(result == #"foo\dbar"#)
+  }
+
+  // MARK: Single quotes preserve everything literally
+
+  @Test func singleQuotesPreserveBackslashesLiterally() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'foo\d+\.bar'"#, from: fileUrl)
+    #expect(result == #"foo\d+\.bar"#)
+  }
+
+  @Test func singleQuotesPreserveDoubleQuotesLiterally() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'{"key": "value"}'"#, from: fileUrl)
+    #expect(result == #"{"key": "value"}"#)
+  }
+
+  @Test func singleQuotesDoNotProcessEscapeSequences() throws {
+    // The documented pitfall: `\n` inside single quotes is 2 literal
+    // characters, not a newline.
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'a\nb'"#, from: fileUrl)
+    #expect(result == #"a\nb"#)
+  }
+
+  // MARK: Nested quotes
+
+  @Test func doubleQuotesPreserveInternalSingleQuotesUnescaped() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""SELECT * FROM 'users'""#, from: fileUrl)
+    #expect(result == "SELECT * FROM 'users'")
+  }
+
+  @Test func singleQuotesPreserveInternalDoubleQuotesUnescaped() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'the "special" one'"#, from: fileUrl)
+    #expect(result == #"the "special" one"#)
+  }
+
+  // MARK: Whitespace preservation
+
+  @Test func quotedValuesPreserveInternalWhitespace() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title "Grand Total"
+      --tags  '  keep   the   spaces  '
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--title", "Grand Total", "--tags", "  keep   the   spaces  "])
+  }
+
+  // MARK: `@file` inside a quoted argument is literal
+
+  @Test func doubleQuotedAtPrefixIsLiteralValue() throws {
+    // The `@` in `"@admin"` must NOT trigger a response-file lookup —
+    // otherwise this test would throw `.fileNotFound`.
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --username "@admin"
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--username", "@admin"])
+  }
+
+  @Test func singleQuotedAtPrefixIsLiteralValue() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --pattern '@daily'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--pattern", "@daily"])
+  }
+
+  // MARK: Mixed-quote value round-tripped through parseFileContent
+
+  @Test func doubleQuotedJSONValueRoundTripsThroughParseFileContent() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --json '{"key": "value"}'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--json", #"{"key": "value"}"#])
+  }
+
+  // MARK: Mismatched-style quotes are implicitly terminated
+
+  @Test func mismatchedQuoteStyleOpensDoubleClosesSingle() throws {
+    // Opening `"` and closing `'` is an unterminated double-quote as
+    // far as the parser is concerned — the trailing `'` is literal
+    // content inside the open double-quoted segment, and the whole
+    // thing implicitly terminates at end-of-line.
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title "unterminated'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(result.map { $0.value } == ["--title", "unterminated'"])
+  }
+
+  @Test func mismatchedQuoteStyleOpensSingleClosesDouble() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title 'unterminated"
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(result.map { $0.value } == ["--title", #"unterminated""#])
+  }
+}
+
+// MARK: - Comment Stripping Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func stripComments() throws {
+    let expander = ResponseFileExpander()
+
+    // Test full line comment
+    #expect(expander.stripComment("# This is a comment") == "")
+
+    // Test end of line comment
+    #expect(expander.stripComment("--name test # comment") == "--name test")
+
+    // Test no comment
+    #expect(expander.stripComment("--name test") == "--name test")
+
+    // Test comment within quotes (should not be stripped)
+    #expect(
+      expander.stripComment(#"--message "hello # world""#)
+        == #"--message "hello # world""#)
+  }
+
+  @Test func stripCommentsWithQuotedContent() throws {
+    let expander = ResponseFileExpander()
+
+    // Comments inside quotes should be preserved
+    let quotedComment =
+      #"--message "hello # this is not a comment" # but this is"#
+    let result = expander.stripComment(quotedComment)
+    #expect(result == #"--message "hello # this is not a comment""#)
+  }
+}
+
+// MARK: - Response File Detection Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func isResponseFileArgument() throws {
+    let expander = ResponseFileExpander()
+
+    #expect(expander.isResponseFileArgument("@file.txt"))
+    #expect(expander.isResponseFileArgument("@/path/to/file.txt"))
+    #expect(expander.isResponseFileArgument("@file with spaces.txt"))
+
+    #expect(!expander.isResponseFileArgument("--option"))
+    #expect(!expander.isResponseFileArgument("value"))
+    // Double @ is literal
+    #expect(!expander.isResponseFileArgument("@@literal"))
+    #expect(!expander.isResponseFileArgument(""))
+    // Just @ without filename
+    #expect(!expander.isResponseFileArgument("@"))
+  }
+
+  @Test func extractResponseFileName() throws {
+    let expander = ResponseFileExpander()
+
+    #expect(expander.extractResponseFileName("@file.txt") == "file.txt")
+    #expect(
+      expander.extractResponseFileName("@/path/to/file.txt")
+        == "/path/to/file.txt")
+    #expect(
+      expander.extractResponseFileName("@file with spaces.txt")
+        == "file with spaces.txt")
+
+    #expect(expander.extractResponseFileName("--option") == nil)
+    #expect(expander.extractResponseFileName("@@literal") == nil)
+    #expect(expander.extractResponseFileName("@") == nil)
+  }
+}
+
+// MARK: - Configuration Tests (Future)
+
+extension ResponseFileExpanderTests {
+
+  @Test func customPrefix() throws {
+    // Test ability to use custom prefixes like +file or -file
+    // This will be implemented as a configuration option
+
+    let expander = ResponseFileExpander(prefix: "+")
+
+    #expect(expander.isResponseFileArgument("+file.txt"))
+    #expect(!expander.isResponseFileArgument("@file.txt"))
+  }
+
+  @Test func maxNestingDepth() async throws {
+    // Test that we can limit nesting depth to prevent deep recursion
+    // This will be implemented as a configuration option
+
+    try await withTemporaryDirectory { dir in
+      var expander = ResponseFileExpander(maxNestingDepth: 2)
+
+      // Create deeply nested files that exceed the limit
+      let level3 = try dir.createTestFile("deep3.txt", content: "--verbose")
+      let level2 = try dir.createTestFile("deep2.txt", content: "@\(level3)")
+      let level1 = try dir.createTestFile("deep1.txt", content: "@\(level2)")
+      let level0 = try dir.createTestFile("deep0.txt", content: "@\(level1)")
+
+      let input = ["@\(level0)"]
+
+      do {
+        _ = try expander.expandArguments(input)
+        Issue.record("Expected ResponseFileError")
+      } catch let responseError as ResponseFileExpander.ResponseFileError {
+        if case .maxNestingDepthExceeded = responseError {
+          // Expected behavior
+        } else {
+          Issue.record("Expected maxNestingDepthExceeded error")
+        }
+      } catch {
+        Issue.record("Expected ResponseFileError")
+      }
+    }
+  }
+}
+
+// MARK: - Performance Tests
+
+extension ResponseFileExpanderTests {
+
+  @Test func largeResponseFile() async throws {
+    // Test performance with a large number of arguments
+    var content = ""
+    for i in 1...10000 {
+      content += "arg\(i)\n"
+    }
+
+    try await withTemporaryFile("large.txt", content: content) { largeFile in
+      var expander = ResponseFileExpander()
+      let input = ["@\(largeFile)"]
+
+      let clock: ContinuousClock = ContinuousClock()
+      let startTime = clock.now
+      let result = try expander.expandArguments(input)
+      let endTime = clock.now
+
+      #expect(result.arguments.count == 10000)
+      #expect(
+        endTime - startTime
+          < Duration(secondsComponent: 1, attosecondsComponent: 0),
+        "Should process large file within 1 second")
+    }
+  }
+
+  @Test func manySmallResponseFiles() async throws {
+    // Test performance with many small response files
+    try await withTemporaryDirectory { dir in
+      var files: [String] = []
+
+      for i in 1...100 {
+        let file = try dir.createTestFile(
+          "small\(i).txt", content: "--arg\(i) value\(i)")
+        files.append("@\(file)")
+      }
+
+      var expander = ResponseFileExpander()
+
+      let clock: ContinuousClock = ContinuousClock()
+      let startTime = clock.now
+      let result = try expander.expandArguments(files)
+      let endTime = clock.now
+
+      #expect(result.arguments.count == 200)  // 100 files * 2 args each
+      #expect(
+        endTime - startTime
+          < Duration(secondsComponent: 1, attosecondsComponent: 0),
+        "Should process many files within 1 second"
+      )
+    }
+  }
+}

--- a/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
+++ b/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
@@ -21,9 +21,11 @@ extension ResponseFileExpander {
   }
 
   /// Test helper: tokenize `input` as a single response-file line and
-  /// return the first token's value. Preserves the ergonomics of the
-  /// removed `parseQuotedArgument` for the quote-focused tests below,
-  /// while routing through the actual production entry point.
+  /// return the first token's value.
+  ///
+  /// Preserves the ergonomics of the removed `parseQuotedArgument` for the
+  /// quote-focused tests below, while routing through the actual production
+  /// entry point.
   fileprivate mutating func firstToken(
     _ input: String, from fileURL: URL
   ) throws -> String {
@@ -438,10 +440,11 @@ extension ResponseFileExpanderTests {
     }
   }
 
-  @Test func unclosedQuotesTerminateAtEndOfLine() throws {
-    // Matches gcc / LLVM's `TokenizeGNUCommandLine`: an unterminated
-    // quote is implicitly closed at end-of-line, so the content after
-    // the opening quote becomes a single token verbatim.
+  @Test func unclosedQuotesTerminateAtEndOfFile() throws {
+    // Once a token opens a quoted segment, it keeps consuming input —
+    // including intervening newlines and any subsequent characters —
+    // until it either encounters a matching quote or reaches EOF, at
+    // which point the accumulated content becomes a single token.
     let content = #"""
       --input "unclosed quote
       --output 'another unclosed
@@ -454,8 +457,8 @@ extension ResponseFileExpanderTests {
     #expect(
       result.map { $0.value }
         == [
-          "--input", "unclosed quote",
-          "--output", "another unclosed",
+          "--input",
+          "unclosed quote\n--output 'another unclosed",
         ])
   }
 }

--- a/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
+++ b/Tests/ArgumentParserUnitTests/ResponseFileExpanderTests.swift
@@ -19,20 +19,6 @@ extension ResponseFileExpander {
   fileprivate init(maxNestingDepth: Int = 32) {
     self.init(prefix: "@", maxNestingDepth: maxNestingDepth)
   }
-
-  /// Test helper: tokenize `input` as a single response-file line and
-  /// return the first token's value.
-  ///
-  /// Preserves the ergonomics of the removed `parseQuotedArgument` for the
-  /// quote-focused tests below, while routing through the actual production
-  /// entry point.
-  fileprivate mutating func firstToken(
-    _ input: String, from fileURL: URL
-  ) throws -> String {
-    guard let token = try parseFileContent(input, fileURL: fileURL).first
-    else { return "" }
-    return token.value
-  }
 }
 
 @Suite struct ResponseFileExpanderTests {}
@@ -105,135 +91,170 @@ extension ResponseFileExpanderTests {
       #expect(result.hasResponseFile)
     }
   }
-}
 
-// MARK: - File Content Parsing Tests
+  @Test func expandArgumentsFileArgsLandAtFilesArgvPosition() async throws {
+    // Guard against a regression where response-file arguments would be
+    // appended after *all* command-line arguments regardless of where
+    // the `@file` reference appeared in the input. In-place expansion
+    // requires that file-origin arguments occupy the slot vacated by
+    // the `@file` token itself — anything else would break the
+    // downstream "last wins" semantics the parser depends on.
+    try await withTemporaryFile(
+      "middle.txt",
+      content: """
+        FROM_FILE_A
+        FROM_FILE_B
+        """
+    ) { responseFile in
+      var expander = ResponseFileExpander()
+      let input = ["cli-before", "@\(responseFile)", "cli-after"]
+      let result = try expander.expandArguments(input)
 
-extension ResponseFileExpanderTests {
-
-  @Test func parseFileContentOneArgumentPerLine() throws {
-    let content = """
-      --input
-      input.txt
-      --output
-      output.txt
-      --force
-      """
-
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+      #expect(
+        result.arguments.map { $0.value }
+          == ["cli-before", "FROM_FILE_A", "FROM_FILE_B", "cli-after"],
+        "File-origin args must land between the preceding and following argv tokens, not at the tail"
+      )
+    }
   }
 
-  @Test func parseFileContentSpaceSeparated() throws {
-    let content = "--input input.txt --output output.txt --force"
+  @Test func expandArgumentsFileAtEndDoesNotReorderPrecedingArgs()
+    async throws
+  {
+    // The "last wins" behaviour at parse time relies on file args
+    // being placed *after* any argv tokens that preceded the `@file`
+    // reference.
+    try await withTemporaryFile(
+      "tail.txt",
+      content: """
+        FROM_FILE
+        """
+    ) { responseFile in
+      var expander = ResponseFileExpander()
+      let input = ["cli-1", "cli-2", "@\(responseFile)"]
+      let result = try expander.expandArguments(input)
 
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+      #expect(
+        result.arguments.map { $0.value }
+          == ["cli-1", "cli-2", "FROM_FILE"])
+    }
   }
 
-  @Test func parseFileContentWithQuotes() throws {
-    let content = #"""
-      --input "file with spaces.txt"
-      --output 'another file.txt'
-      --message "hello world"
-      """#
+  @Test func expandArgumentsInterleavedResponseFilesPreserveArgvOrder()
+    async throws
+  {
+    // Two `@file` references separated by argv tokens: each file's
+    // contents must be spliced in-place, and the surrounding argv
+    // tokens must retain their relative order.
+    try await withTemporaryDirectory { dir in
+      let file1 = try dir.createTestFile(
+        "f1.txt",
+        content: """
+          F1_A
+          F1_B
+          """)
+      let file2 = try dir.createTestFile(
+        "f2.txt",
+        content: """
+          F2_A
+          """)
 
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
+      var expander = ResponseFileExpander()
+      let input = ["head", "@\(file1)", "middle", "@\(file2)", "tail"]
+      let result = try expander.expandArguments(input)
 
-    #expect(
-      result.map { $0.value }
-        == [
-          "--input", "file with spaces.txt",
-          "--output", "another file.txt",
-          "--message", "hello world",
-        ])
+      #expect(
+        result.arguments.map { $0.value }
+          == ["head", "F1_A", "F1_B", "middle", "F2_A", "tail"])
+
+      // Each expanded arg's outermost chain step should point at the
+      // argv index of the token that produced it. This is what lets
+      // error rendering annotate response-file arguments with the
+      // correct `at argv[N]` frame.
+      let outermostChain = result.arguments.map { $0.chain.last }
+      #expect(
+        outermostChain
+          == [
+            .argv(index: 0),  // "head"
+            .argv(index: 1),  // "@f1.txt"
+            .argv(index: 1),  // "@f1.txt"
+            .argv(index: 2),  // "middle"
+            .argv(index: 3),  // "@f2.txt"
+            .argv(index: 4),  // "tail"
+          ])
+    }
   }
 
-  @Test func parseFileContentWithComments() throws {
-    let content = """
-      # This is a comment
-      --input
-      input.txt  # End of line comment
-      # Another comment
-      --output
-      output.txt
-      --force
-      """
+  @Test func expandArgumentsNestedResponseFilePreservesInPlaceOrder()
+    async throws
+  {
+    // Nested response files: `outer.txt` contains an inline argument
+    // before and after an `@inner.txt` reference. The nested file's
+    // tokens must be spliced in-place *within* the outer file's
+    // token stream, so the surrounding outer-file tokens keep their
+    // relative order too.
+    try await withTemporaryDirectory { dir in
+      let innerPath = try dir.createTestFile(
+        "inner.txt",
+        content: """
+          INNER_A
+          INNER_B
+          """)
+      let outerPath = try dir.createTestFile(
+        "outer.txt",
+        content: """
+          OUTER_PRE
+          @inner.txt
+          OUTER_POST
+          """)
 
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
+      var expander = ResponseFileExpander()
+      let input = ["cli-before", "@\(outerPath)", "cli-after"]
+      let result = try expander.expandArguments(input)
 
-    #expect(
-      result.map { $0.value }
-        == ["--input", "input.txt", "--output", "output.txt", "--force"])
-  }
+      #expect(
+        result.arguments.map { $0.value }
+          == [
+            "cli-before",
+            "OUTER_PRE",
+            "INNER_A",
+            "INNER_B",
+            "OUTER_POST",
+            "cli-after",
+          ])
 
-  @Test func parseFileContentWithEmptyLines() throws {
-    let content = """
-      --input
-      input.txt
+      // Every expanded token's chain must terminate at the argv index
+      // of the top-level `@outer.txt` reference (or the argv index of
+      // the token itself, for CLI-origin tokens).
+      #expect(
+        result.arguments.map { $0.chain.last }
+          == [
+            .argv(index: 0),  // "cli-before"
+            .argv(index: 1),  // "@outer.txt"
+            .argv(index: 1),  // "@outer.txt" (via inner)
+            .argv(index: 1),  // "@outer.txt" (via inner)
+            .argv(index: 1),  // "@outer.txt"
+            .argv(index: 2),  // "cli-after"
+          ])
 
+      // Chain depths: CLI tokens carry a single argv step; outer-file
+      // tokens carry [file(outer), argv]; inner-file tokens carry the
+      // full three-step chain [file(inner), file(outer), argv].
+      #expect(result.arguments.map { $0.chain.count } == [1, 2, 3, 3, 2, 1])
 
-      --output
-      output.txt
+      // Innermost step of each expanded token identifies the source
+      // location — verify line numbers propagate correctly through
+      // the include chain.
+      #expect(result.arguments[1].chain[0] == .file(path: outerPath, line: 1))
+      #expect(result.arguments[2].chain[0] == .file(path: innerPath, line: 1))
+      #expect(result.arguments[3].chain[0] == .file(path: innerPath, line: 2))
+      #expect(result.arguments[4].chain[0] == .file(path: outerPath, line: 3))
 
-      --force
-
-      """
-
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == ["--input", "input.txt", "--output", "output.txt", "--force"])
-  }
-
-  @Test func parseFileContentWithEqualsFormat() throws {
-    let content = """
-      --input=input.txt
-      --output=output.txt
-      --count=42
-      """
-
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == ["--input=input.txt", "--output=output.txt", "--count=42"])
-  }
-
-  @Test func parseFileContentWithEscapedAtSign() throws {
-    let content = """
-      --name
-      @@literal
-      --value
-      @@@another
-      """
-
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == ["--name", "@literal", "--value", "@@another"])
+      // Inner-file tokens include the outer file's `@inner.txt`
+      // reference line (2) as their middle chain step.
+      #expect(result.arguments[2].chain[1] == .file(path: outerPath, line: 2))
+      #expect(result.arguments[3].chain[1] == .file(path: outerPath, line: 2))
+    }
   }
 }
 
@@ -438,282 +459,6 @@ extension ResponseFileExpanderTests {
 
       #expect(result.arguments.map { $0.value } == ["--name", "test"])
     }
-  }
-
-  @Test func unclosedQuotesTerminateAtEndOfFile() throws {
-    // Once a token opens a quoted segment, it keeps consuming input —
-    // including intervening newlines and any subsequent characters —
-    // until it either encounters a matching quote or reaches EOF, at
-    // which point the accumulated content becomes a single token.
-    let content = #"""
-      --input "unclosed quote
-      --output 'another unclosed
-      """#
-
-    var expander = ResponseFileExpander()
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-
-    #expect(
-      result.map { $0.value }
-        == [
-          "--input",
-          "unclosed quote\n--output 'another unclosed",
-        ])
-  }
-}
-
-// MARK: - Quote Parsing Tests
-
-extension ResponseFileExpanderTests {
-
-  @Test func parseQuotedArguments() throws {
-    var expander = ResponseFileExpander()
-    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
-
-    // Test double quotes
-    let doubleQuoted = #""hello world""#
-    let result1 = try expander.firstToken(doubleQuoted, from: fileUrl)
-    #expect(result1 == "hello world")
-
-    // Test single quotes
-    let singleQuoted = "'hello world'"
-    let result2 = try expander.firstToken(singleQuoted, from: fileUrl)
-    #expect(result2 == "hello world")
-
-    // Test unquoted
-    let unquoted = "hello"
-    let result3 = try expander.firstToken(unquoted, from: fileUrl)
-    #expect(result3 == "hello")
-  }
-
-  @Test func parseQuotedArgumentsWithEscapes() throws {
-    var expander = ResponseFileExpander()
-    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
-
-    // Test escaped quotes within double quotes
-    let escaped = #""hello \"world\"""#
-    let result = try expander.firstToken(escaped, from: fileUrl)
-    #expect(result == #"hello "world""#)
-  }
-
-  @Test func parseQuotedArgumentsWithInternalQuotes() throws {
-    var expander = ResponseFileExpander()
-    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
-
-    // Test single quotes within double quotes
-    let mixed = #""hello 'world'""#
-    let result = try expander.firstToken(mixed, from: fileUrl)
-    #expect(result == "hello 'world'")
-  }
-}
-
-// MARK: - Quote parsing — documented behaviors
-//
-// These tests pin the behaviors promised by
-// `Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md`
-// under "Quoted Arguments". Each test corresponds to one bullet or
-// example in that section.
-
-extension ResponseFileExpanderTests {
-  private var fileUrl: URL {
-    URL(fileURLWithPath: "usedForReporting.txt")
-  }
-
-  // MARK: Escape sequences (double quotes only)
-
-  @Test func doubleQuotesDecodeNewlineEscape() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""line one\nline two""#, from: fileUrl)
-    #expect(result == "line one\nline two")
-  }
-
-  @Test func doubleQuotesDecodeTabEscape() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""col1\tcol2""#, from: fileUrl)
-    #expect(result == "col1\tcol2")
-  }
-
-  @Test func doubleQuotesDecodeCarriageReturnEscape() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""left\rright""#, from: fileUrl)
-    #expect(result == "left\rright")
-  }
-
-  @Test func doubleQuotesDecodeBackslashEscape() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""C:\\Users\\Bob\\file.txt""#, from: fileUrl)
-    #expect(result == #"C:\Users\Bob\file.txt"#)
-  }
-
-  @Test func doubleQuotesPreserveUnknownEscapeVerbatim() throws {
-    // `\d` isn't a recognized escape, so it should survive verbatim
-    // rather than silently dropping the backslash.
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""foo\dbar""#, from: fileUrl)
-    #expect(result == #"foo\dbar"#)
-  }
-
-  // MARK: Single quotes preserve everything literally
-
-  @Test func singleQuotesPreserveBackslashesLiterally() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #"'foo\d+\.bar'"#, from: fileUrl)
-    #expect(result == #"foo\d+\.bar"#)
-  }
-
-  @Test func singleQuotesPreserveDoubleQuotesLiterally() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #"'{"key": "value"}'"#, from: fileUrl)
-    #expect(result == #"{"key": "value"}"#)
-  }
-
-  @Test func singleQuotesDoNotProcessEscapeSequences() throws {
-    // The documented pitfall: `\n` inside single quotes is 2 literal
-    // characters, not a newline.
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #"'a\nb'"#, from: fileUrl)
-    #expect(result == #"a\nb"#)
-  }
-
-  // MARK: Nested quotes
-
-  @Test func doubleQuotesPreserveInternalSingleQuotesUnescaped() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #""SELECT * FROM 'users'""#, from: fileUrl)
-    #expect(result == "SELECT * FROM 'users'")
-  }
-
-  @Test func singleQuotesPreserveInternalDoubleQuotesUnescaped() throws {
-    var expander = ResponseFileExpander()
-    let result = try expander.firstToken(
-      #"'the "special" one'"#, from: fileUrl)
-    #expect(result == #"the "special" one"#)
-  }
-
-  // MARK: Whitespace preservation
-
-  @Test func quotedValuesPreserveInternalWhitespace() throws {
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --title "Grand Total"
-      --tags  '  keep   the   spaces  '
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(
-      result.map { $0.value }
-        == ["--title", "Grand Total", "--tags", "  keep   the   spaces  "])
-  }
-
-  // MARK: `@file` inside a quoted argument is literal
-
-  @Test func doubleQuotedAtPrefixIsLiteralValue() throws {
-    // The `@` in `"@admin"` must NOT trigger a response-file lookup —
-    // otherwise this test would throw `.fileNotFound`.
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --username "@admin"
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(
-      result.map { $0.value }
-        == ["--username", "@admin"])
-  }
-
-  @Test func singleQuotedAtPrefixIsLiteralValue() throws {
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --pattern '@daily'
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(
-      result.map { $0.value }
-        == ["--pattern", "@daily"])
-  }
-
-  // MARK: Mixed-quote value round-tripped through parseFileContent
-
-  @Test func doubleQuotedJSONValueRoundTripsThroughParseFileContent() throws {
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --json '{"key": "value"}'
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(
-      result.map { $0.value }
-        == ["--json", #"{"key": "value"}"#])
-  }
-
-  // MARK: Mismatched-style quotes are implicitly terminated
-
-  @Test func mismatchedQuoteStyleOpensDoubleClosesSingle() throws {
-    // Opening `"` and closing `'` is an unterminated double-quote as
-    // far as the parser is concerned — the trailing `'` is literal
-    // content inside the open double-quoted segment, and the whole
-    // thing implicitly terminates at end-of-line.
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --title "unterminated'
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(result.map { $0.value } == ["--title", "unterminated'"])
-  }
-
-  @Test func mismatchedQuoteStyleOpensSingleClosesDouble() throws {
-    var expander = ResponseFileExpander()
-    let content = #"""
-      --title 'unterminated"
-      """#
-    let result = try expander.parseFileContent(
-      content, fileURL: URL(fileURLWithPath: "test.txt"))
-    #expect(result.map { $0.value } == ["--title", #"unterminated""#])
-  }
-}
-
-// MARK: - Comment Stripping Tests
-
-extension ResponseFileExpanderTests {
-
-  @Test func stripComments() throws {
-    let expander = ResponseFileExpander()
-
-    // Test full line comment
-    #expect(expander.stripComment("# This is a comment") == "")
-
-    // Test end of line comment
-    #expect(expander.stripComment("--name test # comment") == "--name test")
-
-    // Test no comment
-    #expect(expander.stripComment("--name test") == "--name test")
-
-    // Test comment within quotes (should not be stripped)
-    #expect(
-      expander.stripComment(#"--message "hello # world""#)
-        == #"--message "hello # world""#)
-  }
-
-  @Test func stripCommentsWithQuotedContent() throws {
-    let expander = ResponseFileExpander()
-
-    // Comments inside quotes should be preserved
-    let quotedComment =
-      #"--message "hello # this is not a comment" # but this is"#
-    let result = expander.stripComment(quotedComment)
-    #expect(result == #"--message "hello # this is not a comment""#)
   }
 }
 

--- a/Tests/ArgumentParserUnitTests/ResponseFileTokenizationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ResponseFileTokenizationTests.swift
@@ -1,0 +1,461 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ArgumentParser
+
+// Unit-level tests for the response-file tokenizer: how raw file
+// content is split into tokens, how quoted segments behave, how
+// comments and escapes are handled. These tests exercise
+// `parseFileContent`/`tokenizeContent` directly on
+// `ResponseFileExpander`, without a `ParsableCommand` round trip.
+//
+// End-to-end tokenization behavior — the same rules observed through
+// `expectParse` on a real command — lives in
+// `Tests/ArgumentParserEndToEndTests/ResponseFileEndToEndTests.swift`.
+
+extension ResponseFileExpander {
+  /// Convenience init defaulting the prefix to `"@"`.
+  ///
+  /// Duplicated from `ResponseFileExpanderTests.swift` so both files
+  /// can build expanders without repeating the prefix argument.
+  fileprivate init(maxNestingDepth: Int = 32) {
+    self.init(prefix: "@", maxNestingDepth: maxNestingDepth)
+  }
+
+  /// Test helper: tokenize `input` as a single response-file line and
+  /// return the first token's value.
+  ///
+  /// Preserves the ergonomics of the removed `parseQuotedArgument` for the
+  /// quote-focused tests below, while routing through the actual production
+  /// entry point.
+  fileprivate mutating func firstToken(
+    _ input: String, from fileURL: URL
+  ) throws -> String {
+    guard let token = try parseFileContent(input, fileURL: fileURL).first
+    else { return "" }
+    return token.value
+  }
+}
+
+@Suite struct ResponseFileTokenizationTests {
+  @Suite struct FileContentParsingTests {}
+  @Suite struct QuoteParsingTests {}
+  @Suite struct CommentStrippingTests {}
+}
+
+// MARK: - File Content Parsing Tests
+
+extension ResponseFileTokenizationTests.FileContentParsingTests {
+
+  @Test func parseFileContentOneArgumentPerLine() throws {
+    let content = """
+      --input
+      input.txt
+      --output
+      output.txt
+      --force
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentSpaceSeparated() throws {
+    let content = "--input input.txt --output output.txt --force"
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithQuotes() throws {
+    let content = #"""
+      --input "file with spaces.txt"
+      --output 'another file.txt'
+      --message "hello world"
+      """#
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == [
+          "--input", "file with spaces.txt",
+          "--output", "another file.txt",
+          "--message", "hello world",
+        ])
+  }
+
+  @Test func parseFileContentWithComments() throws {
+    let content = """
+      # This is a comment
+      --input
+      input.txt  # End of line comment
+      # Another comment
+      --output
+      output.txt
+      --force
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithEmptyLines() throws {
+    let content = """
+      --input
+      input.txt
+
+
+      --output
+      output.txt
+
+      --force
+
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input", "input.txt", "--output", "output.txt", "--force"])
+  }
+
+  @Test func parseFileContentWithEqualsFormat() throws {
+    let content = """
+      --input=input.txt
+      --output=output.txt
+      --count=42
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--input=input.txt", "--output=output.txt", "--count=42"])
+  }
+
+  @Test func parseFileContentWithEscapedAtSign() throws {
+    let content = """
+      --name
+      @@literal
+      --value
+      @@@another
+      """
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == ["--name", "@literal", "--value", "@@another"])
+  }
+
+  @Test func unclosedQuotesTerminateAtEndOfFile() throws {
+    // Once a token opens a quoted segment, it keeps consuming input —
+    // including intervening newlines and any subsequent characters —
+    // until it either encounters a matching quote or reaches EOF, at
+    // which point the accumulated content becomes a single token.
+    let content = #"""
+      --input "unclosed quote
+      --output 'another unclosed
+      """#
+
+    var expander = ResponseFileExpander()
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+
+    #expect(
+      result.map { $0.value }
+        == [
+          "--input",
+          "unclosed quote\n--output 'another unclosed",
+        ])
+  }
+}
+
+// MARK: - Quote Parsing Tests
+
+extension ResponseFileTokenizationTests.QuoteParsingTests {
+
+  @Test func parseQuotedArguments() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test double quotes
+    let doubleQuoted = #""hello world""#
+    let result1 = try expander.firstToken(doubleQuoted, from: fileUrl)
+    #expect(result1 == "hello world")
+
+    // Test single quotes
+    let singleQuoted = "'hello world'"
+    let result2 = try expander.firstToken(singleQuoted, from: fileUrl)
+    #expect(result2 == "hello world")
+
+    // Test unquoted
+    let unquoted = "hello"
+    let result3 = try expander.firstToken(unquoted, from: fileUrl)
+    #expect(result3 == "hello")
+  }
+
+  @Test func parseQuotedArgumentsWithEscapes() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test escaped quotes within double quotes
+    let escaped = #""hello \"world\"""#
+    let result = try expander.firstToken(escaped, from: fileUrl)
+    #expect(result == #"hello "world""#)
+  }
+
+  @Test func parseQuotedArgumentsWithInternalQuotes() throws {
+    var expander = ResponseFileExpander()
+    let fileUrl = URL(fileURLWithPath: "usedForReporting.txt")
+
+    // Test single quotes within double quotes
+    let mixed = #""hello 'world'""#
+    let result = try expander.firstToken(mixed, from: fileUrl)
+    #expect(result == "hello 'world'")
+  }
+}
+
+// MARK: - Quote parsing — documented behaviors
+//
+// These tests pin the behaviors promised by
+// `Sources/ArgumentParser/Documentation.docc/Articles/ResponseFiles.md`
+// under "Quoted Arguments". Each test corresponds to one bullet or
+// example in that section.
+
+extension ResponseFileTokenizationTests.QuoteParsingTests {
+  private var fileUrl: URL {
+    URL(fileURLWithPath: "usedForReporting.txt")
+  }
+
+  // MARK: Escape sequences (double quotes only)
+
+  @Test func doubleQuotesDecodeNewlineEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""line one\nline two""#, from: fileUrl)
+    #expect(result == "line one\nline two")
+  }
+
+  @Test func doubleQuotesDecodeTabEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""col1\tcol2""#, from: fileUrl)
+    #expect(result == "col1\tcol2")
+  }
+
+  @Test func doubleQuotesDecodeCarriageReturnEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""left\rright""#, from: fileUrl)
+    #expect(result == "left\rright")
+  }
+
+  @Test func doubleQuotesDecodeBackslashEscape() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""C:\\Users\\Bob\\file.txt""#, from: fileUrl)
+    #expect(result == #"C:\Users\Bob\file.txt"#)
+  }
+
+  @Test func doubleQuotesPreserveUnknownEscapeVerbatim() throws {
+    // `\d` isn't a recognized escape, so it should survive verbatim
+    // rather than silently dropping the backslash.
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""foo\dbar""#, from: fileUrl)
+    #expect(result == #"foo\dbar"#)
+  }
+
+  // MARK: Single quotes preserve everything literally
+
+  @Test func singleQuotesPreserveBackslashesLiterally() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'foo\d+\.bar'"#, from: fileUrl)
+    #expect(result == #"foo\d+\.bar"#)
+  }
+
+  @Test func singleQuotesPreserveDoubleQuotesLiterally() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'{"key": "value"}'"#, from: fileUrl)
+    #expect(result == #"{"key": "value"}"#)
+  }
+
+  @Test func singleQuotesDoNotProcessEscapeSequences() throws {
+    // The documented pitfall: `\n` inside single quotes is 2 literal
+    // characters, not a newline.
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'a\nb'"#, from: fileUrl)
+    #expect(result == #"a\nb"#)
+  }
+
+  // MARK: Nested quotes
+
+  @Test func doubleQuotesPreserveInternalSingleQuotesUnescaped() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #""SELECT * FROM 'users'""#, from: fileUrl)
+    #expect(result == "SELECT * FROM 'users'")
+  }
+
+  @Test func singleQuotesPreserveInternalDoubleQuotesUnescaped() throws {
+    var expander = ResponseFileExpander()
+    let result = try expander.firstToken(
+      #"'the "special" one'"#, from: fileUrl)
+    #expect(result == #"the "special" one"#)
+  }
+
+  // MARK: Whitespace preservation
+
+  @Test func quotedValuesPreserveInternalWhitespace() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title "Grand Total"
+      --tags  '  keep   the   spaces  '
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--title", "Grand Total", "--tags", "  keep   the   spaces  "])
+  }
+
+  // MARK: `@file` inside a quoted argument is literal
+
+  @Test func doubleQuotedAtPrefixIsLiteralValue() throws {
+    // The `@` in `"@admin"` must NOT trigger a response-file lookup —
+    // otherwise this test would throw `.fileNotFound`.
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --username "@admin"
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--username", "@admin"])
+  }
+
+  @Test func singleQuotedAtPrefixIsLiteralValue() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --pattern '@daily'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--pattern", "@daily"])
+  }
+
+  // MARK: Mixed-quote value round-tripped through parseFileContent
+
+  @Test func doubleQuotedJSONValueRoundTripsThroughParseFileContent() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --json '{"key": "value"}'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(
+      result.map { $0.value }
+        == ["--json", #"{"key": "value"}"#])
+  }
+
+  // MARK: Mismatched-style quotes are implicitly terminated
+
+  @Test func mismatchedQuoteStyleOpensDoubleClosesSingle() throws {
+    // Opening `"` and closing `'` is an unterminated double-quote as
+    // far as the parser is concerned — the trailing `'` is literal
+    // content inside the open double-quoted segment, and the whole
+    // thing implicitly terminates at end-of-line.
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title "unterminated'
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(result.map { $0.value } == ["--title", "unterminated'"])
+  }
+
+  @Test func mismatchedQuoteStyleOpensSingleClosesDouble() throws {
+    var expander = ResponseFileExpander()
+    let content = #"""
+      --title 'unterminated"
+      """#
+    let result = try expander.parseFileContent(
+      content, fileURL: URL(fileURLWithPath: "test.txt"))
+    #expect(result.map { $0.value } == ["--title", #"unterminated""#])
+  }
+}
+
+// MARK: - Comment Stripping Tests
+
+extension ResponseFileTokenizationTests.CommentStrippingTests {
+
+  @Test func stripComments() throws {
+    let expander = ResponseFileExpander()
+
+    // Test full line comment
+    #expect(expander.stripComment("# This is a comment") == "")
+
+    // Test end of line comment
+    #expect(expander.stripComment("--name test # comment") == "--name test")
+
+    // Test no comment
+    #expect(expander.stripComment("--name test") == "--name test")
+
+    // Test comment within quotes (should not be stripped)
+    #expect(
+      expander.stripComment(#"--message "hello # world""#)
+        == #"--message "hello # world""#)
+  }
+
+  @Test func stripCommentsWithQuotedContent() throws {
+    let expander = ResponseFileExpander()
+
+    // Comments inside quotes should be preserved
+    let quotedComment =
+      #"--message "hello # this is not a comment" # but this is"#
+    let result = expander.stripComment(quotedComment)
+    #expect(result == #"--message "hello # this is not a comment""#)
+  }
+}

--- a/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
@@ -735,3 +735,9 @@ extension SplitArgumentTests {
     #expect(valueB.1 == "bar")
   }
 }
+
+extension SplitArguments {
+  init(arguments: [String]) throws {
+    try self.init(arguments: arguments, responseFilePrefix: "@")
+  }
+}

--- a/Tests/ArgumentParserUnitTests/StringTrimmedTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringTrimmedTests.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ArgumentParser
+
+@Suite
+struct StringTrimmedTests {
+  @Test(
+    arguments: [
+      ("", ""),
+      ("hello", "hello"),
+      ("  hello", "hello"),
+      ("hello  ", "hello"),
+      ("  hello  ", "hello"),
+      ("\thello\t", "hello"),
+      ("\nhello\n", "hello"),
+      ("\r\n hello \r\n", "hello"),
+      (" \t\n hello \n\t ", "hello"),
+      ("   ", ""),
+      ("\t\n\r ", ""),
+      ("  hello world  ", "hello world"),
+      ("  a  b  ", "a  b"),
+      ("hello world", "hello world"),
+    ] as [(String, String)]
+  )
+  func trimmed(input: String, expected: String) {
+    #expect(input.trimmed() == expected)
+  }
+}


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed

-->

Add native response file support in Swift Argument Parser for all `ParsableCommand` and `AsyncParsableCommand` commands. When at least one `@file` reference is present in the input, parser error messages now include a multi-line `at <file>:<line>` / `included from <file>:<line>` block that pinpoints the offending argument and its full include chain.

Fixes: #846
Relates to #41 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
