### PR TITLE
ArgumentParser: make invalid cast explicit

### DIFF
--- a/Sources/ArgumentParser/Utilities/Platform.swift
+++ b/Sources/ArgumentParser/Utilities/Platform.swift
@@ -73,7 +73,7 @@ extension Platform {
   /// The code for exit with a validation failure.
   static var exitCodeValidationFailure: Int32 {
     #if os(Windows)
-    return ERROR_BAD_ARGUMENTS
+    return Int32(ERROR_BAD_ARGUMENTS)
     #elseif os(WASI)
     return EXIT_FAILURE
     #else


### PR DESCRIPTION
The error codes on Windows are unsigned (and do make use of the sign bit). We explicitly treat the values as signed, so make the conversion explicit. This is required with future enhancements to enable canonical importing of constants on Windows.