### PR TITLE
Support Swift Testing in Test helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT APPLE)
   find_package(Foundation CONFIG)
   if(BUILD_TESTING)
     find_package(XCTest CONFIG)
+    find_package(Testing CONFIG)
   endif()
 endif()
 

--- a/Sources/ArgumentParserTestHelpers/CMakeLists.txt
+++ b/Sources/ArgumentParserTestHelpers/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ArgumentParserTestHelpers
-  TestHelpers.swift)
+  TestHelpers.swift
+  TestHelpers+SwiftTesting.swift)
 set_target_properties(ArgumentParserTestHelpers PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(ArgumentParserTestHelpers PUBLIC
@@ -12,4 +13,8 @@ endif()
 if(XCTest_Found)
   target_link_libraries(ArgumentParserTestHelpers PUBLIC
     XCTest)
+endif()
+if(Testing_FOUND)
+  target_link_libraries(ArgumentParserTestHelpers PUBLIC
+    Testing)
 endif()

--- a/Sources/ArgumentParserTestHelpers/TestHelpers+SwiftTesting.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers+SwiftTesting.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Testing
+
+public func expectResultFailure<T, U: Error>(
+  _ expression: @autoclosure () -> Result<T, U>,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  AssertResultFailure(expression(), message(), sourceLocation: sourceLocation)
+}
+
+public func expectErrorMessage<A: ParsableArguments>(
+  _ type: A.Type, _ arguments: [String], _ errorMessage: String,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  AssertErrorMessage(
+    type, arguments, errorMessage, sourceLocation: sourceLocation)
+}
+
+public func expectFullErrorMessage<A: ParsableArguments>(
+  _ type: A.Type, _ arguments: [String], _ errorMessage: String,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  AssertFullErrorMessage(
+    type, arguments, errorMessage, sourceLocation: sourceLocation)
+}
+
+public func expectParse<A: ParsableArguments>(
+  _ type: A.Type, _ arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation,
+  closure: (A) throws -> Void
+) {
+  AssertParse(type, arguments, sourceLocation: sourceLocation) {
+    try closure($0)
+  }
+}
+
+public func expectParseCommand<A: ParsableCommand>(
+  _ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation,
+  closure: (A) throws -> Void
+) {
+  AssertParseCommand(
+    rootCommand, type, arguments, sourceLocation: sourceLocation
+  ) {
+    try closure($0)
+  }
+}
+
+public func expectEqualStrings(
+  actual: String,
+  expected: String,
+  sourceLocation: SourceLocation = #_sourceLocation
+) {
+  AssertEqualStrings(
+    actual: actual, expected: expected, sourceLocation: sourceLocation)
+}

--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserToolInfo
+import Testing
 import XCTest
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -80,12 +81,20 @@ public func AssertResultFailure<T, U: Error>(
   _ expression: @autoclosure () -> Result<T, U>,
   _ message: @autoclosure () -> String = "",
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) {
   switch expression() {
   case .success:
     let msg = message()
-    XCTFail(msg.isEmpty ? "Incorrectly succeeded" : msg, file: file, line: line)
+    if Test.current != nil {
+      Issue.record(
+        msg.isEmpty ? "Incorrectly succeeded" : "\(msg)",
+        sourceLocation: sourceLocation)
+    } else {
+      XCTFail(
+        msg.isEmpty ? "Incorrectly succeeded" : msg, file: file, line: line)
+    }
   case .failure:
     break
   }
@@ -94,63 +103,118 @@ public func AssertResultFailure<T, U: Error>(
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public func AssertErrorMessage<A>(
   _ type: A.Type, _ arguments: [String], _ errorMessage: String,
-  file: StaticString = #filePath, line: UInt = #line
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) where A: ParsableArguments {
+
   do {
     _ = try A.parse(arguments)
-    XCTFail("Parsing should have failed.", file: file, line: line)
+    if Test.current != nil {
+      Issue.record(
+        "Parsing should have failed.", sourceLocation: sourceLocation)
+    } else {
+      XCTFail("Parsing should have failed.", file: file, line: line)
+    }
   } catch {
     // We expect to hit this path, i.e. getting an error:
-    XCTAssertEqual(A.message(for: error), errorMessage, file: file, line: line)
+    if Test.current != nil {
+      #expect(
+        A.message(for: error) == errorMessage,
+        sourceLocation: sourceLocation
+      )
+    } else {
+      XCTAssertEqual(
+        A.message(for: error), errorMessage, file: file, line: line)
+    }
   }
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public func AssertFullErrorMessage<A>(
   _ type: A.Type, _ arguments: [String], _ errorMessage: String,
-  file: StaticString = #filePath, line: UInt = #line
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) where A: ParsableArguments {
   do {
     _ = try A.parse(arguments)
-    XCTFail("Parsing should have failed.", file: (file), line: line)
+    if Test.current != nil {
+      Issue.record(
+        "Parsing should have failed.", sourceLocation: sourceLocation)
+    } else {
+      XCTFail("Parsing should have failed.", file: (file), line: line)
+    }
   } catch {
     // We expect to hit this path, i.e. getting an error:
-    XCTAssertEqual(
-      A.fullMessage(for: error), errorMessage, file: (file), line: line)
+    if Test.current != nil {
+      #expect(
+        A.fullMessage(for: error) == errorMessage,
+        sourceLocation: sourceLocation
+      )
+    } else {
+      XCTAssertEqual(
+        A.fullMessage(for: error), errorMessage, file: (file), line: line)
+    }
   }
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public func AssertParse<A>(
   _ type: A.Type, _ arguments: [String], file: StaticString = #filePath,
-  line: UInt = #line, closure: (A) throws -> Void
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation,
+  closure: (A) throws -> Void
 ) where A: ParsableArguments {
   do {
     let parsed = try type.parse(arguments)
     try closure(parsed)
   } catch {
     let message = type.message(for: error)
-    XCTFail("\"\(message)\" — \(error)", file: (file), line: line)
+    if Test.current != nil {
+      Issue.record(
+        "\"\(message)\" — \(error)",
+        sourceLocation: sourceLocation
+      )
+    } else {
+      XCTFail("\"\(message)\" — \(error)", file: (file), line: line)
+    }
   }
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public func AssertParseCommand<A: ParsableCommand>(
   _ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String],
-  file: StaticString = #filePath, line: UInt = #line,
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation,
   closure: (A) throws -> Void
 ) {
   do {
     let command = try rootCommand.parseAsRoot(arguments)
     guard let aCommand = command as? A else {
-      XCTFail(
-        "Command is of unexpected type: \(command)", file: (file), line: line)
+      if Test.current != nil {
+        Issue.record(
+          "Command is of unexpected type: \(command)",
+          sourceLocation: sourceLocation
+        )
+      } else {
+        XCTFail(
+          "Command is of unexpected type: \(command)", file: (file), line: line)
+      }
       return
     }
     try closure(aCommand)
   } catch {
     let message = rootCommand.message(for: error)
-    XCTFail("\"\(message)\" — \(error)", file: file, line: line)
+    if Test.current != nil {
+      Issue.record(
+        "\"\(message)\" — \(error)",
+        sourceLocation: sourceLocation
+      )
+    } else {
+      XCTFail("\"\(message)\" — \(error)", file: file, line: line)
+    }
   }
 }
 
@@ -158,7 +222,8 @@ public func AssertParseCommand<A: ParsableCommand>(
 public func AssertParseCommandErrorMessage<A: ParsableCommand>(
   _ rootCommand: ParsableCommand.Type, _ type: A.Type, _ arguments: [String],
   _ errorMessage: String,
-  file: StaticString = #filePath, line: UInt = #line
+  file: StaticString = #filePath,
+  line: UInt = #line
 ) {
   do {
     let command = try rootCommand.parseAsRoot(arguments)
@@ -179,7 +244,8 @@ public func AssertEqualStrings(
   actual: String,
   expected: String,
   file: StaticString = #filePath,
-  line: UInt = #line
+  line: UInt = #line,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) {
   // Normalize line endings to '\n'.
   let actual =
@@ -248,10 +314,17 @@ public func AssertEqualStrings(
       """
   }
 
-  XCTFail(
-    "Actual output does not match the expected output:\n\(stringComparison)",
-    file: file,
-    line: line)
+  if Test.current != nil {
+    Issue.record(
+      "Actual output does not match the expected output:\n\(stringComparison)",
+      sourceLocation: sourceLocation
+    )
+  } else {
+    XCTFail(
+      "Actual output does not match the expected output:\n\(stringComparison)",
+      file: file,
+      line: line)
+  }
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase

--- a/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/CustomParsingEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class ParsingEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/DefaultAsFlagEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultAsFlagEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class DefaultAsFlagEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParserTestHelpers
 import ArgumentParserToolInfo
+import Testing
 import XCTest
 
 @testable import ArgumentParser
@@ -132,7 +133,7 @@ extension DefaultSubcommandEndToEndTests {
     }
   }
 
-  func testNotMyParent() throws {
+  func testNotMyParent() {
     AssertParseCommandErrorMessage(
       MyCommand.self, BadParent.self, ["--verbose", "bad-parent"],
       "Command 'Other' is not a parent of the current command.")

--- a/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultsEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class DefaultsEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/EnumEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/EnumEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class EnumEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/EqualsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/EqualsEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class EqualsEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class FlagsEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class JoinedEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/LongNameWithShortDashEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/LongNameWithShortDashEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class LongNameWithSingleDashEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class NestedCommandEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/OptionGroupEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/OptionGroupEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class OptionGroupEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class OptionalEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class PositionalEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserEndToEndTests/RawRepresentableEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RawRepresentableEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class RawRepresentableEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests+ParsingStrategy.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests+ParsingStrategy.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class RepeatingEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserEndToEndTests/ShortNameEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ShortNameEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class ShortNameEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class SimpleEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/SingleValueParsingStrategyTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SingleValueParsingStrategyTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class SingleValueParsingStrategyTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class SubcommandEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class TransformEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
+++ b/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class UnparsedValuesEndToEndTests: XCTestCase {}

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 final class ValidationEndToEndTests: XCTestCase {

--- a/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/HelpTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserPackageManagerTests/Tests.swift
+++ b/Tests/ArgumentParserPackageManagerTests/Tests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
+++ b/Tests/ArgumentParserUnitTests/CompletionScriptTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
+++ b/Tests/ArgumentParserUnitTests/ErrorMessageTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser

--- a/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
+++ b/Tests/ArgumentParserUnitTests/ParsableArgumentsValidationTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Testing
 import XCTest
 
 @testable import ArgumentParser


### PR DESCRIPTION
Update some of the test helpers to support both XCTest and Swift Testing
API to help with migrating test to Swift Testing.
    
Relates to: #710

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
