### PR TITLE
GHA: Add PR dependency check

### DIFF
--- a/.github/workflows/pull_request_dependency_check.yaml
+++ b/.github/workflows/pull_request_dependency_check.yaml
@@ -1,0 +1,14 @@
+name: Pull Request
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+    name: "Check GitHub PR Dependencies"
+    uses: swiftlang/github-workflows/.github/workflows/github_actions_dependencies.yml@0.0.13


### PR DESCRIPTION
Add a workflow that will check if dependent PR are merged. If not, fail the build.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
