### PR TITLE
Migrate `ArgumentParserToolInfoTests` to Swift Testing

### DIFF
--- a/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
+++ b/Tests/ArgumentParserToolInfoTests/ArgumentParserToolInfoTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 
 import ArgumentParserToolInfo
 import Foundation
-import XCTest
+import Testing
 
 extension DecodingError: Swift.CustomStringConvertible {
   public var description: String {
@@ -61,22 +61,18 @@ extension FileManager {
   }
 }
 
-final class ArgumentParserToolInfoTests: XCTestCase {
-  func test_examples() {
-    let examplesDirectory = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()
-      .appendingPathComponent("Examples")
-    let examples = FileManager.default.files(
-      inDirectory: examplesDirectory,
-      withPathExtension: "json")
+@Suite struct ArgumentParserToolInfoTests {
+  static let examplesDirectory = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Examples")
 
-    for example in examples {
-      do {
-        let data = try Data(contentsOf: example)
-        _ = try JSONDecoder().decode(ToolInfoV0.self, from: data)
-      } catch {
-        XCTFail("Failed to parse \(example.path): \(error)")
-      }
-    }
+  static let examples: [URL] = FileManager.default.files(
+    inDirectory: Self.examplesDirectory,
+    withPathExtension: "json")
+
+  @Test(arguments: examples)
+  func example(url: URL) throws {
+    let data = try Data(contentsOf: url)
+    _ = try JSONDecoder().decode(ToolInfoV0.self, from: data)
   }
 }


### PR DESCRIPTION
Migrate all tests in target `ArgumentParserToolInfoTests` from XCTest to Swift Testing.

Related to #710

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
