### PR TITLE
Migrate HelpGeneration unit tests to Swift Testing

### DIFF
--- a/Sources/ArgumentParserTestHelpers/TestHelpers.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers.swift
@@ -328,14 +328,13 @@ public func AssertEqualStrings(
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
-public func AssertHelp<T: ParsableArguments>(
+public func requireHelp<T: ParsableArguments>(
   _ visibility: ArgumentVisibility,
   for _: T.Type,
   columns: Int? = 80,
   equals expected: String,
-  file: StaticString = #filePath,
-  line: UInt = #line
-) {
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws {
   let flag: String
   let includeHidden: Bool
 
@@ -347,37 +346,53 @@ public func AssertHelp<T: ParsableArguments>(
     flag = "--help-hidden"
     includeHidden = true
   case .private:
-    XCTFail("Should not be called.", file: file, line: line)
+    Issue.record("Should not be called.", sourceLocation: sourceLocation)
     return
   default:
-    XCTFail("Unrecognized visibility.", file: file, line: line)
+    Issue.record("Uxnrecognized visibility.", sourceLocation: sourceLocation)
     return
   }
 
+  #if compiler(>=6.1)
+  let error = try #require(throws: (any Error).self) {
+    _ = try T.parse([flag])
+  }
+  #else
+  let error: any Error
   do {
     _ = try T.parse([flag])
-    XCTFail(file: file, line: line)
-  } catch {
-    let helpString = T.fullMessage(for: error, columns: columns)
-    AssertEqualStrings(
-      actual: helpString, expected: expected, file: file, line: line)
+    Issue.record(
+      "Expected T.parse to throw an error.",
+      sourceLocation: sourceLocation)
+    return
+  } catch let caught {
+    error = caught
   }
+  #endif
+  let errorFullMessage = T.fullMessage(for: error, columns: columns)
+  AssertEqualStrings(
+    actual: errorFullMessage,
+    expected: expected,
+    sourceLocation: sourceLocation
+  )
 
   let helpString = T.helpMessage(includeHidden: includeHidden, columns: columns)
   AssertEqualStrings(
-    actual: helpString, expected: expected, file: file, line: line)
+    actual: helpString,
+    expected: expected,
+    sourceLocation: sourceLocation
+  )
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
-public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
+public func requireHelp<T: ParsableCommand, U: ParsableCommand>(
   _ visibility: ArgumentVisibility,
   for _: T.Type,
   root _: U.Type,
   columns: Int? = 80,
   equals expected: String,
-  file: StaticString = #filePath,
-  line: UInt = #line
-) {
+  sourceLocation: SourceLocation = #_sourceLocation
+) throws {
   let includeHidden: Bool
 
   switch visibility {
@@ -386,17 +401,17 @@ public func AssertHelp<T: ParsableCommand, U: ParsableCommand>(
   case .hidden:
     includeHidden = true
   case .private:
-    XCTFail("Should not be called.", file: file, line: line)
+    Issue.record("Should not be called.", sourceLocation: sourceLocation)
     return
   default:
-    XCTFail("Unrecognized visibility.", file: file, line: line)
+    Issue.record("Uxnrecognized visibility.", sourceLocation: sourceLocation)
     return
   }
 
   let helpString = U.helpMessage(
     for: T.self, includeHidden: includeHidden, columns: columns)
   AssertEqualStrings(
-    actual: helpString, expected: expected, file: file, line: line)
+    actual: helpString, expected: expected, sourceLocation: sourceLocation)
 }
 
 extension XCTest {

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -279,9 +279,12 @@ extension FlagsEndToEndTests {
       XCTAssertEqual(options.shape, nil)
     }
   }
+}
 
-  func testParsingCaseIterable_Help() throws {
-    AssertHelp(
+@Suite
+struct FlagsEndToEndTestsSWT {
+  @Test func testParsingCaseIterable_Help() async throws {
+    try requireHelp(
       .default, for: Baz.self,
       equals: """
         USAGE: baz --pink --purple --silver [--small] [--medium] [--large] [--extra-large] [--humongous] [--round] [--square] [--oblong]
@@ -298,7 +301,10 @@ extension FlagsEndToEndTests {
 
         """)
   }
+}
 
+// swift-format-ignore: AlwaysUseLowerCamelCase
+extension FlagsEndToEndTests {
   func testParsingCaseIterable_Fails() throws {
     // Missing color
     XCTAssertThrowsError(try Baz.parse([]))

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtArgument.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtArgument.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
@@ -65,8 +65,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtArgumentTransform_BareNoDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_BareNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.BareNoDefault.self,
       equals: """
@@ -81,8 +81,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_BareDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_BareDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.BareDefault.self,
       equals: """
@@ -97,8 +97,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_OptionalNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.OptionalNoDefault.self,
       equals: """
@@ -113,8 +113,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atArgumentTransform_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.OptionalDefaultNil.self,
       equals: """
@@ -129,8 +129,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_OptionalDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_OptionalDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.OptionalDefault.self,
       equals: """
@@ -145,8 +145,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_ArrayNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.ArrayNoDefault.self,
       equals: """
@@ -161,8 +161,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atArgumentTransform_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.ArrayDefaultEmpty.self,
       equals: """
@@ -177,8 +177,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentTransform_ArrayDefault() {
-    AssertHelp(
+  @Test func atArgumentTransform_ArrayDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentTransform.ArrayDefault.self,
       equals: """
@@ -248,8 +248,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtArgumentEBA_BareNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBA_BareNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.BareNoDefault.self,
       equals: """
@@ -264,8 +264,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_BareDefault() {
-    AssertHelp(
+  @Test func atArgumentEBA_BareDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.BareDefault.self,
       equals: """
@@ -280,8 +280,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBA_OptionalNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.OptionalNoDefault.self,
       equals: """
@@ -296,8 +296,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atArgumentEBA_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.OptionalDefaultNil.self,
       equals: """
@@ -312,8 +312,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBA_ArrayNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.ArrayNoDefault.self,
       equals: """
@@ -328,8 +328,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atArgumentEBA_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.ArrayDefaultEmpty.self,
       equals: """
@@ -344,8 +344,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBA_ArrayDefault() {
-    AssertHelp(
+  @Test func atArgumentEBA_ArrayDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBA.ArrayDefault.self,
       equals: """
@@ -414,8 +414,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtArgumentEBATransform_BareNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_BareNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.BareNoDefault.self,
       equals: """
@@ -430,8 +430,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_BareDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_BareDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.BareDefault.self,
       equals: """
@@ -446,8 +446,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_OptionalNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.OptionalNoDefault.self,
       equals: """
@@ -462,8 +462,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.OptionalDefaultNil.self,
       equals: """
@@ -478,8 +478,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_OptionalDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_OptionalDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.OptionalDefault.self,
       equals: """
@@ -494,8 +494,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_ArrayNoDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.ArrayNoDefault.self,
       equals: """
@@ -510,8 +510,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.ArrayDefaultEmpty.self,
       equals: """
@@ -526,8 +526,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtArgumentEBATransform_ArrayDefault() {
-    AssertHelp(
+  @Test func atArgumentEBATransform_ArrayDefault() async throws {
+    try requireHelp(
       .default,
       for: AtArgumentEBATransform.ArrayDefault.self,
       equals: """

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOption.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOption.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
@@ -65,8 +65,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtOptionTransform_BareNoDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_BareNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.BareNoDefault.self,
       equals: """
         USAGE: bare-no-default --arg0 <arg0>
@@ -78,8 +78,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_BareDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_BareDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.BareDefault.self,
       equals: """
         USAGE: bare-default [--arg0 <arg0>]
@@ -91,8 +91,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_OptionalNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.OptionalNoDefault.self,
       equals: """
         USAGE: optional-no-default [--arg0 <arg0>]
@@ -104,8 +104,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atOptionTransform_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.OptionalDefaultNil.self,
       equals: """
         USAGE: optional-default-nil [--arg0 <arg0>]
@@ -117,8 +117,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_OptionalDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_OptionalDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.OptionalDefault.self,
       equals: """
         USAGE: optional-default [--arg0 <arg0>]
@@ -130,8 +130,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_ArrayNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.ArrayNoDefault.self,
       equals: """
         USAGE: array-no-default --arg0 <arg0> ...
@@ -143,8 +143,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atOptionTransform_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.ArrayDefaultEmpty.self,
       equals: """
         USAGE: array-default-empty [--arg0 <arg0> ...]
@@ -156,8 +156,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionTransform_ArrayDefault() {
-    AssertHelp(
+  @Test func atOptionTransform_ArrayDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionTransform.ArrayDefault.self,
       equals: """
         USAGE: array-default [--arg0 <arg0> ...]
@@ -224,8 +224,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtOptionEBA_BareNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBA_BareNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.BareNoDefault.self,
       equals: """
         USAGE: bare-no-default --arg0 <arg0>
@@ -237,8 +237,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_BareDefault() {
-    AssertHelp(
+  @Test func atOptionEBA_BareDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.BareDefault.self,
       equals: """
         USAGE: bare-default [--arg0 <arg0>]
@@ -250,8 +250,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBA_OptionalNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.OptionalNoDefault.self,
       equals: """
         USAGE: optional-no-default [--arg0 <arg0>]
@@ -263,8 +263,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atOptionEBA_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.OptionalDefaultNil.self,
       equals: """
         USAGE: optional-default-nil [--arg0 <arg0>]
@@ -276,8 +276,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBA_ArrayNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.ArrayNoDefault.self,
       equals: """
         USAGE: array-no-default --arg0 <arg0> ...
@@ -289,8 +289,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atOptionEBA_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.ArrayDefaultEmpty.self,
       equals: """
         USAGE: array-default-empty [--arg0 <arg0> ...]
@@ -302,8 +302,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBA_ArrayDefault() {
-    AssertHelp(
+  @Test func atOptionEBA_ArrayDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBA.ArrayDefault.self,
       equals: """
         USAGE: array-default [--arg0 <arg0> ...]
@@ -369,8 +369,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testAtOptionEBATransform_BareNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_BareNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.BareNoDefault.self,
       equals: """
         USAGE: bare-no-default --arg0 <arg0>
@@ -382,8 +382,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_BareDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_BareDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.BareDefault.self,
       equals: """
         USAGE: bare-default [--arg0 <arg0>]
@@ -395,8 +395,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_OptionalNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_OptionalNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.OptionalNoDefault.self,
       equals: """
         USAGE: optional-no-default [--arg0 <arg0>]
@@ -408,8 +408,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_OptionalDefaultNil() {
-    AssertHelp(
+  @Test func atOptionEBATransform_OptionalDefaultNil() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.OptionalDefaultNil.self,
       equals: """
         USAGE: optional-default-nil [--arg0 <arg0>]
@@ -421,8 +421,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_OptionalDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_OptionalDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.OptionalDefault.self,
       equals: """
         USAGE: optional-default [--arg0 <arg0>]
@@ -434,8 +434,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_ArrayNoDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_ArrayNoDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.ArrayNoDefault.self,
       equals: """
         USAGE: array-no-default --arg0 <arg0> ...
@@ -447,8 +447,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_ArrayDefaultEmpty() {
-    AssertHelp(
+  @Test func atOptionEBATransform_ArrayDefaultEmpty() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.ArrayDefaultEmpty.self,
       equals: """
         USAGE: array-default-empty [--arg0 <arg0> ...]
@@ -460,8 +460,8 @@ extension HelpGenerationTests {
         """)
   }
 
-  func testAtOptionEBATransform_ArrayDefault() {
-    AssertHelp(
+  @Test func atOptionEBATransform_ArrayDefault() async throws {
+    try requireHelp(
       .default, for: AtOptionEBATransform.ArrayDefault.self,
       equals: """
         USAGE: array-default [--arg0 <arg0> ...]

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOptionDefaultAsFlag.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+AtOptionDefaultAsFlag.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
@@ -36,8 +36,8 @@ extension HelpGenerationTests {
     var regular: String?
   }
 
-  func testDefaultAsFlagHelpOutput() {
-    AssertHelp(
+  @Test func defaultAsFlagHelpOutput() async throws {
+    try requireHelp(
       .default, for: BasicDefaultAsFlag.self,
       equals: """
         USAGE: basic_default_as_flag [--string-flag [<string-flag>]] [--number-flag [<number-flag>]] [--bool-flag [<bool-flag>]] [--transform-flag [<transform-flag>]] [--regular <regular>]
@@ -73,8 +73,8 @@ extension HelpGenerationTests {
     var shortOnly: String?
   }
 
-  func testDefaultAsFlagWithShortNames() {
-    AssertHelp(
+  @Test func defaultAsFlagWithShortNames() async throws {
+    try requireHelp(
       .default, for: DefaultAsFlagWithShortNames.self,
       equals: """
         USAGE: default_as_flag_with_short_names [--short-and-long [<short-and-long>]] [-o [<o>]]
@@ -102,8 +102,8 @@ extension HelpGenerationTests {
     var positional: String?
   }
 
-  func testMixedOptionTypes() {
-    AssertHelp(
+  @Test func mixedOptionTypes() async throws {
+    try requireHelp(
       .default, for: MixedOptionTypes.self,
       equals: """
         USAGE: mixed_option_types [--flag] [--default-as-flag [<default-as-flag>]] [--regular <regular>] [<positional>]

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
@@ -75,8 +75,8 @@ extension HelpGenerationTests {
     var argsAndFlags: ArgsAndFlags
   }
 
-  func testAllVisible() {
-    AssertHelp(
+  @Test func allVisible() async throws {
+    try requireHelp(
       .default, for: AllVisible.self,
       equals: """
         USAGE: all-visible [--verbose] [--oversharing] [--name <name>] --age <age> [--experimental] --prefix <prefix> [<name>] [--existing-user]
@@ -100,7 +100,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: AllVisible.self,
       equals: """
         USAGE: all-visible [--verbose] [--oversharing] [--name <name>] --age <age> [--experimental] --prefix <prefix> [<name>] <title> [--existing-user]
@@ -140,8 +140,8 @@ extension HelpGenerationTests {
     var argsAndFlags: ArgsAndFlags
   }
 
-  func testCombined() {
-    AssertHelp(
+  @Test func combined() async throws {
+    try requireHelp(
       .default, for: Combined.self,
       equals: """
         USAGE: combined [--verbose] [--oversharing] [--name <name>] --age <age> [--experimental] --prefix <prefix> [<name>] [--existing-user]
@@ -163,7 +163,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: Combined.self,
       equals: """
         USAGE: combined [--verbose] [--oversharing] [--name <name>] --age <age> [--experimental] --prefix <prefix> [<name>] <title> [--existing-user]
@@ -201,8 +201,8 @@ extension HelpGenerationTests {
     var argsAndFlags: ArgsAndFlags
   }
 
-  func testHiddenGroups() {
-    AssertHelp(
+  @Test func hiddenGroups() async throws {
+    try requireHelp(
       .default, for: HiddenGroups.self,
       equals: """
         USAGE: hidden-groups
@@ -212,7 +212,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: HiddenGroups.self,
       equals: """
         USAGE: hidden-groups [--verbose] [--oversharing] [--name <name>] --age <age> [--experimental] --prefix <prefix>
@@ -246,8 +246,8 @@ extension HelpGenerationTests {
     var nested: NestedGroups
   }
 
-  func testNestedHiddenGroups() {
-    AssertHelp(
+  @Test func nestedHiddenGroups() async throws {
+    try requireHelp(
       .default, for: NestedHiddenGroups.self,
       equals: """
         USAGE: nested-hidden-groups
@@ -257,7 +257,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: NestedHiddenGroups.self,
       equals: """
         USAGE: nested-hidden-groups [--experimental] --prefix <prefix>
@@ -293,8 +293,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testParentChild() {
-    AssertHelp(
+  @Test func parentChild() async throws {
+    try requireHelp(
       .default, for: ParentWithGroups.self,
       equals: """
         USAGE: parent-with-groups [--verbose] [--oversharing] [<name>] [--existing-user] <subcommand>
@@ -316,7 +316,7 @@ extension HelpGenerationTests {
           See 'parent-with-groups help <subcommand>' for detailed help.
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: ParentWithGroups.self,
       equals: """
         USAGE: parent-with-groups [--verbose] [--oversharing] [<name>] <title> [--existing-user] <subcommand>
@@ -339,7 +339,7 @@ extension HelpGenerationTests {
           See 'parent-with-groups help <subcommand>' for detailed help.
         """)
 
-    AssertHelp(
+    try requireHelp(
       .default, for: ParentWithGroups.ChildWithGroups.self,
       root: ParentWithGroups.self,
       equals: """
@@ -362,7 +362,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: ParentWithGroups.ChildWithGroups.self,
       root: ParentWithGroups.self,
       equals: """
@@ -392,8 +392,8 @@ extension HelpGenerationTests {
     var extras: ContainsOptionGroup
   }
 
-  func testUnnamedNestedGroups() {
-    AssertHelp(
+  @Test func unnamedNestedGroups() async throws {
+    try requireHelp(
       .default, for: GroupsWithUnnamedGroups.self,
       equals: """
         USAGE: groups-with-unnamed-groups [--verbose] [--oversharing] [<name>] [--existing-user]
@@ -417,8 +417,8 @@ extension HelpGenerationTests {
     var extras: ContainsOptionGroup
   }
 
-  func testNamedNestedGroups() {
-    AssertHelp(
+  @Test func namedNestedGroups() async throws {
+    try requireHelp(
       .default, for: GroupsWithNamedGroups.self,
       equals: """
         USAGE: groups-with-named-groups [--verbose] [--oversharing] [<name>] [--existing-user]

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,12 +10,13 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParserTestHelpers
+import Foundation
 import Testing
 import XCTest
 
 @testable import ArgumentParser
 
-final class HelpGenerationTests: XCTestCase {
+@Suite struct HelpGenerationTests {
 }
 
 extension Foundation.URL: ArgumentParser.ExpressibleByArgument {
@@ -39,8 +40,8 @@ extension HelpGenerationTests {
     @Option(help: "Your title") var title: String?
   }
 
-  func testHelp() {
-    AssertHelp(
+  @Test func help() async throws {
+    try requireHelp(
       .default, for: A.self,
       equals: """
         USAGE: a --name <name> [--title <title>]
@@ -64,8 +65,8 @@ extension HelpGenerationTests {
       true
   }
 
-  func testHelpWithHidden() {
-    AssertHelp(
+  @Test func helpWithHidden() async throws {
+    try requireHelp(
       .default, for: B.self,
       equals: """
         USAGE: b --name <name> [--title <title>]
@@ -77,7 +78,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .hidden, for: B.self,
       equals: """
         USAGE: b --name <name> [--title <title>] [<hidden-name>] [--hidden-title <hidden-title>] [--hidden-flag] [--hidden-inverted-flag] [--no-hidden-inverted-flag]
@@ -105,8 +106,8 @@ extension HelpGenerationTests {
     var name: String
   }
 
-  func testHelpWithDiscussion() {
-    AssertHelp(
+  @Test func helpWithDiscussion() async throws {
+    try requireHelp(
       .default, for: C.self,
       equals: """
         USAGE: c --name <name>
@@ -130,8 +131,8 @@ extension HelpGenerationTests {
     var five: String = ""
   }
 
-  func testHelpWithDefaultValueButNoDiscussion() {
-    AssertHelp(
+  @Test func helpWithDefaultValueButNoDiscussion() async throws {
+    try requireHelp(
       .default, for: Issue27.self,
       equals: """
         USAGE: issue27 [--two <two>] --three <three> [--four <four>] [--five <five>]
@@ -213,8 +214,8 @@ extension HelpGenerationTests {
     var special: SpecializedSynthesized = .apple
   }
 
-  func testHelpWithDefaultValues() {
-    AssertHelp(
+  @Test func helpWithDefaultValues() async throws {
+    try requireHelp(
       .default, for: D.self,
       equals: """
         USAGE: d [<occupation>] [--name <name>] [--age <age>] [--logging <logging>] [--lucky <numbers> ...] [--optional] [--required] [--degree <degree>] [--directory <directory>] [--manual <manual>] [--unspecial <unspecial>] [--special <special>]
@@ -270,8 +271,8 @@ extension HelpGenerationTests {
     var flag: Bool = false
   }
 
-  func testHelpWithMutuallyExclusiveFlags() {
-    AssertHelp(
+  @Test func helpWithMutuallyExclusiveFlags() async throws {
+    try requireHelp(
       .default, for: E.self,
       equals: """
         USAGE: e --stats --count --list
@@ -283,7 +284,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .default, for: F.self,
       equals: """
         USAGE: f [-s] [-c] [-l]
@@ -294,7 +295,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertHelp(
+    try requireHelp(
       .default, for: G.self,
       equals: """
         USAGE: g [--flag] [--no-flag]
@@ -338,8 +339,8 @@ extension HelpGenerationTests {
     ])
   }
 
-  func testHelpWithSubcommands() {
-    AssertHelp(
+  @Test func helpWithSubcommands() async throws {
+    try requireHelp(
       .default, for: H.self,
       equals: """
         USAGE: h <subcommand>
@@ -357,7 +358,7 @@ extension HelpGenerationTests {
           See 'h help <subcommand>' for detailed help.
         """)
 
-    AssertHelp(
+    try requireHelp(
       .default, for: H.AnotherCommand.self, root: H.self,
       equals: """
         USAGE: h another-command [--some-option-with-very-long-name <some-option-with-very-long-name>] [--option <option>] [<argument-with-very-long-name-and-help>] [<argument-with-very-long-name>] [<argument>]
@@ -380,8 +381,8 @@ extension HelpGenerationTests {
     static let configuration = CommandConfiguration(version: "1.0.0")
   }
 
-  func testHelpWithVersion() {
-    AssertHelp(
+  @Test func helpWithVersion() async throws {
+    try requireHelp(
       .default, for: I.self,
       equals: """
         USAGE: i
@@ -398,10 +399,10 @@ extension HelpGenerationTests {
     static let configuration = CommandConfiguration(discussion: "test")
   }
 
-  func testOverviewButNoAbstractSpacing() {
+  @Test func overviewButNoAbstractSpacing() async throws {
     let renderedHelp = HelpGenerator(J.self, visibility: .default)
       .rendered()
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: renderedHelp,
       expected: """
         OVERVIEW: \n\
@@ -426,8 +427,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testHelpWithNoValueForArray() {
-    AssertHelp(
+  @Test func helpWithNoValueForArray() async throws {
+    try requireHelp(
       .default, for: K.self,
       equals: """
         USAGE: k [<paths> ...]
@@ -452,8 +453,8 @@ extension HelpGenerationTests {
     var time: String?
   }
 
-  func testHelpWithMultipleCustomNames() {
-    AssertHelp(
+  @Test func helpWithMultipleCustomNames() async throws {
+    try requireHelp(
       .default, for: L.self,
       equals: """
         USAGE: l [--remote <remote>]
@@ -473,8 +474,8 @@ extension HelpGenerationTests {
       subcommands: [M.self], defaultSubcommand: M.self)
   }
 
-  func testHelpWithDefaultCommand() {
-    AssertHelp(
+  @Test func helpWithDefaultCommand() async throws {
+    try requireHelp(
       .default, for: N.self,
       equals: """
         USAGE: n <subcommand>
@@ -509,8 +510,8 @@ extension HelpGenerationTests {
     var remainder: [O] = [.large]
   }
 
-  func testHelpWithDefaultValueForArray() {
-    AssertHelp(
+  @Test func helpWithDefaultValueForArray() async throws {
+    try requireHelp(
       .default, for: P.self,
       equals: """
         USAGE: p [-o <o> ...] [<remainder> ...]
@@ -553,8 +554,8 @@ extension HelpGenerationTests {
     public init() {}
   }
 
-  func testHelpExcludingSuperCommand() throws {
-    AssertHelp(
+  @Test func helpExcludingSuperCommand() async throws {
+    try requireHelp(
       .default, for: Bar.self, root: Foo.self,
       equals: """
         OVERVIEW: Perform bar operations
@@ -583,8 +584,8 @@ extension HelpGenerationTests {
     )
   }
 
-  func testHelpSubcommandGroups() throws {
-    AssertHelp(
+  @Test func helpSubcommandGroups() async throws {
+    try requireHelp(
       .default, for: WithSubgroups.self,
       equals: """
         USAGE: subgroupings <subcommand>
@@ -622,8 +623,8 @@ extension HelpGenerationTests {
     )
   }
 
-  func testHelpOnlySubcommandGroups() throws {
-    AssertHelp(
+  @Test func helpOnlySubcommandGroups() async throws {
+    try requireHelp(
       .default, for: OnlySubgroups.self,
       equals: """
         USAGE: subgroupings <subcommand>
@@ -724,23 +725,25 @@ extension HelpGenerationTests {
   }
 
   @available(*, deprecated)
-  func testHidingOptionGroup() throws {
-    AssertHelp(
+  @Test func hidingOptionGroup() async throws {
+    try requireHelp(
       .default, for: HideOptionGroupLegacyDriver.self, equals: helpMessage)
-    AssertHelp(.default, for: HideOptionGroupDriver.self, equals: helpMessage)
-    AssertHelp(
+    try requireHelp(
+      .default, for: HideOptionGroupDriver.self, equals: helpMessage)
+    try requireHelp(
       .default, for: PrivateOptionGroupDriver.self, equals: helpMessage)
   }
 
   @available(*, deprecated)
-  func testHelpHiddenShowsDefaultAndHidden() throws {
-    AssertHelp(
+  @Test func helpHiddenShowsDefaultAndHidden() async throws {
+    try requireHelp(
       .hidden, for: HideOptionGroupLegacyDriver.self, equals: helpHiddenMessage)
-    AssertHelp(
+    try requireHelp(
       .hidden, for: HideOptionGroupDriver.self, equals: helpHiddenMessage)
 
     // Note: Private option groups are not visible at `.hidden` help level.
-    AssertHelp(.hidden, for: PrivateOptionGroupDriver.self, equals: helpMessage)
+    try requireHelp(
+      .hidden, for: PrivateOptionGroupDriver.self, equals: helpMessage)
   }
 }
 
@@ -770,34 +773,34 @@ extension HelpGenerationTests {
     @Option var specializedSynthesizedOption: SpecializedSynthesized
   }
 
-  func testAllValueStrings() throws {
-    XCTAssertEqual(AllValues.Manual.allValueStrings, ["bar"])
-    XCTAssertEqual(
-      AllValues.UnspecializedSynthesized.allValueStrings, ["0", "1"])
-    XCTAssertEqual(
-      AllValues.SpecializedSynthesized.allValueStrings, ["Apple", "Banana"])
+  @Test func allValueStrings() async throws {
+    #expect(AllValues.Manual.allValueStrings == ["bar"])
+    #expect(
+      AllValues.UnspecializedSynthesized.allValueStrings == ["0", "1"])
+    #expect(
+      AllValues.SpecializedSynthesized.allValueStrings == ["Apple", "Banana"])
   }
 
-  func testAllValues() {
+  @Test func allValues() async throws {
     let opts = ArgumentSet(AllValues.self, visibility: .private, parent: nil)
-    XCTAssertEqual(
-      AllValues.Manual.allValueStrings, opts[0].help.allValueStrings)
-    XCTAssertEqual(
-      AllValues.Manual.allValueStrings, opts[1].help.allValueStrings)
+    #expect(
+      AllValues.Manual.allValueStrings == opts[0].help.allValueStrings)
+    #expect(
+      AllValues.Manual.allValueStrings == opts[1].help.allValueStrings)
 
-    XCTAssertEqual(
-      AllValues.UnspecializedSynthesized.allValueStrings,
-      opts[2].help.allValueStrings)
-    XCTAssertEqual(
-      AllValues.UnspecializedSynthesized.allValueStrings,
-      opts[3].help.allValueStrings)
+    #expect(
+      AllValues.UnspecializedSynthesized.allValueStrings
+        == opts[2].help.allValueStrings)
+    #expect(
+      AllValues.UnspecializedSynthesized.allValueStrings
+        == opts[3].help.allValueStrings)
 
-    XCTAssertEqual(
-      AllValues.SpecializedSynthesized.allValueStrings,
-      opts[4].help.allValueStrings)
-    XCTAssertEqual(
-      AllValues.SpecializedSynthesized.allValueStrings,
-      opts[5].help.allValueStrings)
+    #expect(
+      AllValues.SpecializedSynthesized.allValueStrings
+        == opts[4].help.allValueStrings)
+    #expect(
+      AllValues.SpecializedSynthesized.allValueStrings
+        == opts[5].help.allValueStrings)
   }
 
   struct Q: ParsableArguments {
@@ -811,8 +814,8 @@ extension HelpGenerationTests {
       Bool = true
   }
 
-  func testHelpWithPrivate() {
-    AssertHelp(
+  @Test func helpWithPrivate() async throws {
+    try requireHelp(
       .default, for: Q.self,
       equals: """
         USAGE: q --name <name> [--title <title>]
@@ -848,8 +851,8 @@ extension HelpGenerationTests {
     }
   }
 
-  func testIssue278() {
-    AssertHelp(
+  @Test func issue278() async throws {
+    try requireHelp(
       .default, for: ParserBug.Sub.self, root: ParserBug.self,
       equals: """
         USAGE: parserBug sub [--example] [<argument>]
@@ -865,7 +868,6 @@ extension HelpGenerationTests {
   }
 }
 
-// swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension HelpGenerationTests {
   struct NonCustomUsage: ParsableCommand {
@@ -910,8 +912,9 @@ extension HelpGenerationTests {
     @Flag var verboseMode = false
   }
 
-  func test_usageCustomization_helpMessage() {
-    AssertEqualStrings(
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  @Test func test_usageCustomization_helpMessage() async throws {
+    expectEqualStrings(
       actual: NonCustomUsage.helpMessage(columns: 80),
       expected: """
         USAGE: non-custom-usage <file> [--verbose-mode] <subcommand>
@@ -929,7 +932,7 @@ extension HelpGenerationTests {
           See 'non-custom-usage help <subcommand>' for detailed help.
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: NonCustomUsage.helpMessage(
         for: NonCustomUsage.ExampleSubcommand.self, columns: 80),
       expected: """
@@ -943,7 +946,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageShort.helpMessage(columns: 80),
       expected: """
         USAGE: example [--verbose] <file-name>
@@ -957,7 +960,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageLong.helpMessage(columns: 80),
       expected: """
         USAGE: example <file-name>
@@ -973,7 +976,7 @@ extension HelpGenerationTests {
 
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageHidden.helpMessage(columns: 80),
       expected: """
         ARGUMENTS:
@@ -986,8 +989,9 @@ extension HelpGenerationTests {
         """)
   }
 
-  func test_usageCustomization_fullMessage() {
-    AssertEqualStrings(
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  @Test func test_usageCustomization_fullMessage() async throws {
+    expectEqualStrings(
       actual: NonCustomUsage.fullMessage(for: ValidationError("Test")),
       expected: """
         Error: Test
@@ -995,7 +999,7 @@ extension HelpGenerationTests {
           See 'non-custom-usage --help' for more information.
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageShort.fullMessage(for: ValidationError("Test")),
       expected: """
         Error: Test
@@ -1003,7 +1007,7 @@ extension HelpGenerationTests {
           See 'custom-usage-short --help' for more information.
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageLong.fullMessage(for: ValidationError("Test")),
       expected: """
         Error: Test
@@ -1013,7 +1017,7 @@ extension HelpGenerationTests {
           See 'custom-usage-long --help' for more information.
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageHidden.fullMessage(for: ValidationError("Test")),
       expected: """
         Error: Test
@@ -1021,27 +1025,28 @@ extension HelpGenerationTests {
         """)
   }
 
-  func test_usageCustomization_usageString() {
-    AssertEqualStrings(
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  @Test func test_usageCustomization_usageString() async throws {
+    expectEqualStrings(
       actual: NonCustomUsage.usageString(),
       expected: """
         non-custom-usage <file> [--verbose-mode] <subcommand>
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: NonCustomUsage.usageString(
         for: NonCustomUsage.ExampleSubcommand.self),
       expected: """
         non-custom-usage example-subcommand <output>
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageShort.usageString(),
       expected: """
         example [--verbose] <file-name>
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageLong.usageString(),
       expected: """
         example <file-name>
@@ -1049,14 +1054,13 @@ extension HelpGenerationTests {
         example --help
         """)
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: CustomUsageHidden.usageString(),
       expected: """
         """)
   }
 }
 
-// swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension HelpGenerationTests {
   enum OptionValues: String, CaseIterable, ExpressibleByArgument {
@@ -1080,8 +1084,8 @@ extension HelpGenerationTests {
     @Option(help: "An option with enumerable values.") var opt: OptionValues
   }
 
-  func testEnumerableOptionValuesWithoutDefault() {
-    AssertHelp(
+  @Test func enumerableOptionValuesWithoutDefault() async throws {
+    try requireHelp(
       .default, for: CustomOption.self,
       equals: """
         USAGE: custom-option --opt <opt>
@@ -1102,8 +1106,8 @@ extension HelpGenerationTests {
     var opt: [OptionValues] = [.red]
   }
 
-  func testEnumerableOptionAsListWithSingleDefault() {
-    AssertHelp(
+  @Test func enumerableOptionAsListWithSingleDefault() async throws {
+    try requireHelp(
       .default,
       for: CustomOptionAsListWithSingleDefaultValue.self,
       columns: 100,
@@ -1126,8 +1130,8 @@ extension HelpGenerationTests {
     var opt: [OptionValues] = [.red, .blue]
   }
 
-  func testEnumerableOptionAsListWithMultipleDefault() {
-    AssertHelp(
+  @Test func enumerableOptionAsListWithMultipleDefault() async throws {
+    try requireHelp(
       .default,
       for: CustomOptionAsListWithMultipleDefaultValue.self,
       columns: 100,
@@ -1151,8 +1155,8 @@ extension HelpGenerationTests {
     var opt: [OptionValues] = []
   }
 
-  func testEnumerableOptionAsListWithEmptyArrayAsDefault() {
-    AssertHelp(
+  @Test func enumerableOptionAsListWithEmptyArrayAsDefault() async throws {
+    try requireHelp(
       .default,
       for: CustomOptionAsListWithEmptyArrayAsDefault.self,
       columns: 100,
@@ -1175,8 +1179,8 @@ extension HelpGenerationTests {
     var opt: OptionValues = .red
   }
 
-  func testEnumerableOptionValuesWithDefault() {
-    AssertHelp(
+  @Test func enumerableOptionValuesWithDefault() async throws {
+    try requireHelp(
       .default, for: CustomOptionWithDefault.self,
       equals: """
         USAGE: custom-option-with-default [--opt <opt>]
@@ -1196,8 +1200,8 @@ extension HelpGenerationTests {
     @Option(help: "Optional option type.") var optional: OptionValues?
   }
 
-  func testOptionalEnumerableOptionValue() {
-    AssertHelp(
+  @Test func optionalEnumerableOptionValue() async throws {
+    try requireHelp(
       .default, for: Optional.self,
       equals: """
         USAGE: optional [--optional <optional>]
@@ -1217,8 +1221,9 @@ extension HelpGenerationTests {
     @Option var b: OptionValues = .red
   }
 
-  func testEnumerableOptionValue_NoAbstract() {
-    AssertHelp(
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  @Test func enumerableOptionValue_NoAbstract() async throws {
+    try requireHelp(
       .default, for: NoAbstract.self,
       equals: """
         USAGE: no-abstract --a <a> [--b <b>]
@@ -1260,8 +1265,8 @@ extension HelpGenerationTests {
     var b: OptionValues?
   }
 
-  func testEnumerableValuesWithPreamble() {
-    AssertHelp(
+  @Test func enumerableValuesWithPreamble() async throws {
+    try requireHelp(
       .default, for: Preamble.self,
       equals: """
         USAGE: preamble --a <a> [--b <b>]
@@ -1300,8 +1305,8 @@ extension HelpGenerationTests {
     var values: OptionWithoutEnumerationHelpText
   }
 
-  func testOptionHelpTextWithAndWithoutEnumeratedDescriptions() {
-    AssertHelp(
+  @Test func optionHelpTextWithAndWithoutEnumeratedDescriptions() async throws {
+    try requireHelp(
       .default, for: HelpTextComparison.self,
       equals: """
         USAGE: help-text-comparison --enumerable <enumerable> --values <values>
@@ -1336,8 +1341,8 @@ extension HelpGenerationTests {
     @Option(help: "An option with no values.") var empty: Empty
   }
 
-  func testEmptyOptionValues() {
-    AssertHelp(
+  @Test func emptyOptionValues() async throws {
+    try requireHelp(
       .default, for: EmptyCommand.self,
       equals: """
         USAGE: empty-command --empty <empty>
@@ -1380,8 +1385,8 @@ extension HelpGenerationTests {
     var argument: Cases
   }
 
-  func testLongOptionLabelAndDescriptionHelp() {
-    AssertHelp(
+  @Test func longOptionLabelAndDescriptionHelp() async throws {
+    try requireHelp(
       .default, for: LongLabelHelp.self,
       equals: """
         USAGE: long-label-help --argument <argument>
@@ -1414,8 +1419,10 @@ extension HelpGenerationTests {
     var argument: Cases
   }
 
-  func testLongOptionLabelAndDescriptionHelpWithOptionDescription() {
-    AssertHelp(
+  @Test func longOptionLabelAndDescriptionHelpWithOptionDescription()
+    async throws
+  {
+    try requireHelp(
       .default, for: LongLabelHelpWithOptionDescription.self,
       equals: """
         USAGE: long-label-help-with-option-description --argument <argument>
@@ -1445,11 +1452,11 @@ extension HelpGenerationTests {
     var argument: String?
   }
 
-  func testColumnsEnvironmentOverride() throws {
+  @Test func columnsEnvironmentOverride() async throws {
     #if !(os(Windows) || os(WASI))
     defer { Platform.Environment[.columns] = nil }
     Platform.Environment[.columns] = nil
-    AssertHelp(
+    try requireHelp(
       .default, for: WideHelp.self, columns: nil,
       equals: """
         USAGE: wide-help [<argument>]
@@ -1463,7 +1470,7 @@ extension HelpGenerationTests {
         """)
 
     Platform.Environment[.columns, as: Int.self] = 60
-    AssertHelp(
+    try requireHelp(
       .default, for: WideHelp.self, columns: nil,
       equals: """
         USAGE: wide-help [<argument>]
@@ -1478,7 +1485,7 @@ extension HelpGenerationTests {
         """)
 
     Platform.Environment[.columns, as: Int.self] = 79
-    AssertHelp(
+    try requireHelp(
       .default, for: WideHelp.self, columns: nil,
       equals: """
         USAGE: wide-help [<argument>]
@@ -1511,16 +1518,16 @@ extension HelpGenerationTests {
     var arg: String = ""
   }
 
-  func testOptionGroupUsageDoesNotIncludeGroupName() throws {
+  @Test func optionGroupUsageDoesNotIncludeGroupName() async throws {
     // The usage string from --help should not prepend the OptionGroup
     // type name when all arguments are optional (#578).
     let result = try OptionGroupCommand.parseAsRoot(["--help"])
     guard let helpCommand = result as? HelpCommand else {
-      XCTFail("Expected HelpCommand, got \(type(of: result))")
+      Issue.record("Expected HelpCommand, got \(type(of: result))")
       return
     }
     let helpText = helpCommand.generateHelp(screenWidth: 80)
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: helpText,
       expected: """
         USAGE: test [--num <num>] [<arg>]


### PR DESCRIPTION
Migrate all the HelpGenearation unit tests from XCTest to Swift Testing.

Depends on #920
Relates to: #710

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
