### PR TITLE
Migrate String Helpers unit tests to Swift Testing

### DIFF
--- a/Tests/ArgumentParserUnitTests/StringEditDistanceTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringEditDistanceTests.swift
@@ -2,32 +2,30 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
-final class StringEditDistanceTests: XCTestCase {}
-
-extension StringEditDistanceTests {
-  func testStringEditDistance() {
-    XCTAssertEqual("".editDistance(to: ""), 0)
-    XCTAssertEqual("".editDistance(to: "foo"), 3)
-    XCTAssertEqual("foo".editDistance(to: ""), 3)
-    XCTAssertEqual("foo".editDistance(to: "bar"), 3)
-    XCTAssertEqual("bar".editDistance(to: "foo"), 3)
-    XCTAssertEqual("bar".editDistance(to: "baz"), 1)
-    XCTAssertEqual("baz".editDistance(to: "bar"), 1)
-    XCTAssertEqual("friend".editDistance(to: "fresh"), 3)
-    XCTAssertEqual("friend".editDistance(to: "friend"), 0)
-    XCTAssertEqual("friend".editDistance(to: "fried"), 1)
-    XCTAssertEqual("friend".editDistance(to: "friendly"), 2)
-    XCTAssertEqual("friendly".editDistance(to: "friend"), 2)
+@Suite struct StringEditDistanceTests {
+  @Test func stringEditDistance() {
+    #expect("".editDistance(to: "") == 0)
+    #expect("".editDistance(to: "foo") == 3)
+    #expect("foo".editDistance(to: "") == 3)
+    #expect("foo".editDistance(to: "bar") == 3)
+    #expect("bar".editDistance(to: "foo") == 3)
+    #expect("bar".editDistance(to: "baz") == 1)
+    #expect("baz".editDistance(to: "bar") == 1)
+    #expect("friend".editDistance(to: "fresh") == 3)
+    #expect("friend".editDistance(to: "friend") == 0)
+    #expect("friend".editDistance(to: "fried") == 1)
+    #expect("friend".editDistance(to: "friendly") == 2)
+    #expect("friendly".editDistance(to: "friend") == 2)
   }
 }

--- a/Tests/ArgumentParserUnitTests/StringSnakeCaseTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringSnakeCaseTests.swift
@@ -2,22 +2,21 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
 @testable import ArgumentParser
 
-final class StringSnakeCaseTests: XCTestCase {}
-
-extension StringSnakeCaseTests {
-  func testStringSnakeCase() {
-    let toSnakeCaseTests = [
+@Suite
+struct StringSnakeCaseTests {
+  @Test(
+    arguments: [
       ("simpleOneTwo", "simple_one_two"),
       ("myURL", "my_url"),
       ("singleCharacterAtEndX", "single_character_at_end_x"),
@@ -57,13 +56,13 @@ extension StringSnakeCaseTests {
       ("_Sample", "_sample"),
       ("_IAmAnAPPDeveloper", "_i_am_an_app_developer"),
     ]
-    for test in toSnakeCaseTests {
-      XCTAssertEqual(test.0.convertedToSnakeCase(), test.1)
-    }
+  )
+  func stringSnakeCase(value: String, expected: String) {
+    #expect(value.convertedToSnakeCase() == expected)
   }
 
-  func testStringSnakeCaseWithSeparator() {
-    let toSnakeCaseTests = [
+  @Test(
+    arguments: [
       ("simpleOneTwo", "simple-one-two"),
       ("myURL", "my-url"),
       ("singleCharacterAtEndX", "single-character-at-end-x"),
@@ -103,8 +102,8 @@ extension StringSnakeCaseTests {
       ("_Sample", "_-sample"),
       ("_IAmAnAPPDeveloper", "_-i-am-an-app-developer"),
     ]
-    for test in toSnakeCaseTests {
-      XCTAssertEqual(test.0.convertedToSnakeCase(separator: "-"), test.1)
-    }
+  )
+  func stringSnakeCaseWithSeparator(value: String, expected: String) {
+    #expect(value.convertedToSnakeCase(separator: "-") == expected)
   }
 }

--- a/Tests/ArgumentParserUnitTests/StringWrappingTests.swift
+++ b/Tests/ArgumentParserUnitTests/StringWrappingTests.swift
@@ -9,11 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+import Testing
 
 @testable import ArgumentParser
-
-final class StringWrappingTests: XCTestCase {}
 
 let shortSample = """
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lectus proin nibh nisl condimentum id. Semper feugiat nibh sed pulvinar proin gravida hendrerit. Massa id neque aliquam vestibulum morbi blandit cursus risus at. Iaculis urna id volutpat lacus laoreet. Netus et malesuada fames ac turpis egestas sed tempus urna.
@@ -43,183 +41,174 @@ let jsonSample = """
 
 // MARK: -
 
-extension StringWrappingTests {
-  func testShort() {
-    XCTAssertEqual(
-      shortSample.wrapped(to: 40),
-      """
-      Lorem ipsum dolor sit amet, consectetur
-      adipiscing elit, sed do eiusmod tempor
-      incididunt ut labore et dolore magna
-      aliqua. Lectus proin nibh nisl
-      condimentum id. Semper feugiat nibh sed
-      pulvinar proin gravida hendrerit. Massa
-      id neque aliquam vestibulum morbi
-      blandit cursus risus at. Iaculis urna
-      id volutpat lacus laoreet. Netus et
-      malesuada fames ac turpis egestas sed
-      tempus urna.
-      """)
+@Suite struct StringWrappingTests {
+  @Test func short() {
+    #expect(
+      shortSample.wrapped(to: 40) == """
+        Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit, sed do eiusmod tempor
+        incididunt ut labore et dolore magna
+        aliqua. Lectus proin nibh nisl
+        condimentum id. Semper feugiat nibh sed
+        pulvinar proin gravida hendrerit. Massa
+        id neque aliquam vestibulum morbi
+        blandit cursus risus at. Iaculis urna
+        id volutpat lacus laoreet. Netus et
+        malesuada fames ac turpis egestas sed
+        tempus urna.
+        """)
 
-    XCTAssertEqual(
-      shortSample.wrapped(to: 80),
-      """
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-      incididunt ut labore et dolore magna aliqua. Lectus proin nibh nisl condimentum
-      id. Semper feugiat nibh sed pulvinar proin gravida hendrerit. Massa id neque
-      aliquam vestibulum morbi blandit cursus risus at. Iaculis urna id volutpat
-      lacus laoreet. Netus et malesuada fames ac turpis egestas sed tempus urna.
-      """)
+    #expect(
+      shortSample.wrapped(to: 80) == """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+        incididunt ut labore et dolore magna aliqua. Lectus proin nibh nisl condimentum
+        id. Semper feugiat nibh sed pulvinar proin gravida hendrerit. Massa id neque
+        aliquam vestibulum morbi blandit cursus risus at. Iaculis urna id volutpat
+        lacus laoreet. Netus et malesuada fames ac turpis egestas sed tempus urna.
+        """)
   }
 
-  func testShortWithIndent() {
-    XCTAssertEqual(
-      shortSample.wrapped(to: 60, wrappingIndent: 10),
-      """
-                Lorem ipsum dolor sit amet, consectetur
-                adipiscing elit, sed do eiusmod tempor incididunt
-                ut labore et dolore magna aliqua. Lectus proin
-                nibh nisl condimentum id. Semper feugiat nibh sed
-                pulvinar proin gravida hendrerit. Massa id neque
-                aliquam vestibulum morbi blandit cursus risus at.
-                Iaculis urna id volutpat lacus laoreet. Netus et
-                malesuada fames ac turpis egestas sed tempus urna.
-      """)
+  @Test func shortWithIndent() {
+    #expect(
+      shortSample.wrapped(to: 60, wrappingIndent: 10) == """
+                  Lorem ipsum dolor sit amet, consectetur
+                  adipiscing elit, sed do eiusmod tempor incididunt
+                  ut labore et dolore magna aliqua. Lectus proin
+                  nibh nisl condimentum id. Semper feugiat nibh sed
+                  pulvinar proin gravida hendrerit. Massa id neque
+                  aliquam vestibulum morbi blandit cursus risus at.
+                  Iaculis urna id volutpat lacus laoreet. Netus et
+                  malesuada fames ac turpis egestas sed tempus urna.
+        """)
   }
 
-  func testLong() {
-    XCTAssertEqual(
-      longSample.wrapped(to: 40),
-      """
-      Pretium vulputate sapien nec sagittis
-      aliquam malesuada bibendum. Ut diam
-      quam nulla porttitor.
+  @Test func long() {
+    #expect(
+      longSample.wrapped(to: 40) == """
+        Pretium vulputate sapien nec sagittis
+        aliquam malesuada bibendum. Ut diam
+        quam nulla porttitor.
 
-      Egestas egestas fringilla phasellus
-      faucibus. Amet dictum sit amet justo
-      donec enim diam. Consectetur adipiscing
-      elit duis tristique.
+        Egestas egestas fringilla phasellus
+        faucibus. Amet dictum sit amet justo
+        donec enim diam. Consectetur adipiscing
+        elit duis tristique.
 
-      Enim lobortis scelerisque fermentum
-      dui.
+        Enim lobortis scelerisque fermentum
+        dui.
 
-      Et leo duis ut diam quam.
+        Et leo duis ut diam quam.
 
-      Integer eget aliquet nibh praesent
-      tristique magna sit. Faucibus turpis in
-      eu mi bibendum neque egestas congue
-      quisque.       Risus nec feugiat in
-      fermentum posuere urna nec tincidunt.
-      """)
+        Integer eget aliquet nibh praesent
+        tristique magna sit. Faucibus turpis in
+        eu mi bibendum neque egestas congue
+        quisque.       Risus nec feugiat in
+        fermentum posuere urna nec tincidunt.
+        """)
 
-    XCTAssertEqual(
-      longSample.wrapped(to: 80),
-      """
-      Pretium vulputate sapien nec sagittis aliquam malesuada bibendum. Ut diam quam
-      nulla porttitor.
+    #expect(
+      longSample.wrapped(to: 80) == """
+        Pretium vulputate sapien nec sagittis aliquam malesuada bibendum. Ut diam quam
+        nulla porttitor.
 
-      Egestas egestas fringilla phasellus faucibus. Amet dictum sit amet justo donec
-      enim diam. Consectetur adipiscing elit duis tristique.
+        Egestas egestas fringilla phasellus faucibus. Amet dictum sit amet justo donec
+        enim diam. Consectetur adipiscing elit duis tristique.
 
-      Enim lobortis scelerisque fermentum dui.
+        Enim lobortis scelerisque fermentum dui.
 
-      Et leo duis ut diam quam.
+        Et leo duis ut diam quam.
 
-      Integer eget aliquet nibh praesent tristique magna sit. Faucibus turpis in eu
-      mi bibendum neque egestas congue quisque.       Risus nec feugiat in fermentum
-      posuere urna nec tincidunt.
-      """)
+        Integer eget aliquet nibh praesent tristique magna sit. Faucibus turpis in eu
+        mi bibendum neque egestas congue quisque.       Risus nec feugiat in fermentum
+        posuere urna nec tincidunt.
+        """)
   }
 
-  func testLongWithIndent() {
-    XCTAssertEqual(
-      longSample.wrapped(to: 60, wrappingIndent: 10),
-      """
-                Pretium vulputate sapien nec sagittis aliquam
-                malesuada bibendum. Ut diam quam nulla porttitor.
+  @Test func longWithIndent() {
+    #expect(
+      longSample.wrapped(to: 60, wrappingIndent: 10) == """
+                  Pretium vulputate sapien nec sagittis aliquam
+                  malesuada bibendum. Ut diam quam nulla porttitor.
 
-                Egestas egestas fringilla phasellus faucibus.
-                Amet dictum sit amet justo donec enim diam.
-                Consectetur adipiscing elit duis tristique.
+                  Egestas egestas fringilla phasellus faucibus.
+                  Amet dictum sit amet justo donec enim diam.
+                  Consectetur adipiscing elit duis tristique.
 
-                Enim lobortis scelerisque fermentum dui.
+                  Enim lobortis scelerisque fermentum dui.
 
-                Et leo duis ut diam quam.
+                  Et leo duis ut diam quam.
 
-                Integer eget aliquet nibh praesent tristique
-                magna sit. Faucibus turpis in eu mi bibendum
-                neque egestas congue quisque.       Risus nec
-                feugiat in fermentum posuere urna nec tincidunt.
-      """)
-
+                  Integer eget aliquet nibh praesent tristique
+                  magna sit. Faucibus turpis in eu mi bibendum
+                  neque egestas congue quisque.       Risus nec
+                  feugiat in fermentum posuere urna nec tincidunt.
+        """)
   }
 
-  func testJSON() {
-    XCTAssertEqual(
-      jsonSample.wrapped(to: 80),
-      """
-      {
-        "level1": {
-          "level2": {
-            "level3": true
+  @Test func json() {
+    #expect(
+      jsonSample.wrapped(to: 80) == """
+        {
+          "level1": {
+            "level2": {
+              "level3": true
+            }
           }
         }
-      }
-      """)
+        """)
   }
 
-  func testJSONWithIndent() {
-    XCTAssertEqual(
-      jsonSample.wrapped(to: 80, wrappingIndent: 10),
-      """
-                {
-                  "level1": {
-                    "level2": {
-                      "level3": true
+  @Test func jsonWithIndent() {
+    #expect(
+      jsonSample.wrapped(to: 80, wrappingIndent: 10) == """
+                  {
+                    "level1": {
+                      "level2": {
+                        "level3": true
+                      }
                     }
                   }
-                }
-      """)
+        """)
   }
 
-  func testIndent() {
-    XCTAssertEqual(
-      shortSample.wrapped(to: 40).indentingEachLine(by: 10),
-      shortSample.wrapped(to: 50, wrappingIndent: 10))
-    XCTAssertEqual(
-      longSample.wrapped(to: 40).indentingEachLine(by: 10),
-      longSample.wrapped(to: 50, wrappingIndent: 10))
+  @Test func indent() {
+    #expect(
+      shortSample.wrapped(to: 40).indentingEachLine(by: 10)
+        == shortSample.wrapped(to: 50, wrappingIndent: 10))
+    #expect(
+      longSample.wrapped(to: 40).indentingEachLine(by: 10)
+        == longSample.wrapped(to: 50, wrappingIndent: 10))
 
-    XCTAssertEqual("".indentingEachLine(by: 10), "")
-    XCTAssertEqual("\n".indentingEachLine(by: 10), "\n")
-    XCTAssertEqual("a\n".indentingEachLine(by: 10), "          a\n")
-    XCTAssertEqual("\na\n".indentingEachLine(by: 10), "\n          a\n")
-    XCTAssertEqual(
-      "a\n\nb\n".indentingEachLine(by: 10),
-      "          a\n\n          b\n")
-    XCTAssertEqual(
-      "\na\n\nb\n".indentingEachLine(by: 10),
-      "\n          a\n\n          b\n")
+    #expect("".indentingEachLine(by: 10) == "")
+    #expect("\n".indentingEachLine(by: 10) == "\n")
+    #expect("a\n".indentingEachLine(by: 10) == "          a\n")
+    #expect("\na\n".indentingEachLine(by: 10) == "\n          a\n")
+    #expect(
+      "a\n\nb\n".indentingEachLine(by: 10)
+        == "          a\n\n          b\n")
+    #expect(
+      "\na\n\nb\n".indentingEachLine(by: 10)
+        == "\n          a\n\n          b\n")
   }
 
-  func testHangingIndent() {
-    XCTAssertEqual(
-      shortSample.wrapped(to: 40).hangingIndentingEachLine(by: 10),
-      String(shortSample.wrapped(to: 50, wrappingIndent: 10).dropFirst(10)))
-    XCTAssertEqual(
-      longSample.wrapped(to: 40).hangingIndentingEachLine(by: 10),
-      String(longSample.wrapped(to: 50, wrappingIndent: 10).dropFirst(10)))
+  @Test func hangingIndent() {
+    #expect(
+      shortSample.wrapped(to: 40).hangingIndentingEachLine(by: 10)
+        == String(shortSample.wrapped(to: 50, wrappingIndent: 10).dropFirst(10))
+    )
+    #expect(
+      longSample.wrapped(to: 40).hangingIndentingEachLine(by: 10)
+        == String(longSample.wrapped(to: 50, wrappingIndent: 10).dropFirst(10)))
 
-    XCTAssertEqual("".hangingIndentingEachLine(by: 10), "")
-    XCTAssertEqual("\n".hangingIndentingEachLine(by: 10), "\n")
-    XCTAssertEqual("a\n".hangingIndentingEachLine(by: 10), "a\n")
-    XCTAssertEqual("\na\n".hangingIndentingEachLine(by: 10), "\n          a\n")
-    XCTAssertEqual(
-      "a\n\nb\n".hangingIndentingEachLine(by: 10),
-      "a\n\n          b\n")
-    XCTAssertEqual(
-      "\na\n\nb\n".hangingIndentingEachLine(by: 10),
-      "\n          a\n\n          b\n")
-
+    #expect("".hangingIndentingEachLine(by: 10) == "")
+    #expect("\n".hangingIndentingEachLine(by: 10) == "\n")
+    #expect("a\n".hangingIndentingEachLine(by: 10) == "a\n")
+    #expect("\na\n".hangingIndentingEachLine(by: 10) == "\n          a\n")
+    #expect(
+      "a\n\nb\n".hangingIndentingEachLine(by: 10)
+        == "a\n\n          b\n")
+    #expect(
+      "\na\n\nb\n".hangingIndentingEachLine(by: 10)
+        == "\n          a\n\n          b\n")
   }
 }


### PR DESCRIPTION
Migrate a few String related unit test suites from XCTest to Swift Testing.

Relates to: #710

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
