### PR TITLE
Add experimental source-location dump argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 - `CommandConfiguration` now accepts a `helpBanner`, a string printed verbatim above the overview on a command's help screen and inherited by its subcommands unless they provide their own banner or the empty string.
 - Commands can now opt in to response-file expansion by setting the `responseFilePrefix` property on their `CommandConfiguration` to the character that should introduce a response-file reference (for example, `static let configuration = CommandConfiguration(responseFilePrefix: "@")`). The property defaults to `nil`, meaning response-file expansion is disabled unless the root command opts in.
+- Added the experimental `--experimental-dump-arguments-source-location` option. When present, the parser fully parses the command line and then prints every parsed argument together with its value and source location (file:line for response-file args, `argv[N]` for command-line args), organized as a subcommand tree. Accepts `=text` (default) or `=json`.
 
 ---
 

--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(ArgumentParser
   Usage/HelpCommand.swift
   Usage/HelpGenerator.swift
   Usage/MessageInfo.swift
+  Usage/SourceLocationDumpGenerator.swift
   Usage/UsageGenerator.swift
 
   Utilities/CollectionExtensions.swift

--- a/Sources/ArgumentParser/Documentation.docc/Articles/ExperimentalFeatures.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/ExperimentalFeatures.md
@@ -13,7 +13,10 @@ If you have any feedback on experimental features, please [open a GitHub issue][
 | Name | Description | related PRs | Version |
 | ------------- | ------------- | ------------- | ------------- |
 | `--experimental-dump-help`  | Dumps command/argument/help information as JSON | [#310][] [#335][] | 0.5.0 or newer |
+| `--experimental-dump-arguments-source-location`  | Dumps the parsed argument tree with each value's source location (file:line for response-file args, `argv[N]` for command-line args). Accepts `=text` (default) or `=json`. | [#909][] | Unreleased |
+
 
 [#310]: https://github.com/apple/swift-argument-parser/pull/310
 [#335]: https://github.com/apple/swift-argument-parser/pull/335
-[issue]: https://github.com/apple/swift-argument-parser/issues/new/choose 
+[issue]: https://github.com/apple/swift-argument-parser/issues/new/choose
+[#909]: https://github.com/apple/swift-argument-parser/pull/909

--- a/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
+++ b/Sources/ArgumentParser/Parsing/ArgumentDecoder.swift
@@ -17,6 +17,13 @@
 struct DecodedArguments {
   var type: ParsableArguments.Type
   var value: ParsableArguments
+  /// The parsed values used to decode `value`.
+  ///
+  /// Populated when this entry was decoded directly by
+  /// `CommandParser.parseCurrent`; `nil` for entries that surfaced
+  /// indirectly (e.g., `@OptionGroup` members previously decoded by the
+  /// same `ArgumentDecoder`).
+  var parsedValues: ParsedValues? = nil
 
   var commandType: ParsableCommand.Type? {
     type as? ParsableCommand.Type

--- a/Sources/ArgumentParser/Parsing/CommandParser.swift
+++ b/Sources/ArgumentParser/Parsing/CommandParser.swift
@@ -255,7 +255,10 @@ extension CommandParser {
       }
     decodedArguments.append(contentsOf: newDecodedValues)
     decodedArguments.append(
-      DecodedArguments(type: currentNode.element, value: decodedResult)
+      DecodedArguments(
+        type: currentNode.element,
+        value: decodedResult,
+        parsedValues: values)
     )
 
     return decodedResult
@@ -421,7 +424,29 @@ extension CommandParser {
     do {
       try checkForCompletionScriptRequest(&split)
       try descendingParse(&split)
+
+      // Detect & consume the dump-source-location option from any
+      // unconsumed split entries so it does not trigger an unknown-option
+      // error in `extractLastParsedValue`. If parsing fails for any
+      // *other* reason (e.g., an unknown `--bogus`), that failure takes
+      // precedence — we still throw the dump only on the success path.
+      let dumpFormat = consumeDumpSourceLocationOption(from: &split)
+
       let result = try extractLastParsedValue(split)
+
+      if let format = dumpFormat {
+        let text = SourceLocationDumpGenerator(
+          commandStack: commandStack,
+          decodedArguments: decodedArguments,
+          formattingContext: formattingContext,
+          format: format
+        ).rendered()
+        throw CommandError(
+          commandStack: commandStack,
+          parserError: .dumpArgumentsSourceLocationRequested(text),
+          formattingContext: formattingContext
+        )
+      }
 
       // HelpCommand is a valid result, but needs extra information about
       // the tree from the parser to build its stack of commands.
@@ -687,6 +712,48 @@ extension CommandParser {
     return path.isEmpty
       ? [commandTree.element]
       : path
+  }
+}
+
+// MARK: - Source-Location Dump Option
+
+extension CommandParser {
+  /// The long name of the experimental dump-source-location option.
+  fileprivate static let dumpSourceLocationOptionName =
+    Name.long("experimental-dump-arguments-source-location")
+
+  /// Scans `split` for the dump-source-location option, removes any
+  /// matching elements, and returns the requested output format.
+  ///
+  /// Returns `nil` if the option is not present. Throws if the option
+  /// appears with an unrecognized value (e.g., `=yaml`).
+  fileprivate func consumeDumpSourceLocationOption(
+    from split: inout SplitArguments
+  ) -> SourceLocationDumpFormat? {
+    var format: SourceLocationDumpFormat?
+    var matches: [SplitArguments.Index] = []
+
+    for element in split.elements {
+      switch element.value {
+      case .option(.name(Self.dumpSourceLocationOptionName)):
+        format = .text
+        matches.append(element.index)
+      case .option(
+        .nameWithValue(Self.dumpSourceLocationOptionName, let value)
+      ):
+        format = SourceLocationDumpFormat(rawValue: value) ?? .text
+        matches.append(element.index)
+      default:
+        continue
+      }
+    }
+
+    // Remove matches in reverse so earlier indices remain valid.
+    for index in matches.reversed() {
+      split.remove(at: index)
+    }
+
+    return format
   }
 }
 

--- a/Sources/ArgumentParser/Parsing/InputOrigin.swift
+++ b/Sources/ArgumentParser/Parsing/InputOrigin.swift
@@ -227,9 +227,91 @@ extension InputOrigin.ResponseFileStep: Comparable {
   }
 }
 
-// MARK: - Response File Chain
+// MARK: - Codable
 
-extension InputOrigin.Element {
+extension InputOrigin.ResponseFileStep: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case path, line, argvIndex
+  }
+  /// Sentinel `path` value that indicates an argv step (as opposed to
+  /// a real filesystem path).
+  private static let argvPathSentinel = "argv"
+
+  func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .file(let path, let line):
+      try c.encode(path, forKey: .path)
+      try c.encode(line, forKey: .line)
+    case .argv(let index):
+      try c.encode(Self.argvPathSentinel, forKey: .path)
+      try c.encode(index, forKey: .argvIndex)
+    }
+  }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let path = try c.decode(String.self, forKey: .path)
+    if path == Self.argvPathSentinel {
+      let index = try c.decode(Int.self, forKey: .argvIndex)
+      self = .argv(index: index)
+    } else {
+      let line = try c.decode(Int.self, forKey: .line)
+      self = .file(path: path, line: line)
+    }
+  }
+}
+
+extension InputOrigin.Element: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case kind, argvIndex, chain
+  }
+  private enum Kind: String, Codable {
+    case `default`
+    case commandLine
+    case responseFile
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .defaultValue:
+      try c.encode(Kind.default, forKey: .kind)
+
+    case .argumentIndex(let idx):
+      try c.encode(Kind.commandLine, forKey: .kind)
+      try c.encode(idx.inputIndex.rawValue, forKey: .argvIndex)
+
+    case .responseFile:
+      try c.encode(Kind.responseFile, forKey: .kind)
+      try c.encode(chainAsSteps(), forKey: .chain)
+    }
+  }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let kind = try c.decode(Kind.self, forKey: .kind)
+    switch kind {
+    case .default:
+      self = .defaultValue
+    case .commandLine:
+      let raw = try c.decode(Int.self, forKey: .argvIndex)
+      let index = SplitArguments.Index(
+        inputIndex: SplitArguments.InputIndex(rawValue: raw))
+      self = .argumentIndex(index)
+    case .responseFile:
+      let steps = try c.decode(
+        [InputOrigin.ResponseFileStep].self, forKey: .chain)
+      guard !steps.isEmpty else {
+        throw DecodingError.dataCorruptedError(
+          forKey: .chain,
+          in: c,
+          debugDescription: "responseFile chain must be non-empty")
+      }
+      self = Self.rebuild(fromSteps: steps)
+    }
+  }
+
   /// Walks the linked `.responseFile` list and produces a flat array of
   /// steps from innermost to outermost.
   ///
@@ -248,5 +330,35 @@ extension InputOrigin.Element {
       steps.append(.argv(index: idx.inputIndex.rawValue))
     }
     return steps
+  }
+
+  /// Inverse of `chainAsSteps()`: folds a flat step array into a nested
+  /// `.responseFile(step:referencedFrom:)` linked list.
+  fileprivate static func rebuild(
+    fromSteps steps: [InputOrigin.ResponseFileStep]
+  ) -> InputOrigin.Element {
+    // The last step is expected to be `.argv(_)` — the argv terminator.
+    // Any file steps before it become nested `.responseFile` wrappers.
+    var iterator = steps.makeIterator()
+    var reversed: [InputOrigin.ResponseFileStep] = []
+    while let step = iterator.next() { reversed.append(step) }
+
+    let terminator: InputOrigin.Element
+    if let last = reversed.last, case .argv(let idx) = last {
+      terminator = .argumentIndex(
+        SplitArguments.Index(
+          inputIndex: SplitArguments.InputIndex(rawValue: idx)))
+      reversed.removeLast()
+    } else {
+      // Malformed chain (no argv terminator). Best effort: use
+      // `.defaultValue` as the terminator so decoding succeeds.
+      terminator = .defaultValue
+    }
+
+    var current = terminator
+    for step in reversed.reversed() {
+      current = .responseFile(step: step, referencedFrom: current)
+    }
+    return current
   }
 }

--- a/Sources/ArgumentParser/Parsing/ParserError.swift
+++ b/Sources/ArgumentParser/Parsing/ParserError.swift
@@ -20,6 +20,10 @@ enum ParserError: Error {
   case helpRequested(visibility: ArgumentVisibility)
   case versionRequested
   case dumpHelpRequested
+  /// The dump of the parsed arguments' source locations is requested.
+  /// The associated `String` is the fully-rendered dump text (text or JSON
+  /// per the requested format) ready to be displayed to the user.
+  case dumpArgumentsSourceLocationRequested(String)
 
   case completionScriptRequested(shell: String?)
   case completionScriptCustomResponse(String)

--- a/Sources/ArgumentParser/Usage/MessageInfo.swift
+++ b/Sources/ArgumentParser/Usage/MessageInfo.swift
@@ -39,6 +39,12 @@ enum MessageInfo {
           text: DumpHelpGenerator(commandStack: e.commandStack).rendered())
         return
 
+      case .dumpArgumentsSourceLocationRequested(let text):
+        // The parser pre-renders the dump text so that `MessageInfo` doesn't
+        // need access to the parsed-value tree itself.
+        self = .help(text: text)
+        return
+
       case .versionRequested:
         let versionString =
           commandStack

--- a/Sources/ArgumentParser/Usage/SourceLocationDumpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/SourceLocationDumpGenerator.swift
@@ -1,0 +1,387 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// Output format for the `--experimental-dump-arguments-source-location` option.
+///
+/// Text is the default when the option is provided without a value
+/// (i.e., the `defaultAsFlag` mode).
+enum SourceLocationDumpFormat: String {
+  case text
+  case json
+}
+
+/// Renders the parsed-argument tree with each value's source location.
+///
+/// Walks the command stack from root to leaf, listing each argument
+/// definition together with its parsed value and origin. Argv-origin
+/// arguments report their argv index; response-file-origin arguments
+/// report the full include chain (innermost file first, outermost argv
+/// last).
+struct SourceLocationDumpGenerator {
+  var commandStack: [ParsableCommand.Type]
+  var decodedArguments: [DecodedArguments]
+  var formattingContext: InputOrigin.FormattingContext
+  var format: SourceLocationDumpFormat
+
+  func rendered() -> String {
+    guard let root = buildCommandNode(stack: commandStack[...]) else {
+      return ""
+    }
+    switch format {
+    case .text: return renderText(root: root)
+    case .json: return renderJSON(root: root)
+    }
+  }
+}
+
+// MARK: - Model (also the JSON schema via Codable)
+
+extension SourceLocationDumpGenerator {
+  /// A single value parsed for one argument.
+  ///
+  /// The struct's field names double as the JSON schema — no separate
+  /// translation layer. Access is internal so consumers (including test
+  /// code) can decode the emitted JSON back into these typed values.
+  struct ValueEntry: Codable {
+    let value: String
+    let source: InputOrigin.Element
+
+    /// Whether this entry represents the property's default (nothing was bound from the command line).
+    ///
+    /// Derived from `source` — not encoded.
+    var isDefault: Bool {
+      if case .defaultValue = source { return true }
+      return false
+    }
+
+    private enum CodingKeys: String, CodingKey { case value, source }
+  }
+
+  /// One argument (option/flag/positional) with all of its parsed values.
+  struct ArgumentEntry: Codable {
+    let name: String
+    let values: [ValueEntry]
+  }
+
+  /// One command-level node in the tree.
+  ///
+  /// Encoded shape: `{"command": ..., "arguments": [...], "subcommand": {...}?}`.
+  struct CommandNode: Codable {
+    let command: String
+    let arguments: [ArgumentEntry]
+    let subcommand: Indirect<CommandNode>?
+  }
+
+  /// Reference-typed single-value box that lets `CommandNode` recurse (a struct can't hold a stored property that transitively contains itself).
+  ///
+  /// Encodes as the wrapped value directly.
+  final class Indirect<Wrapped: Codable>: Codable {
+    let value: Wrapped
+    init(_ value: Wrapped) { self.value = value }
+
+    func encode(to encoder: Encoder) throws {
+      var c = encoder.singleValueContainer()
+      try c.encode(value)
+    }
+
+    required init(from decoder: Decoder) throws {
+      let c = try decoder.singleValueContainer()
+      self.value = try c.decode(Wrapped.self)
+    }
+  }
+}
+
+// MARK: - Build
+
+extension SourceLocationDumpGenerator {
+  /// Walks the command stack tail-first and builds a nested `CommandNode` tree.
+  ///
+  /// Returns `nil` when the stack is empty.
+  fileprivate func buildCommandNode(
+    stack: ArraySlice<ParsableCommand.Type>
+  ) -> CommandNode? {
+    guard let type = stack.first else { return nil }
+    let decoded = decodedArguments.first(where: { $0.type == type })
+    let parsedValues = decoded?.parsedValues
+    let argSet = ArgumentSet(type, visibility: .default, parent: nil)
+
+    var args: [ArgumentEntry] = []
+    var seenKeys: Set<InputKey> = []
+    for def in argSet {
+      let key = def.help.keys.first ?? def.help.keys[0]
+      if seenKeys.contains(key) { continue }
+      seenKeys.insert(key)
+
+      // Prefer the long-form name for display so the dump is readable
+      // even when the property declares `[.short, .long]` (where
+      // `.short` sorts first). Fall back to whatever we have.
+      let displayName: String
+      let longName = def.names.first {
+        switch $0 {
+        case .long, .longWithSingleDash: return true
+        case .short: return false
+        }
+      }
+      if let chosen = longName ?? def.names.first {
+        displayName = chosen.synopsisString
+      } else {
+        displayName = "<\(def.valueName)>"
+      }
+
+      let element = parsedValues?.element(forKey: key)
+      let values = renderedValues(for: element, defaultFromHelp: def)
+      args.append(.init(name: displayName, values: values))
+    }
+
+    let subcommand = buildCommandNode(stack: stack.dropFirst()).map {
+      Indirect($0)
+    }
+    return CommandNode(
+      command: type._commandName,
+      arguments: args,
+      subcommand: subcommand)
+  }
+
+  /// Renders the value(s) for one argument key.
+  ///
+  /// Splits arrays into one entry per element so each gets its own source.
+  fileprivate func renderedValues(
+    for element: ParsedValues.Element?,
+    defaultFromHelp def: ArgumentDefinition
+  ) -> [ValueEntry] {
+    guard let element = element, let raw = element.value else {
+      return [
+        .init(
+          value: def.help.defaultValue.map(formatRaw) ?? "nil",
+          source: .defaultValue)
+      ]
+    }
+
+    let origins = element.inputOrigin.elements.filter {
+      if case .argumentIndex = $0 { return true }
+      return false
+    }
+
+    // If nothing was parsed from argv, treat this as a default. Covers
+    // both scalars whose element was populated only from the property's
+    // default and arrays whose declared default (e.g., `[]`) fired.
+    if origins.isEmpty {
+      return [
+        .init(
+          value: def.help.defaultValue.map(formatRaw) ?? formatRaw(raw),
+          source: .defaultValue)
+      ]
+    }
+
+    if let array = raw as? [Any] {
+      // Sort origins by argv position so we can pair them with values in
+      // their input order.
+      let sortedOrigins = origins.sorted()
+
+      // Positional array (`@Argument var files: [String]`) — each value
+      // has exactly one origin (its own token). One-to-one match.
+      if !array.isEmpty, sortedOrigins.count == array.count {
+        return zip(array, sortedOrigins).map { (v, origin) in
+          .init(
+            value: formatRaw(v),
+            source: classifySource(origin: origin))
+        }
+      }
+
+      // Repeating named option (`@Option var tags: [String]`). Origins
+      // include both option-name tokens (`--tag`) and value tokens
+      // (a bare value or an attached `--tag=v`). Keep only the
+      // value-carrying origins so the count matches the array.
+      let valueOrigins = sortedOrigins.filter(isValueCarryingOrigin)
+      if !array.isEmpty, valueOrigins.count == array.count {
+        return zip(array, valueOrigins).map { (v, origin) in
+          .init(
+            value: formatRaw(v),
+            source: classifySource(origin: origin))
+        }
+      }
+
+      // Fallback for shapes we don't recognize (e.g., joined `-D`-style
+      // parsing where origins may not have a clean 1:1 or 2:1 mapping).
+      // Attach the last (max-argv) origin to each entry rather than
+      // lose information.
+      return array.map { v in
+        .init(
+          value: formatRaw(v),
+          source: sortedOrigins.last.map(classifySource(origin:))
+            ?? .defaultValue)
+      }
+    }
+
+    // Scalar. Use the last origin — for a `--name value` pair the input
+    // origin records both tokens; the value token is at the later index.
+    if let origin = origins.last {
+      return [
+        .init(value: formatRaw(raw), source: classifySource(origin: origin))
+      ]
+    }
+    return [.init(value: formatRaw(raw), source: .defaultValue)]
+  }
+
+  /// Returns `true` if the argv token at this origin's position carries a value: either a bare value token, or an option-with-value like `--name=foo`.
+  ///
+  /// Bare option-name tokens (`--name`) return `false`.
+  fileprivate func isValueCarryingOrigin(
+    _ origin: InputOrigin.Element
+  ) -> Bool {
+    // Sub-indexed origins (unpacked short options) are always name-only.
+    guard case .argumentIndex(let idx) = origin,
+      case .complete = idx.subIndex,
+      let token = formattingContext.rawToken(at: origin)
+    else {
+      return false
+    }
+    if token.contains("=") { return true }
+    if token.hasPrefix("-") && token.count > 1 { return false }
+    return true
+  }
+
+  /// Turns a raw argv origin into the `InputOrigin.Element` value that
+  /// belongs in a `ValueEntry.source`.
+  ///
+  /// If the parser recorded a response-file include chain, the result
+  /// is a nested `.responseFile(step:referencedFrom:)` linked list
+  /// terminated by an `.argumentIndex` at the outermost argv position.
+  /// Argv-only origins return an `.argumentIndex` whose input index is
+  /// the *pre-expansion* argv index recorded on the chain — that's the
+  /// position in the user-typed argv, not the internal post-expansion
+  /// slot.
+  fileprivate func classifySource(
+    origin: InputOrigin.Element
+  ) -> InputOrigin.Element {
+    guard case .argumentIndex = origin,
+      let chain = formattingContext.responseFileChain(for: origin)
+    else {
+      return origin
+    }
+    let hasFile = chain.contains {
+      if case .file = $0 { return true } else { return false }
+    }
+    if hasFile {
+      return foldChainIntoElement(chain)
+    }
+    // Argv-only chain: use the argv step so the encoded index reflects
+    // the pre-expansion argv position.
+    if case .argv(let idx) = chain.first {
+      return .argumentIndex(
+        SplitArguments.Index(
+          inputIndex: SplitArguments.InputIndex(rawValue: idx)))
+    }
+    return origin
+  }
+
+  /// Folds a flat include-chain step array into a nested
+  /// `.responseFile(step:referencedFrom:)` linked list.
+  ///
+  /// The last step is expected to be `.argv(_)` — it becomes the
+  /// `.argumentIndex(_)` terminator.
+  fileprivate func foldChainIntoElement(
+    _ chain: [InputOrigin.ResponseFileStep]
+  ) -> InputOrigin.Element {
+    guard let last = chain.last, case .argv(let idx) = last else {
+      return .defaultValue
+    }
+    var current: InputOrigin.Element = .argumentIndex(
+      SplitArguments.Index(
+        inputIndex: SplitArguments.InputIndex(rawValue: idx)))
+    for step in chain.dropLast().reversed() {
+      current = .responseFile(step: step, referencedFrom: current)
+    }
+    return current
+  }
+
+  fileprivate func formatRaw(_ value: Any) -> String {
+    if let s = value as? String { return "\"\(s)\"" }
+    if let b = value as? Bool { return b ? "true" : "false" }
+    return String(describing: value)
+  }
+}
+
+// MARK: - Text rendering
+
+extension SourceLocationDumpGenerator {
+  fileprivate func renderText(root: CommandNode) -> String {
+    var lines: [String] = []
+    renderTextCommand(node: root, depth: 0, into: &lines)
+    return lines.joined(separator: "\n")
+  }
+
+  fileprivate func renderTextCommand(
+    node: CommandNode,
+    depth: Int,
+    into lines: inout [String]
+  ) {
+    let indent = String(repeating: "    ", count: depth)
+    if depth == 0 {
+      lines.append(node.command)
+    } else {
+      lines.append("\(indent)\(node.command)  (subcommand)")
+    }
+
+    let childIndent = String(repeating: "    ", count: depth + 1)
+    let hasSubcommand = node.subcommand != nil
+    for (idx, arg) in node.arguments.enumerated() {
+      let isLastArg = idx == node.arguments.count - 1 && !hasSubcommand
+      let connector = isLastArg ? "└── " : "├── "
+      let leafPrefix = childIndent + connector
+
+      if arg.values.isEmpty {
+        lines.append("\(leafPrefix)\(arg.name)")
+        continue
+      }
+      for (vidx, value) in arg.values.enumerated() {
+        let label =
+          vidx == 0
+          ? "\(arg.name) = \(value.value)"
+          : "\(arg.name)[\(vidx)] = \(value.value)"
+
+        if value.isDefault {
+          lines.append("\(leafPrefix)\(label)   (default)")
+          continue
+        }
+
+        lines.append("\(leafPrefix)\(label)")
+        let metaIndent = childIndent + "      "
+        // Walk the source's chain directly — the linked list carries
+        // the whole ancestry.
+        let steps = value.source.chainAsSteps()
+        for (i, step) in steps.enumerated() {
+          let prefix = i == 0 ? "at " : "included from "
+          lines.append("\(metaIndent)\(prefix)\(formatStep(step))")
+        }
+      }
+    }
+
+    if let next = node.subcommand?.value {
+      renderTextCommand(node: next, depth: depth + 1, into: &lines)
+    }
+  }
+
+  fileprivate func formatStep(_ step: InputOrigin.ResponseFileStep) -> String {
+    switch step {
+    case .file(let path, let line): return "\(path):\(line)"
+    case .argv(let index): return "argv[\(index)]"
+    }
+  }
+}
+
+// MARK: - JSON rendering
+
+extension SourceLocationDumpGenerator {
+  fileprivate func renderJSON(root: CommandNode) -> String {
+    JSONEncoder.encode(root)
+  }
+}

--- a/Sources/ArgumentParser/Usage/UsageGenerator.swift
+++ b/Sources/ArgumentParser/Usage/UsageGenerator.swift
@@ -210,7 +210,8 @@ extension ErrorMessageGenerator {
   func makeErrorMessage() -> String? {
     switch error {
     case .helpRequested, .versionRequested, .completionScriptRequested,
-      .completionScriptCustomResponse, .dumpHelpRequested:
+      .completionScriptCustomResponse, .dumpHelpRequested,
+      .dumpArgumentsSourceLocationRequested:
       return nil
 
     case .unsupportedShell(let shell?):

--- a/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
+++ b/Tests/ArgumentParserEndToEndTests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(EndToEndTests
   ShortNameEndToEndTests.swift
   SimpleEndToEndTests.swift
   SingleValueParsingStrategyTests.swift
+  SourceLocationDumpEndToEndTests.swift
   SourceLocationEndToEndTestSupport.swift
   SourceLocationErrorEndToEndTests.swift
   SubcommandEndToEndTests.swift

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -419,17 +419,17 @@ private func time(_ body: () -> Void) -> TimeInterval {
 extension RepeatingEndToEndTests {
   // A regression test against array parsing performance going non-linear.
   @Test func parsing_repeatingPerformance() throws {
-    let timeFor20 = time {
+    let timeFor100 = time {
       expectParse(PerformanceTest.self, argumentGenerator(100)) { test in
         #expect(test.bundleIdentifiers.count == 100)
       }
     }
-    let timeFor40 = time {
+    let timeFor200 = time {
       expectParse(PerformanceTest.self, argumentGenerator(200)) { test in
         #expect(test.bundleIdentifiers.count == 200)
       }
     }
 
-    #expect(timeFor40 < timeFor20 * 10)
+    #expect(timeFor200 < timeFor100 * 10)
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/SourceLocationDumpEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceLocationDumpEndToEndTests.swift
@@ -1,0 +1,1013 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParserTestHelpers
+import Foundation
+import Testing
+
+@testable import ArgumentParser
+
+// Behavior tests of `--experimental-dump-arguments-source-location`.
+//
+// These tests drive a sample command with the new option and assert on the
+// emitted dump output (text + JSON).
+//
+// They are expected to FAIL today: the option does not exist yet, so today
+// `T.parse([...])` throws an `Unknown option` error instead of producing
+// the dump.  Once Phase C of the plan lands, parsing the option throws a
+// `dumpArgumentsSourceLocationRequested(format:)` parser error which the
+// framework converts to a clean-exit help message containing the dump.
+//
+// Message-extraction helpers live in
+// `SourceLocationEndToEndTestSupport.swift`.
+
+@Suite struct SourceLocationDumpEndToEndTests {
+
+  /// Decode the dump output into the typed production model.
+  ///
+  /// Returns `nil` if the input isn't valid JSON for the schema.
+  fileprivate func decodeDump(
+    _ raw: String
+  ) -> SourceLocationDumpGenerator.CommandNode? {
+    guard let data = raw.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(
+      SourceLocationDumpGenerator.CommandNode.self, from: data)
+  }
+}
+
+// MARK: - Typed accessors for the dump wire format
+//
+// The generator's `CommandNode`/`ArgumentEntry`/`ValueEntry` types double
+// as the JSON schema. `@testable import ArgumentParser` gives us access
+// to them; these extensions add test-only convenience accessors.
+
+extension SourceLocationDumpGenerator.CommandNode {
+  /// First argument entry whose display name contains any of `candidates`.
+  ///
+  /// Preserves the existing lookup-by-substring semantics.
+  fileprivate func firstArgument(
+    matching candidates: [String]
+  ) -> SourceLocationDumpGenerator.ArgumentEntry? {
+    arguments.first { arg in
+      candidates.contains { arg.name.contains($0) }
+    }
+  }
+}
+
+extension SourceLocationDumpGenerator.ArgumentEntry {
+  /// Convenience for scalar arguments — the single value entry.
+  fileprivate var firstValue: SourceLocationDumpGenerator.ValueEntry? {
+    values.first
+  }
+}
+
+extension SourceLocationDumpGenerator.ValueEntry {
+  /// The argv index this value's source resolves to, or `nil` if the
+  /// source isn't an argv origin (i.e., it's `.defaultValue` or
+  /// `.responseFile(_,_)`).
+  fileprivate var argvIndex: Int? {
+    if case .argumentIndex(let idx) = source {
+      return idx.inputIndex.rawValue
+    }
+    return nil
+  }
+
+  /// The flattened chain of response-file steps for a response-file
+  /// origin, or `nil` if the source isn't `.responseFile(_,_)`.
+  fileprivate var responseFileChain: [InputOrigin.ResponseFileStep]? {
+    if case .responseFile = source { return source.chainAsSteps() }
+    return nil
+  }
+}
+
+// MARK: - Test Commands
+
+private struct DumpRoot: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "tool",
+    subcommands: [DumpDeploy.self]
+  )
+
+  @Flag(name: .long) var globalFlag = false
+}
+
+private struct DumpDeploy: ParsableCommand {
+  static let configuration = CommandConfiguration(commandName: "deploy")
+
+  @Option var env: String
+  @Option var count: Int = 1
+  @Argument var target: String
+}
+
+private struct DumpSimple: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "simple",
+    responseFilePrefix: "@"
+  )
+
+  @Option var name: String
+  @Option var count: Int = 1
+}
+
+private struct DumpArrayCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(commandName: "array")
+
+  /// Repeatable named option — each value pair `--tag X` contributes one
+  /// element, and each element should carry the argv index of its own
+  /// value (not the option name, and not the aggregate origin of the
+  /// whole array).
+  @Option(name: .customLong("tag")) var tags: [String] = []
+
+  /// Positional array — each value has its own argv index.
+  @Argument var files: [String] = []
+}
+
+/// Kitchen-sink command exercising the full matrix of argument shapes.
+private struct DumpKitchenSink: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "kitchen",
+    responseFilePrefix: "@"
+  )
+
+  // Scalar option with both short and long names.
+  @Option(name: [.short, .long]) var name: String
+
+  // Typed scalar option.
+  @Option var count: Int = 0
+
+  // Boolean flag with both a short and long name — can be packed with
+  // another short flag.
+  @Flag(name: [.short, .long]) var verbose = false
+
+  // Boolean flag with a short name — for testing packed short options.
+  @Flag(name: [.short, .long]) var force = false
+
+  // Repeatable named option.
+  @Option(name: .customLong("tag")) var tags: [String] = []
+
+  // `defaultAsFlag` option — three invocation shapes:
+  //   • omitted                    → property is nil (no origin)
+  //   • `--log-level` (bare)       → property = "info" (the flag default)
+  //   • `--log-level=<value>`      → property = <value>
+  //
+  // Using `.next` (rather than the `defaultAsFlag` default of
+  // `.scanningForValue`) so that a bare `--log-level` does NOT read
+  // ahead past subsequent option tokens looking for a value.
+  @Option(
+    name: .customLong("log-level"),
+    defaultAsFlag: "info",
+    parsing: .next
+  ) var logLevel: String? = nil
+
+  // Positional (single required).
+  @Argument var target: String
+
+  // Positional array (captures the rest).
+  @Argument var extras: [String] = []
+}
+
+// MARK: - Text format (default via `defaultAsFlag`)
+
+extension SourceLocationDumpEndToEndTests {
+
+  @Test func textTopLevelCommandArgvOnlyRendersCommandHeader() async throws {
+    let out = try fullMessage(
+      for: DumpSimple.self,
+      arguments: [
+        "--name", "alpha", "--experimental-dump-arguments-source-location",
+      ])
+
+    #expect(
+      out.contains("simple"),
+      "Text dump should begin with the command name: got \(out)")
+    #expect(
+      out.contains("--name"),
+      "Text dump should list the --name option: got \(out)")
+    #expect(
+      out.contains("alpha"),
+      "Text dump should include the value `alpha`: got \(out)")
+    #expect(
+      out.contains("argv["),
+      "Text dump should reference an argv index for argv-origin args: \(out)")
+  }
+
+  @Test func textArgvOnlyMarksDefaultValuedProperty() async throws {
+    // `count` defaults to 1 and is not on the command line, so the dump
+    // should mark it as `(default)`.
+    let out = try fullMessage(
+      for: DumpSimple.self,
+      arguments: [
+        "--name", "alpha", "--experimental-dump-arguments-source-location",
+      ])
+
+    #expect(
+      out.contains("--count"),
+      "Default-valued options should still appear in the dump: \(out)")
+    #expect(
+      out.contains("(default)"),
+      "Default-valued options should be tagged `(default)`: \(out)")
+  }
+
+  @Test func textSubcommandRendersAsNestedNode() async throws {
+    let out = try fullMessage(
+      for: DumpRoot.self,
+      arguments: [
+        "--global-flag",
+        "deploy",
+        "--env", "prod",
+        "target1",
+        "--experimental-dump-arguments-source-location",
+      ])
+
+    #expect(
+      out.contains("tool"),
+      "Root command name should appear at the top: \(out)")
+    #expect(
+      out.contains("deploy"),
+      "Subcommand should appear nested under the root: \(out)")
+    #expect(
+      out.contains("--global-flag"),
+      "Root-level flag should be listed under the root: \(out)")
+    #expect(
+      out.contains("--env"),
+      "Subcommand option should be listed under the subcommand: \(out)")
+    #expect(
+      out.contains("target1"),
+      "Positional should appear with its value: \(out)")
+
+    // Structural check: --global-flag should appear before `deploy`, which
+    // should appear before --env (root → subcommand → its args).
+    let globalIdx = try #require(
+      out.range(of: "--global-flag"),
+      "Anchor is missing in output: \(out)"
+    )
+    let deployIdx = try #require(
+      out.range(of: "deploy"),
+      "Anchor is missing in output: \(out)"
+    )
+    let envIdx = try #require(
+      out.range(of: "--env"),
+      "Anchor is missing in output: \(out)"
+    )
+
+    #expect(
+      globalIdx.lowerBound < deployIdx.lowerBound,
+      "Root-level args should appear before subcommand block: \(out)")
+    #expect(
+      deployIdx.lowerBound < envIdx.lowerBound,
+      "Subcommand header should appear before its args: \(out)")
+  }
+
+  @Test func textResponseFileArgLeafShowsAtAndIncludedFrom() async throws {
+    try await withTemporaryFile(
+      "rfdump.txt",
+      content: """
+        --name
+        beta
+        """
+    ) { responseFile in
+      let out = try fullMessage(
+        for: DumpSimple.self,
+        arguments: [
+          "@\(responseFile)",
+          "--experimental-dump-arguments-source-location",
+        ])
+
+      #expect(
+        out.contains("--name"),
+        "Dump must list --name: \(out)")
+      #expect(
+        out.contains("beta"),
+        "Dump must include the value beta: \(out)")
+      #expect(
+        out.contains("at \(responseFile):2"),
+        "Leaf must show `at <file>:<line>` for response-file origin: \(out)")
+      #expect(
+        out.contains("included from argv[0]"),
+        "Leaf must show `included from argv[N]` for the @file entry: \(out)")
+    }
+  }
+}
+
+// MARK: - JSON format (via `=json`)
+
+extension SourceLocationDumpEndToEndTests {
+
+  @Test func jsonTopLevelCommandArgvOnlyValidJSONAndCommandKey() async throws {
+    let out = try fullMessage(
+      for: DumpSimple.self,
+      arguments: [
+        "--name", "alpha",
+        "--experimental-dump-arguments-source-location=json",
+      ])
+
+    let dump = try #require(
+      decodeDump(out), "Output is not valid JSON: \(out)")
+    #expect(
+      dump.command == "simple",
+      "JSON should have command='simple': \(dump)")
+    #expect(
+      !dump.arguments.isEmpty,
+      "JSON should have an `arguments` array: \(dump)")
+  }
+
+  @Test func jsonResponseFileArgChainOrderedInnermostFirst() async throws {
+    try await withTemporaryDirectory { dir in
+      let inner = try dir.createTestFile(
+        "inner-json.txt",
+        content: """
+          --name
+          gamma
+          """)
+      let outer = try dir.createTestFile(
+        "outer-json.txt",
+        content: """
+          @\(inner)
+          """)
+
+      let out = try fullMessage(
+        for: DumpSimple.self,
+        arguments: [
+          "@\(outer)",
+          "--experimental-dump-arguments-source-location=json",
+        ])
+
+      let dump = try #require(
+        decodeDump(out), "Output is not valid JSON: \(out)")
+
+      // Find the entry for --name and inspect its chain.
+      let nameArg = try #require(
+        dump.arguments.first(where: { $0.name == "--name" }),
+        "Missing --name in dump: \(dump.arguments)")
+      #expect(
+        nameArg.values.count == 1,
+        "Expected exactly one value for --name")
+
+      let value = try #require(
+        nameArg.firstValue, "no value for --name in \(nameArg)")
+      guard case .responseFile = value.source else {
+        Issue.record("Source kind should be `.responseFile`: \(value.source)")
+        return
+      }
+      let chain = try #require(
+        value.responseFileChain, "no response-file chain: \(value.source)")
+      #expect(
+        chain.count == 3,
+        "Chain must have 3 steps: inner file, outer file, argv. Got: \(chain)")
+
+      #expect(
+        chain[0] == .file(path: inner, line: 2),
+        "Innermost (index 0) must be inner file at line 2: \(chain)")
+
+      #expect(
+        chain[1] == .file(path: outer, line: 1),
+        "Second (index 1) must be outer file at line 1: \(chain)")
+
+      #expect(
+        chain[2] == .argv(index: 0),
+        "Outermost (last) must be the argv sentinel at argv[0]: \(chain)")
+    }
+  }
+
+  @Test func jsonSubcommandNestedUnderSubcommandKey() async throws {
+    let out = try fullMessage(
+      for: DumpRoot.self,
+      arguments: [
+        "--global-flag",
+        "deploy",
+        "--env", "prod",
+        "target1",
+        "--experimental-dump-arguments-source-location=json",
+      ])
+
+    let dump = try #require(
+      decodeDump(out), "Output is not valid JSON: \(out)")
+    #expect(dump.command == "tool")
+
+    let sub = try #require(
+      dump.subcommand?.value, "Expected a `subcommand` key: \(dump)")
+    #expect(sub.command == "deploy")
+  }
+
+  @Test func jsonArgvOriginSourceRecordsCommandLineKind() async throws {
+    let out = try fullMessage(
+      for: DumpSimple.self,
+      arguments: [
+        "--name", "alpha",
+        "--experimental-dump-arguments-source-location=json",
+      ])
+
+    let dump = try #require(
+      decodeDump(out), "Output is not valid JSON: \(out)")
+    let nameArg = try #require(
+      dump.arguments.first(where: { $0.name == "--name" }),
+      "Missing --name in dump: \(dump)")
+    let value = try #require(
+      nameArg.firstValue, "no value for --name in \(nameArg)")
+    guard case .argumentIndex = value.source else {
+      Issue.record(
+        "Argv-origin source must be `.argumentIndex`: \(value.source)")
+      return
+    }
+    #expect(
+      value.argvIndex != nil,
+      "Argv-origin source must carry an argvIndex: \(value.source)")
+  }
+}
+
+// MARK: - Interaction with the failure path
+//
+// When parsing fails, the dump must NOT be produced — the source location  error
+// path takes precedence. Furthermore, the presence of the dump option
+// alone (no @file in input) must not activate the source location gate.
+
+extension SourceLocationDumpEndToEndTests {
+
+  @Test func failurePathTakesPrecedenceOverDump() async throws {
+    // `--name` is required; parsing must fail and the dump must not run.
+    let msg = try fullMessage(
+      for: DumpSimple.self,
+      arguments: ["--experimental-dump-arguments-source-location"])
+    #expect(
+      msg.contains("--name"),
+      "Failure path should mention the missing --name: \(msg)")
+    #expect(
+      !msg.contains("(default)"),
+      "Dump-style output must not be produced on failure: \(msg)")
+  }
+
+  @Test func failurePathDumpFlagAloneDoesNotActivateREQ1Gate() async throws {
+    // The dump option is present, no `@file`.
+    // Therefore the error message must NOT include the new location block.
+    let msg = try rootErrorMessage(
+      for: DumpSimple.self,
+      arguments: [
+        "--name", "a",
+        "--bogus",
+        "--experimental-dump-arguments-source-location",
+      ])
+    #expect(
+      msg.contains("Unknown option '--bogus'"),
+      "Should still report unknown option: \(msg)")
+    #expect(
+      !msg.contains("at argv["),
+      "Dump option alone must not activate the source location gate: \(msg)")
+    #expect(
+      !msg.contains("included from"),
+      "Dump option alone must not produce a chain: \(msg)")
+  }
+}
+
+// MARK: - Array-valued arguments
+//
+// Each element of a repeated `@Option` or an `@Argument` array should
+// carry the source location of its own value token, not the aggregate
+// origin of the whole array.
+
+extension SourceLocationDumpEndToEndTests {
+
+  @Test func jsonRepeatingOptionEachValueHasDistinctArgvIndex() async throws {
+    // `--tag alpha --tag beta --tag gamma` — argv:
+    //   [0]=--tag, [1]=alpha, [2]=--tag, [3]=beta, [4]=--tag, [5]=gamma, [6]=--experimental-...
+    let out = try fullMessage(
+      for: DumpArrayCommand.self,
+      arguments: [
+        "--tag", "alpha",
+        "--tag", "beta",
+        "--tag", "gamma",
+        "--experimental-dump-arguments-source-location=json",
+      ])
+
+    let dump = try #require(
+      decodeDump(out), "Output is not valid JSON: \(out)")
+    let tagArg = try #require(
+      dump.arguments.first(where: { $0.name == "--tag" }),
+      "Missing --tag entry in dump: \(dump)")
+
+    let values = tagArg.values
+    #expect(
+      values.count == 3, "Should render one entry per value: \(values)")
+    #expect(values[0].value == "\"alpha\"")
+    #expect(values[1].value == "\"beta\"")
+    #expect(values[2].value == "\"gamma\"")
+
+    // Each value's source must point to that value's own argv index.
+    let expectedArgvByValue: [(String, Int)] = [
+      ("\"alpha\"", 1),
+      ("\"beta\"", 3),
+      ("\"gamma\"", 5),
+    ]
+    for (index, entry) in values.enumerated() {
+      let (expectedRendered, expectedArgv) = expectedArgvByValue[index]
+      #expect(
+        entry.value == expectedRendered,
+        "Value ordering mismatch at [\(index)]: \(values)")
+      guard case .argumentIndex = entry.source else {
+        Issue.record(
+          "Argv-origin source must be `.argumentIndex` at [\(index)]: \(entry.source)"
+        )
+        continue
+      }
+      #expect(
+        entry.argvIndex == expectedArgv,
+        "Value '\(expectedRendered)' should carry argv[\(expectedArgv)]: \(values)"
+      )
+    }
+  }
+
+  @Test func jsonPositionalArrayEachValueHasDistinctArgvIndex() async throws {
+    let out = try fullMessage(
+      for: DumpArrayCommand.self,
+      arguments: [
+        "a.txt",
+        "b.txt",
+        "c.txt",
+        "--experimental-dump-arguments-source-location=json",
+      ])
+
+    let dump = try #require(
+      decodeDump(out), "Output is not valid JSON: \(out)")
+    let filesArg = try #require(
+      dump.arguments.first(where: {
+        $0.name.contains("files") || $0.name == "<files>"
+      }),
+      "Missing positional entry in dump: \(dump)")
+
+    let values = filesArg.values
+    #expect(values.count == 3, "Should render one entry per value")
+    let expectedArgvByValue: [(String, Int)] = [
+      ("\"a.txt\"", 0),
+      ("\"b.txt\"", 1),
+      ("\"c.txt\"", 2),
+    ]
+    for (index, entry) in values.enumerated() {
+      let (expectedRendered, expectedArgv) = expectedArgvByValue[index]
+      #expect(
+        entry.value == expectedRendered,
+        "Positional ordering mismatch at [\(index)]: \(values)")
+
+      guard case .argumentIndex = entry.source else {
+        Issue.record(
+          "Positional source must be `.argumentIndex` at [\(index)]: \(entry.source)"
+        )
+        continue
+      }
+      #expect(
+        entry.argvIndex == expectedArgv,
+        "Positional '\(expectedRendered)' should carry argv[\(expectedArgv)]")
+    }
+  }
+}
+
+// MARK: - Kitchen-sink command / invocation-syntax coverage
+//
+// Exercises a command that mixes scalar options, flags (long + short,
+// packed shorts), a repeating named option, a required positional, and a
+// positional array — invoked via the various CLI syntaxes ArgumentParser
+// accepts (`--opt value`, `--opt=value`, `-n value`, packed `-vf`, mixed
+// argv + response file).
+
+extension SourceLocationDumpEndToEndTests {
+
+  /// Extracts the decoded dump for a set of kitchen-sink arguments, or
+  /// throws if the output cannot be decoded as JSON.
+  fileprivate func kitchenDump(
+    _ arguments: [String]
+  ) throws -> SourceLocationDumpGenerator.CommandNode {
+    let out = try fullMessage(
+      for: DumpKitchenSink.self,
+      arguments: arguments
+        + ["--experimental-dump-arguments-source-location=json"])
+    return try #require(decodeDump(out), "Output is not valid JSON: \(out)")
+  }
+
+  @Test func kitchenSinkAllSyntaxesRenderCommandLineOrigins() async throws {
+    // Invoke with: --name space, --count=42, -v, --force, --tag one,
+    // --tag=two, target-value, extra1, extra2
+    // Argv:
+    //   [0]=--name [1]=Alice [2]=--count=42 [3]=-v [4]=--force
+    //   [5]=--tag  [6]=one   [7]=--tag=two  [8]=target-value
+    //   [9]=extra1 [10]=extra2 [11]=--experimental-dump-...
+    let dump = try kitchenDump([
+      "--name", "Alice",
+      "--count=42",
+      "-v",
+      "--force",
+      "--tag", "one",
+      "--tag=two",
+      "target-value",
+      "extra1", "extra2",
+    ])
+
+    // --name Alice (space-separated) → value at argv[1]
+    let nameValue = try #require(
+      dump.firstArgument(matching: ["name"])?.firstValue)
+    guard case .argumentIndex = nameValue.source else {
+      Issue.record(
+        "--name source must be `.argumentIndex`:  \(String(describing: nameValue.source))"
+      )
+      return
+    }
+    #expect(nameValue.value == "\"Alice\"")
+    #expect(
+      nameValue.argvIndex == 1,
+      "space-separated `--name Alice` value should be at argv[1]")
+
+    // --count=42 (attached with =) → value is at argv[2] (the same token)
+    let countValue = try #require(
+      dump.firstArgument(matching: ["count"])?.firstValue)
+    guard case .argumentIndex = countValue.source else {
+      Issue.record(
+        "--count source must be `.argumentIndex`: \(String(describing: countValue.source))"
+      )
+      return
+    }
+    #expect(countValue.value == "42")
+    #expect(
+      countValue.argvIndex == 2,
+      "attached `--count=42` should record argv[2]")
+
+    // -v (short flag) → argv[3]
+    let verboseValue =
+      try #require(dump.firstArgument(matching: ["verbose"])?.firstValue)
+    guard case .argumentIndex = verboseValue.source else {
+      Issue.record(
+        "--verbose source must be `.argumentIndex`: \(String(describing: verboseValue.source))"
+      )
+      return
+    }
+    #expect(verboseValue.value == "true")
+    #expect(verboseValue.argvIndex == 3, "short `-v` at argv[3]")
+
+    // --force (long flag) → argv[4]
+    let forceValue =
+      try #require(dump.firstArgument(matching: ["force"])?.firstValue)
+    guard case .argumentIndex = forceValue.source else {
+      Issue.record(
+        "--force source must be `.argumentIndex`: \(String(describing: forceValue.source))"
+      )
+      return
+    }
+    #expect(forceValue.value == "true")
+    #expect(forceValue.argvIndex == 4, "long `--force` at argv[4]")
+
+    // --tag one --tag=two → two entries, argv indices [6] and [7]
+    let tagArg = try #require(dump.firstArgument(matching: ["tag"]))
+    let tagValues = tagArg.values
+    #expect(
+      tagValues.count == 2, "tags should have 2 values: \(tagValues)")
+    for (i, tv) in tagValues.enumerated() {
+      guard case .argumentIndex = tv.source else {
+        Issue.record(
+          "tag[\(i)] source must be `.argumentIndex`: \(tv.source)")
+        return
+      }
+    }
+    let firstTag = try #require(tagValues.first)
+    let lastTag = try #require(tagValues.last)
+    #expect(firstTag.value == "\"one\"")
+    #expect(firstTag.argvIndex == 6)
+    #expect(lastTag.value == "\"two\"")
+    #expect(
+      lastTag.argvIndex == 7,
+      "attached `--tag=two` value token is at argv[7]")
+
+    // target-value positional → argv[8]
+    let targetValue =
+      try #require(dump.firstArgument(matching: ["target"])?.firstValue)
+    guard case .argumentIndex = targetValue.source else {
+      Issue.record(
+        "target source must be `.argumentIndex`: \(String(describing: targetValue.source))"
+      )
+      return
+    }
+    #expect(targetValue.value == "\"target-value\"")
+    #expect(targetValue.argvIndex == 8)
+
+    // extras positional array → argv[9], argv[10]
+    let extrasArg = try #require(dump.firstArgument(matching: ["extras"]))
+    let extrasValues = extrasArg.values
+    #expect(extrasValues.count == 2)
+    for (i, ev) in extrasValues.enumerated() {
+      guard case .argumentIndex = ev.source else {
+        Issue.record(
+          "extras[\(i)] source must be `.argumentIndex`: \(ev.source)")
+        return
+      }
+    }
+    let firstExtra = try #require(extrasValues.first)
+    let lastExtra = try #require(extrasValues.last)
+    #expect(firstExtra.argvIndex == 9)
+    #expect(lastExtra.argvIndex == 10)
+  }
+
+  @Test func kitchenSinkPackedShortFlagsShareArgvIndex() async throws {
+    // `-vf target` should treat `-v` and `-f` as coming from argv[0],
+    // and `target` as argv[1].
+    let dump = try kitchenDump([
+      "-vf",
+      "target",
+      "--name", "Bob",
+    ])
+
+    let verbose = try #require(
+      dump.firstArgument(matching: ["verbose"])?.firstValue)
+    let force = try #require(
+      dump.firstArgument(matching: ["force"])?.firstValue)
+    guard case .argumentIndex = verbose.source else {
+      Issue.record(
+        "-v source must be `.argumentIndex`: \(verbose.source)")
+      return
+    }
+    guard case .argumentIndex = force.source else {
+      Issue.record(
+        "-f source must be `.argumentIndex`: \(force.source)")
+      return
+    }
+    #expect(verbose.value == "true")
+    #expect(force.value == "true")
+    #expect(
+      verbose.argvIndex == 0,
+      "packed `-v` should carry argv[0]: \(verbose)")
+    #expect(
+      force.argvIndex == 0,
+      "packed `-f` should carry argv[0]: \(force)")
+
+    let target = try #require(
+      dump.firstArgument(matching: ["target"])?.firstValue)
+    guard case .argumentIndex = target.source else {
+      Issue.record(
+        "target source must be `.argumentIndex`: \(target.source)")
+      return
+    }
+    #expect(target.argvIndex == 1)
+  }
+
+  @Test func kitchenSinkShortAndLongNameFormsAgreeOnArgvIndex() async throws {
+    // Using the short form of --name (`-n Charlie`) should render the
+    // value at the argv index of the value token, matching the long-form
+    // behavior.
+    let dump = try kitchenDump([
+      "-n", "Charlie",
+      "the-target",
+    ])
+
+    let nameValue = try #require(
+      dump.firstArgument(matching: ["name"])?.firstValue)
+    guard case .argumentIndex = nameValue.source else {
+      Issue.record(
+        "-n source must be `.argumentIndex`: \(nameValue.source)")
+      return
+    }
+    #expect(nameValue.value == "\"Charlie\"")
+    #expect(
+      nameValue.argvIndex == 1,
+      "short form `-n Charlie` should still record the value's argv index")
+  }
+
+  @Test func kitchenSinkDefaultsRenderWithoutSource() async throws {
+    // Only `--name` and the positional provided. `count`, `verbose`,
+    // `force`, `tags`, `extras` should render as (default) / kind=default.
+    let dump = try kitchenDump([
+      "--name", "Dana",
+      "only-target",
+    ])
+
+    // Scalars default → .defaultValue source.
+    for name in ["count", "verbose", "force"] {
+      let value = try #require(
+        dump.firstArgument(matching: [name])?.firstValue,
+        "missing entry for \(name)")
+      guard case .defaultValue = value.source else {
+        Issue.record(
+          "\(name) should have `.defaultValue` source: \(value.source)")
+        return
+      }
+    }
+
+    // Array `tags` default → single default entry.
+    let tagsArg = try #require(dump.firstArgument(matching: ["tag"]))
+    #expect(tagsArg.values.count == 1, "empty tags renders as one entry")
+    let tagValue = try #require(tagsArg.values.first)
+    guard case .defaultValue = tagValue.source else {
+      Issue.record(
+        "tags default entry must be `.defaultValue`: \(tagValue.source)")
+      return
+    }
+
+    // Array `extras` default → single default entry.
+    let extrasArg = try #require(dump.firstArgument(matching: ["extras"]))
+    #expect(extrasArg.values.count == 1)
+    let extrasValue = try #require(extrasArg.values.first)
+    guard case .defaultValue = extrasValue.source else {
+      Issue.record(
+        "extras default entry must be `.defaultValue`: \(extrasValue.source)")
+      return
+    }
+  }
+
+  @Test func kitchenSinkArgvArgAfterResponseFileShowsCorrectArgvIndex()
+    async throws
+  {
+    // Response file supplies `--name FromFile`. Argv-only args after it
+    // should get argv indices that reflect their position in the
+    // pre-expansion argv (0=@file, 1=--verbose, 2=positional).
+    try await withTemporaryFile(
+      "kitchen.txt",
+      content: """
+        --name
+        FromFile
+        """
+    ) { responseFile in
+      let dump = try kitchenDump([
+        "@\(responseFile)",
+        "--verbose",
+        "argv-target",
+      ])
+
+      // Response-file-origin `--name FromFile` — chain source, not commandLine.
+      let nameValue = try #require(
+        dump.firstArgument(matching: ["name"])?.firstValue)
+      guard case .responseFile = nameValue.source else {
+        Issue.record(
+          "name-from-@file source must be `.responseFile`: \(String(describing: nameValue.source))"
+        )
+        return
+      }
+      #expect(nameValue.value == "\"FromFile\"")
+      let chain = try #require(nameValue.responseFileChain)
+      #expect(
+        chain.first == .file(path: responseFile, line: 2),
+        "chain[0] should be the response file: \(chain)")
+      #expect(
+        chain.last == .argv(index: 0),
+        "@file itself lives at argv[0]: \(chain)")
+
+      // Argv-origin `--verbose` at argv[1]
+      let verbose = try #require(
+        dump.firstArgument(matching: ["verbose"])?.firstValue)
+      guard case .argumentIndex = verbose.source else {
+        Issue.record(
+          "--verbose source must be `.argumentIndex`: \(verbose.source)")
+        return
+      }
+      #expect(verbose.value == "true")
+      #expect(verbose.argvIndex == 1)
+
+      // Argv-origin positional `argv-target` at argv[2]
+      let target = try #require(
+        dump.firstArgument(matching: ["target"])?.firstValue)
+      guard case .argumentIndex = target.source else {
+        Issue.record(
+          "target source must be `.argumentIndex`: \(target.source)")
+        return
+      }
+      #expect(target.value == "\"argv-target\"")
+      #expect(target.argvIndex == 2)
+    }
+  }
+
+  @Test func kitchenSinkMixedShorthandAndAttachedInSameInvocation() async throws
+  {
+    // Mix long-with-equals, short-with-space, and packed shorts.
+    // Argv: [0]=--count=7 [1]=-n [2]=Eve [3]=-vf [4]=tgt [5]=e1
+    //       [6]=--experimental-...
+    let dump = try kitchenDump([
+      "--count=7",
+      "-n", "Eve",
+      "-vf",
+      "tgt",
+      "e1",
+    ])
+
+    // Bind each value and verify each source kind via `guard case`.
+    let countValue = try #require(
+      dump.firstArgument(matching: ["count"])?.firstValue)
+    let nameValue = try #require(
+      dump.firstArgument(matching: ["name"])?.firstValue)
+    let verboseValue = try #require(
+      dump.firstArgument(matching: ["verbose"])?.firstValue)
+    let forceValue = try #require(
+      dump.firstArgument(matching: ["force"])?.firstValue)
+    let targetValue = try #require(
+      dump.firstArgument(matching: ["target"])?.firstValue)
+
+    for (label, v) in [
+      ("--count", countValue),
+      ("--name", nameValue),
+      ("--verbose", verboseValue),
+      ("--force", forceValue),
+      ("<target>", targetValue),
+    ] {
+      guard case .argumentIndex = v.source else {
+        Issue.record(
+          "\(label) source must be `.argumentIndex`: \(v.source)")
+        return
+      }
+    }
+
+    #expect(countValue.argvIndex == 0)
+    #expect(
+      nameValue.argvIndex == 2, "short `-n Eve` — value token at argv[2]")
+    #expect(verboseValue.argvIndex == 3)
+    #expect(forceValue.argvIndex == 3)
+    #expect(targetValue.argvIndex == 4)
+    let extras = try #require(
+      dump.firstArgument(matching: ["extras"])?.values)
+    let extrasFirst = try #require(extras.first)
+    guard case .argumentIndex = extrasFirst.source else {
+      Issue.record(
+        "extras[0] source must be `.argumentIndex`: \(extrasFirst.source)")
+      return
+    }
+    #expect(extrasFirst.argvIndex == 5)
+  }
+
+  // MARK: - defaultAsFlag coverage
+  //
+  // The `--log-level` option can be invoked three ways. Each has a
+  // distinct expected source rendering:
+  //   • omitted           → kind=default, no argv index
+  //   • bare `--log-level` → the value is the flag's default ("info"),
+  //     but the source is still argv (the flag token itself)
+  //   • `--log-level=warn` → argv-origin, value from the same token
+
+  @Test func kitchenSinkDefaultAsFlagOmittedRendersAsDefault() async throws {
+    let dump = try kitchenDump([
+      "--name", "Frank",
+      "tgt",
+    ])
+
+    let logValue = try #require(
+      dump.firstArgument(matching: ["log-level"])?.firstValue)
+    guard case .defaultValue = logValue.source else {
+      Issue.record(
+        "omitted defaultAsFlag option should render as `.defaultValue`: \(String(describing: logValue.source))"
+      )
+      return
+    }
+  }
+
+  @Test func kitchenSinkDefaultAsFlagBareInvocationSourcesToFlagToken()
+    async throws
+  {
+    // With `.next` parsing, the bare-flag path fires when the token
+    // immediately after `--log-level` starts with `--` (i.e., is
+    // clearly not a value). Place another option right after it.
+    // Argv: [0]=--name [1]=Frank [2]=--log-level [3]=--verbose [4]=tgt
+    //       [5]=--experimental-...
+    let dump = try kitchenDump([
+      "--name", "Frank",
+      "--log-level",
+      "--verbose",
+      "tgt",
+    ])
+
+    let logValue = try #require(
+      dump.firstArgument(matching: ["log-level"])?.firstValue)
+    guard case .argumentIndex = logValue.source else {
+      Issue.record(
+        "bare `--log-level` should be sourced to `.argumentIndex`, not `.defaultValue`: \(logValue.source)"
+      )
+      return
+    }
+    #expect(
+      logValue.value == "\"info\"",
+      "bare `--log-level` should render the flag default value: \(logValue)")
+    #expect(
+      logValue.argvIndex == 2,
+      "bare `--log-level` should be sourced to argv[2]: \(logValue)")
+  }
+
+  @Test func kitchenSinkDefaultAsFlagAttachedValueSourcesToSameToken()
+    async throws
+  {
+    // Argv: [0]=--name [1]=Frank [2]=--log-level=warn [3]=tgt
+    let dump = try kitchenDump([
+      "--name", "Frank",
+      "--log-level=warn",
+      "tgt",
+    ])
+
+    let logValue = try #require(
+      dump.firstArgument(matching: ["log-level"])?.firstValue)
+    guard case .argumentIndex = logValue.source else {
+      Issue.record(
+        "attached `--log-level=warn` source must be `.argumentIndex`: \(String(describing: logValue.source))"
+      )
+      return
+    }
+    #expect(logValue.value == "\"warn\"")
+    #expect(
+      logValue.argvIndex == 2,
+      "attached `--log-level=warn` value is at argv[2]: \(logValue)")
+  }
+}

--- a/Tests/ArgumentParserUnitTests/InputOriginTests.swift
+++ b/Tests/ArgumentParserUnitTests/InputOriginTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import Testing
 
 @testable import ArgumentParser
@@ -55,5 +56,306 @@ extension InputOriginTests {
   func isDefaultValue(tcData: IsDefaultTestData) {
     let inputOrigin = InputOrigin(elements: tcData.elements)
     #expect(inputOrigin.isDefaultValue == tcData.expectedIsDefaultValue)
+  }
+}
+
+// MARK: - `InputOrigin.ResponseFileStep` Codable
+
+extension InputOriginTests {
+  fileprivate func encode<T: Encodable>(_ value: T) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(value)
+    // swift-format-ignore: NeverForceUnwrap
+    return
+      (try JSONSerialization.jsonObject(with: data)) as! [String: Any]
+  }
+
+  @Test func responseFileStepEncodeFile() async throws {
+    let step = InputOrigin.ResponseFileStep.file(path: "/a/b.txt", line: 7)
+    let obj = try encode(step)
+    #expect(obj["path"] as? String == "/a/b.txt")
+    #expect(obj["line"] as? Int == 7)
+    #expect(obj["argvIndex"] == nil)
+  }
+
+  @Test func responseFileStepEncodeArgv() async throws {
+    let step = InputOrigin.ResponseFileStep.argv(index: 3)
+    let obj = try encode(step)
+    #expect(obj["path"] as? String == "argv")
+    #expect(obj["argvIndex"] as? Int == 3)
+    #expect(obj["line"] == nil)
+  }
+}
+
+/// Cases exercising Codable round-trip for `InputOrigin.ResponseFileStep`.
+struct ResponseFileStepRoundtripCase:
+  @unchecked Sendable, CustomTestStringConvertible
+{
+  let label: String
+  let step: InputOrigin.ResponseFileStep
+
+  var testDescription: String { label }
+}
+
+extension InputOriginTests {
+  @Test(
+    arguments: [
+      ResponseFileStepRoundtripCase(
+        label: "file(/x/y.rsp:12)",
+        step: .file(path: "/x/y.rsp", line: 12)),
+      ResponseFileStepRoundtripCase(
+        label: "argv(0)",
+        step: .argv(index: 0)),
+    ]
+  )
+  func responseFileStepRoundtrip(
+    _ testCase: ResponseFileStepRoundtripCase
+  ) async throws {
+    let data = try JSONEncoder().encode(testCase.step)
+    let decoded = try JSONDecoder().decode(
+      InputOrigin.ResponseFileStep.self, from: data)
+    #expect(testCase.step == decoded)
+  }
+}
+
+// MARK: - `InputOrigin.Element` Codable
+
+extension InputOriginTests {
+  @Test func elementEncodeDefaultValue() async throws {
+    let element = InputOrigin.Element.defaultValue
+    let obj = try encode(element)
+    #expect(obj["kind"] as? String == "default")
+    #expect(obj.count == 1, "no extra fields for default: \(obj)")
+  }
+
+  @Test func elementEncodeArgumentIndex() async throws {
+    let idx = SplitArguments.Index(
+      inputIndex: SplitArguments.InputIndex(rawValue: 5))
+    let element = InputOrigin.Element.argumentIndex(idx)
+    let obj = try encode(element)
+    #expect(obj["kind"] as? String == "commandLine")
+    #expect(obj["argvIndex"] as? Int == 5)
+    #expect(obj["chain"] == nil)
+  }
+
+  /// Nested `.responseFile` linked list should encode as a flat `chain`
+  /// array from innermost to outermost, terminated by an argv step.
+  @Test func elementEncodeResponseFileNested() async throws {
+    // Build: main.txt:7 → shared.txt:4 → prod.txt:12 → argv[2]
+    let argvTerm = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 2)))
+    let level2 = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/prod.txt", line: 12),
+      referencedFrom: argvTerm)
+    let level1 = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/shared.txt", line: 4),
+      referencedFrom: level2)
+    let element = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/main.txt", line: 7),
+      referencedFrom: level1)
+
+    let obj = try encode(element)
+    #expect(obj["kind"] as? String == "responseFile")
+
+    let chain = try #require(
+      obj["chain"] as? [[String: Any]], "Missing chain in \(obj)")
+    #expect(chain.count == 4)
+
+    #expect(chain[0]["path"] as? String == "/abs/main.txt")
+    #expect(chain[0]["line"] as? Int == 7)
+
+    #expect(chain[1]["path"] as? String == "/abs/shared.txt")
+    #expect(chain[1]["line"] as? Int == 4)
+
+    #expect(chain[2]["path"] as? String == "/abs/prod.txt")
+    #expect(chain[2]["line"] as? Int == 12)
+
+    #expect(chain[3]["path"] as? String == "argv")
+    #expect(chain[3]["argvIndex"] as? Int == 2)
+  }
+}
+
+/// Cases exercising Codable round-trip for `InputOrigin.Element`.
+///
+/// Labels carry the suffix of the original XCTest method for each case.
+struct ElementRoundtripCase:
+  @unchecked Sendable, CustomTestStringConvertible
+{
+  let label: String
+  let element: InputOrigin.Element
+
+  var testDescription: String { label }
+
+  /// Builds the three roundtrip cases — one per `InputOrigin.Element`
+  /// shape (`.argumentIndex`, `.defaultValue`, and a nested
+  /// `.responseFile` chain).
+  static let all: [ElementRoundtripCase] = {
+    let argvTerm = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 1)))
+    let level1 = InputOrigin.Element.responseFile(
+      step: .file(path: "/tmp/inner.txt", line: 3),
+      referencedFrom: argvTerm)
+    let nested = InputOrigin.Element.responseFile(
+      step: .file(path: "/tmp/outer.txt", line: 1),
+      referencedFrom: level1)
+
+    return [
+      ElementRoundtripCase(
+        label: "argumentIndex",
+        element: .argumentIndex(
+          SplitArguments.Index(
+            inputIndex: SplitArguments.InputIndex(rawValue: 42)))),
+      ElementRoundtripCase(
+        label: "defaultValue",
+        element: .defaultValue),
+      ElementRoundtripCase(
+        label: "responseFileNested",
+        element: nested),
+    ]
+  }()
+}
+
+extension InputOriginTests {
+  @Test(arguments: ElementRoundtripCase.all)
+  func elementRoundtrip(_ testCase: ElementRoundtripCase) async throws {
+    let data = try JSONEncoder().encode(testCase.element)
+    let decoded = try JSONDecoder().decode(
+      InputOrigin.Element.self, from: data)
+    #expect(testCase.element == decoded)
+  }
+}
+
+// MARK: - JSON → `[String: InputOrigin.Element]` decoding
+//
+// These tests exercise the decoding path a consumer would use to
+// interpret a JSON dump's `source` field(s) as typed
+// `InputOrigin.Element` values, rather than as `[String: Any]` bags.
+//
+// Each test starts from a hardcoded JSON string (representing what an
+// external tool or a test fixture would see on the wire), decodes it as
+// `[String: InputOrigin.Element]`, and asserts the resulting typed
+// values.
+
+/// Cases exercising `[String: InputOrigin.Element]` decoding.
+///
+/// Labels carry the suffix of the original XCTest method for each case.
+struct DecodeSourceMapCase:
+  @unchecked Sendable, CustomTestStringConvertible
+{
+  let label: String
+  let json: String
+  let expected: InputOrigin.Element
+
+  var testDescription: String { label }
+
+  /// A `{"source": ...}` JSON payload paired with the expected decoded
+  /// `InputOrigin.Element` value at `map["source"]`.
+  static let all: [DecodeSourceMapCase] = {
+    let argumentIndexExpected = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 5)))
+
+    // main.txt:7 → shared.txt:4 → prod.txt:12 → argv[2]
+    let nestedArgvTerm = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 2)))
+    let nestedL2 = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/prod.txt", line: 12),
+      referencedFrom: nestedArgvTerm)
+    let nestedL1 = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/shared.txt", line: 4),
+      referencedFrom: nestedL2)
+    let nestedExpected = InputOrigin.Element.responseFile(
+      step: .file(path: "/abs/main.txt", line: 7),
+      referencedFrom: nestedL1)
+
+    let singleArgvTerm = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 0)))
+    let singleExpected = InputOrigin.Element.responseFile(
+      step: .file(path: "/tmp/inner.txt", line: 3),
+      referencedFrom: singleArgvTerm)
+
+    return [
+      DecodeSourceMapCase(
+        label: "default",
+        json: #"{"source": {"kind": "default"}}"#,
+        expected: .defaultValue),
+      DecodeSourceMapCase(
+        label: "argumentIndex",
+        json: #"{"source": {"kind": "commandLine", "argvIndex": 5}}"#,
+        expected: argumentIndexExpected),
+      DecodeSourceMapCase(
+        label: "responseFileNestedChain",
+        json: """
+          {
+            "source": {
+              "kind": "responseFile",
+              "chain": [
+                {"path": "/abs/main.txt",   "line": 7},
+                {"path": "/abs/shared.txt", "line": 4},
+                {"path": "/abs/prod.txt",   "line": 12},
+                {"path": "argv",            "argvIndex": 2}
+              ]
+            }
+          }
+          """,
+        expected: nestedExpected),
+      DecodeSourceMapCase(
+        label: "responseFileSingleFile",
+        json: """
+          {
+            "source": {
+              "kind": "responseFile",
+              "chain": [
+                {"path": "/tmp/inner.txt", "line": 3},
+                {"path": "argv", "argvIndex": 0}
+              ]
+            }
+          }
+          """,
+        expected: singleExpected),
+    ]
+  }()
+}
+
+extension InputOriginTests {
+  fileprivate func decodeSourceMap(
+    _ json: String
+  ) throws -> [String: InputOrigin.Element] {
+    // swift-format-ignore: NeverForceUnwrap
+    let data = json.data(using: .utf8)!
+    return try JSONDecoder().decode(
+      [String: InputOrigin.Element].self, from: data)
+  }
+
+  @Test(arguments: DecodeSourceMapCase.all)
+  func decodeSourceMap(_ testCase: DecodeSourceMapCase) async throws {
+    let map = try decodeSourceMap(testCase.json)
+    #expect(map.count == 1)
+    #expect(map["source"] == testCase.expected)
+  }
+
+  @Test func decodeSourceMapMultipleEntries() async throws {
+    // A synthetic multi-entry wrapper — proves the `[String: ...]`
+    // decoding preserves keys and values independently.
+    let json = """
+      {
+        "alpha": {"kind": "default"},
+        "beta":  {"kind": "commandLine", "argvIndex": 3}
+      }
+      """
+    let map = try decodeSourceMap(json)
+    #expect(map.count == 2)
+    #expect(map["alpha"] == .defaultValue)
+    let expectedBeta = InputOrigin.Element.argumentIndex(
+      SplitArguments.Index(inputIndex: SplitArguments.InputIndex(rawValue: 3)))
+    #expect(map["beta"] == expectedBeta)
+  }
+
+  /// Decoding a `responseFile` payload with an empty `chain` array must
+  /// throw — an empty chain is semantically invalid (there's no
+  /// argv terminator).
+  @Test func decodeSourceMapEmptyChainThrows() async throws {
+    let json = #"{"source": {"kind": "responseFile", "chain": []}}"#
+    #expect(throws: (any Error).self) {
+      try decodeSourceMap(json)
+    }
   }
 }


### PR DESCRIPTION
Add the experimental `--experimental-dump-arguments-source-location` option. When present, the parser fully parses the command line and then prints every parsed argument together with its value and source location (file:line for response-file args, `argv[N]` for command-line args), organized as a subcommand tree. Accepts `=text` (default) or `=json`.

Fixes #846
Relates to #41

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
