### PR TITLE
Add ArgumentParserFoundation package trait

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,10 @@ var package = Package(
       name: "GenerateManual",
       targets: ["GenerateManual"]),
   ],
+  traits: [
+    "ArgumentParserFoundation",
+    .default(enabledTraits: ["ArgumentParserFoundation"])
+  ],
   dependencies: [],
   targets: [
     // Core Library

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Argument Parser open source project

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,144 @@
+// swift-tools-version:6.0
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+var package = Package(
+  name: "swift-argument-parser",
+  products: [
+    .library(
+      name: "ArgumentParser",
+      targets: ["ArgumentParser"]),
+    .plugin(
+      name: "GenerateDoccReference",
+      targets: ["GenerateDoccReference"]),
+    .plugin(
+      name: "GenerateManual",
+      targets: ["GenerateManual"]),
+  ],
+  dependencies: [],
+  targets: [
+    // Core Library
+    .target(
+      name: "ArgumentParser",
+      dependencies: ["ArgumentParserToolInfo"],
+      exclude: ["CMakeLists.txt"]),
+    .target(
+      name: "ArgumentParserTestHelpers",
+      dependencies: ["ArgumentParser", "ArgumentParserToolInfo"],
+      exclude: ["CMakeLists.txt"]),
+    .target(
+      name: "ArgumentParserToolInfo",
+      exclude: ["CMakeLists.txt"]),
+
+    // Plugins
+    .plugin(
+      name: "GenerateDoccReference",
+      capability: .command(
+        intent: .custom(
+          verb: "generate-docc-reference",
+          description:
+            "Generate a documentation reference for a specified target."),
+        permissions: [
+          .writeToPackageDirectory(
+            reason: "This command generates documentation.")
+        ]),
+      dependencies: ["generate-docc-reference"]),
+    .plugin(
+      name: "GenerateManual",
+      capability: .command(
+        intent: .custom(
+          verb: "generate-manual",
+          description: "Generate a manual entry for a specified target.")),
+      dependencies: ["generate-manual"]),
+
+    // Examples
+    .executableTarget(
+      name: "roll",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/roll"),
+    .executableTarget(
+      name: "math",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/math"),
+    .executableTarget(
+      name: "repeat",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/repeat"),
+    .executableTarget(
+      name: "color",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/color"),
+    .executableTarget(
+      name: "default-as-flag",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/default-as-flag"
+    ),
+
+    // Tools
+    .executableTarget(
+      name: "generate-docc-reference",
+      dependencies: ["ArgumentParser", "ArgumentParserToolInfo"],
+      path: "Tools/generate-docc-reference"),
+    .executableTarget(
+      name: "generate-manual",
+      dependencies: ["ArgumentParser", "ArgumentParserToolInfo"],
+      path: "Tools/generate-manual"),
+
+    // Tests
+    .testTarget(
+      name: "ArgumentParserEndToEndTests",
+      dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
+      exclude: ["CMakeLists.txt"]),
+    .testTarget(
+      name: "ArgumentParserExampleTests",
+      dependencies: ["ArgumentParserTestHelpers"],
+      exclude: ["Snapshots"],
+      resources: [.copy("CountLinesTest.txt")]),
+    .testTarget(
+      name: "ArgumentParserGenerateDoccReferenceTests",
+      dependencies: ["ArgumentParserTestHelpers"],
+      exclude: ["Snapshots"]),
+    .testTarget(
+      name: "ArgumentParserGenerateManualTests",
+      dependencies: ["ArgumentParserTestHelpers"],
+      exclude: ["Snapshots"]),
+    .testTarget(
+      name: "ArgumentParserPackageManagerTests",
+      dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
+      exclude: ["CMakeLists.txt"]),
+    .testTarget(
+      name: "ArgumentParserToolInfoTests",
+      dependencies: ["ArgumentParserToolInfo"],
+      exclude: ["Examples"]),
+    .testTarget(
+      name: "ArgumentParserUnitTests",
+      dependencies: ["ArgumentParser", "ArgumentParserTestHelpers"],
+      exclude: ["CMakeLists.txt", "Snapshots"]),
+  ]
+)
+
+#if os(macOS)
+package.targets.append(contentsOf: [
+  // Examples
+  .executableTarget(
+    name: "count-lines",
+    dependencies: ["ArgumentParser"],
+    path: "Examples/count-lines"),
+
+  // Tools
+  .executableTarget(
+    name: "changelog-authors",
+    dependencies: ["ArgumentParser"],
+    path: "Tools/changelog-authors"),
+])
+#endif

--- a/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/DumpHelpGenerator.swift
@@ -23,7 +23,11 @@ internal struct DumpHelpGenerator {
   }
 
   func rendered() -> String {
+    #if ArgumentParserFoundation
     JSONEncoder.encode(self.toolInfo)
+    #else
+    "(cannot dump help to JSON without Foundation)"
+    #endif
   }
 }
 

--- a/Sources/ArgumentParser/Utilities/Foundation.swift
+++ b/Sources/ArgumentParser/Utilities/Foundation.swift
@@ -33,6 +33,7 @@ extension Error {
   }
 }
 
+#if ArgumentParserFoundation
 enum JSONEncoder {
   static func encode<T: Encodable>(_ value: T) -> String {
     #if canImport(FoundationEssentials)
@@ -46,3 +47,4 @@ enum JSONEncoder {
     return String(data: encoded, encoding: .utf8) ?? ""
   }
 }
+#endif

--- a/Sources/ArgumentParser/Utilities/Foundation.swift
+++ b/Sources/ArgumentParser/Utilities/Foundation.swift
@@ -17,6 +17,7 @@ internal import Foundation
 
 extension Error {
   func describe() -> String {
+    #if ArgumentParserFoundation
     if let description = (self as? LocalizedError)?.errorDescription {
       return description
     } else {
@@ -30,6 +31,9 @@ extension Error {
       }
       #endif
     }
+    #else
+    return String(describing: self)
+    #endif
   }
 }
 

--- a/Sources/ArgumentParser/Utilities/Foundation.swift
+++ b/Sources/ArgumentParser/Utilities/Foundation.swift
@@ -9,10 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if ArgumentParserFoundation
 #if canImport(FoundationEssentials)
 internal import FoundationEssentials
 #else
 internal import Foundation
+#endif
 #endif
 
 extension Error {


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

This PR adds a package trait, `ArgumentParserFoundation` (enabled by default), that conditionalizes ArgumentParser's dependencies on `Foundation.NSError`, `Foundation.LocalizedError`, and `Foundation.JSONEncoder`, such that the library can be used without having to link Foundation. External API availability is unchanged (so it's source-compatible either way); the only major caveat I'm aware of when `ArgumentParserFoundation` is disabled is that `--experimental-dump-help` is rendered all but useless (since it's reliant on `JSONEncoder`).

I'm not sure where the best place to add documentation for this trait would be, or how to go about testing it. (I did manually verify that trivial programs compiled with the trait disabled do not link Foundation in the resulting binary, but I don't know what the best way of automating such a check would be.)

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
