### PR TITLE
Fix references to a protocol that does not exist

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/ArgumentDiscussion.swift
+++ b/Sources/ArgumentParser/Parsable Properties/ArgumentDiscussion.swift
@@ -11,16 +11,16 @@
 
 /// A structure that contains an extended description of the argument.
 ///
-/// For `EnumerableOptionValue` types, the `.enumerated` case encapsulates the
+/// For `ExpressibleByArgument` types, the `.enumerated` case encapsulates the
 /// necessary information to list each of the possible values and their
 /// descriptions. Optionally, users can add a discussion preamble that will be
 /// appended to the beginning of the value list section.
 ///
-/// For example, the following `EnumerableOptionValue` type defined in a command
+/// For example, the following `ExpressibleByArgument` type defined in a command
 /// could contain an additional discussion block defined in its `ArgumentHelp`:
 ///
 /// ```swift
-/// enum Color: String, EnumerableOptionValue {
+/// enum Color: String, ExpressibleByArgument {
 ///   case red
 ///   case blue
 ///   case yellow
@@ -29,7 +29,7 @@
 ///     switch self {
 ///        case .red:
 ///         return "A red color."
-///        case. blue:
+///        case .blue:
 ///         return "A blue color."
 ///        case .yellow:
 ///         return "A yellow color."
@@ -97,8 +97,8 @@
 ///    -h, --help           Show help information
 /// ```
 ///
-/// In any case where the argument type is not `EnumerableOptionValue` or an
-/// array of `EnumerableOptionValue`, the default implementation will use the
+/// In any case where the argument type is not `ExpressibleByArgument` or an
+/// array of `ExpressibleByArgument`, the default implementation will use the
 /// `.staticText` case and will print a block of discussion text.
 enum ArgumentDiscussion {
   case staticText(String)

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -39,7 +39,7 @@ public struct CommandConfiguration: Sendable {
   /// display.
   ///
   /// Can include specific abstracts about the argument's possible values (e.g.
-  /// for a custom `EnumerableOptionValue` type), or can describe
+  /// for a custom `ExpressibleByArgument` type), or can describe
   /// a static block of text that extends the description of the argument.
   public var discussion: String
 


### PR DESCRIPTION
`EnumerableOptionValue` is referenced five times in `ArgumentDiscussion.swift` and once in `CommandConfiguration.swift`, but no such protocol exists anywhere in the package — the only other matches in the repo are unrelated test method names.

The type these comments describe is `ExpressibleByArgument` (`ExpressibleByArgument.swift:13`). The enum being documented makes that explicit:

```swift
case enumerated(preamble: String? = nil, any ExpressibleByArgument.Type)
```

So the sample at `ArgumentDiscussion.swift:23` cannot compile as written:

```diff
-/// enum Color: String, EnumerableOptionValue {
+/// enum Color: String, ExpressibleByArgument {
```

While in the same sample I also fixed a stray period in one of the switch cases:

```diff
-///        case. blue:
+///        case .blue:
```

Documentation comments only — no API or behaviour change.
