### PR TITLE
Preserve nested @OptionGroup titles in help output

### DIFF
--- a/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
+++ b/Sources/ArgumentParser/Parsable Properties/OptionGroup.swift
@@ -85,7 +85,12 @@ public struct OptionGroup<Value: ParsableArguments>: Decodable, ParsedWrapper {
           Value.self, visibility: .private, parent: parentKey)
         if !title.isEmpty {
           args.content.withEach {
-            $0.help.parentTitle = title
+            // Only apply this group's title to members that aren't already
+            // grouped by a nested `@OptionGroup`, so nested titles are
+            // preserved instead of being overwritten by the outer group.
+            if $0.help.parentTitle.isEmpty {
+              $0.help.parentTitle = title
+            }
           }
         }
         args.content = args.content.map { arg in

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+GroupName.swift
@@ -418,14 +418,19 @@ extension HelpGenerationTests {
   }
 
   func testNamedNestedGroups() {
+    // A title on an outer `@OptionGroup` must not override the titles of
+    // groups nested inside it: `--verbose`/`--oversharing` keep their inner
+    // "Flags Group" title, while the untitled members fall back to "Nested".
     AssertHelp(
       .default, for: GroupsWithNamedGroups.self,
       equals: """
         USAGE: groups-with-named-groups [--verbose] [--oversharing] [<name>] [--existing-user]
 
-        NESTED:
+        FLAGS GROUP:
           --verbose               example
           --oversharing           example
+
+        NESTED:
           <name>                  example
           --existing-user         example
 


### PR DESCRIPTION
Fixes #558.

### Problem
When an `@OptionGroup(title:)` is nested inside another titled
`@OptionGroup`, the inner group's title is silently dropped: all options
collapse into the outer group's section instead of keeping their own.

### Cause
`OptionGroup.init(title:visibility:)` applied the group's `title` to
*every* member unconditionally, overwriting the `parentTitle` that a
nested group had already set.

### Fix
Only assign the outer title to members that aren't already grouped
(i.e. whose `parentTitle` is still empty), so nested titles are
preserved while untitled members still fall back to the outer title.

### Tests
`testNamedNestedGroups` previously encoded the buggy behavior (nested
title swallowed into the outer section); updated its expected output to
reflect the corrected grouping. All other help-generation tests pass
unchanged.