### PR TITLE
Document the option terminator

### DIFF
--- a/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
+++ b/Sources/ArgumentParser/Documentation.docc/ArgumentParser.md
@@ -49,6 +49,7 @@ and then either calls your `run()` method or exits with a useful message.
 
 ### Essentials
 
+- <doc:UsingArgumentParserTools>
 - <doc:GettingStarted>
 - ``ParsableCommand``
 - ``AsyncParsableCommand``

--- a/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
@@ -540,11 +540,25 @@ Usage: example [--verbose] [<files> ...]
   See 'example --help' for more information.
 ```
 
-Any input after the `--` terminator is automatically treated as positional input, so users can provide dash-prefixed values that way even with the default configuration:
+##### Separating options from positional arguments
+
+Use the `--` terminator when a positional value starts with a dash and could
+otherwise be interpreted as an option or flag. The parser stops recognizing
+options and flags after `--` and treats every remaining input as positional.
+The terminator itself isn't included in the parsed values:
 
 ```
 % example --verbose -- file1.swift file2.swift --other
 Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
+```
+
+This convention also lets users pass a value that has the same spelling as a
+declared option or flag. In the following example, `--verbose` is stored in
+`files` instead of setting the `verbose` property:
+
+```
+% example -- --verbose file1.swift
+Verbose: false, files: ["--verbose", "file1.swift"]
 ```
 
 The `.unconditionalRemaining` parsing strategy uses whatever input is left after parsing known options and flags, even if that input is dash-prefixed, including the terminator itself. If `files` were defined as `@Argument(parsing: .unconditionalRemaining) var files: [String]`, then the resulting array would also include strings that look like options:

--- a/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md
@@ -540,25 +540,11 @@ Usage: example [--verbose] [<files> ...]
   See 'example --help' for more information.
 ```
 
-##### Separating options from positional arguments
-
-Use the `--` terminator when a positional value starts with a dash and could
-otherwise be interpreted as an option or flag. The parser stops recognizing
-options and flags after `--` and treats every remaining input as positional.
-The terminator itself isn't included in the parsed values:
+Any input after the `--` terminator is automatically treated as positional input, so users can provide dash-prefixed values that way even with the default configuration:
 
 ```
 % example --verbose -- file1.swift file2.swift --other
 Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
-```
-
-This convention also lets users pass a value that has the same spelling as a
-declared option or flag. In the following example, `--verbose` is stored in
-`files` instead of setting the `verbose` property:
-
-```
-% example -- --verbose file1.swift
-Verbose: false, files: ["--verbose", "file1.swift"]
 ```
 
 The `.unconditionalRemaining` parsing strategy uses whatever input is left after parsing known options and flags, even if that input is dash-prefixed, including the terminator itself. If `files` were defined as `@Argument(parsing: .unconditionalRemaining) var files: [String]`, then the resulting array would also include strings that look like options:

--- a/Sources/ArgumentParser/Documentation.docc/Articles/UsingArgumentParserTools.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/UsingArgumentParserTools.md
@@ -1,0 +1,30 @@
+# Using ArgumentParser Tools
+
+Learn how to provide input to command-line tools built with `ArgumentParser`.
+
+## Overview
+
+Tools built with `ArgumentParser` can accept positional arguments, named
+options, and flags. The tool's help screen describes the inputs it supports;
+run a tool with the `--help` flag to display it.
+
+### Separating Options from Positional Arguments
+
+Use the `--` option terminator when a positional value starts with a dash and
+could otherwise be interpreted as an option or flag. A tool stops recognizing
+options and flags after `--` and treats every remaining input as positional.
+The terminator itself isn't included in the parsed values:
+
+```
+% example --verbose -- file1.swift file2.swift --other
+Verbose: true, files: ["file1.swift", "file2.swift", "--other"]
+```
+
+This convention also lets you pass a positional value that has the same
+spelling as a declared option or flag. In the following example, `--verbose`
+is stored in `files` instead of setting the `verbose` flag:
+
+```
+% example -- --verbose file1.swift
+Verbose: false, files: ["--verbose", "file1.swift"]
+```


### PR DESCRIPTION
## Summary

- add a new guide for people using command-line tools built with ArgumentParser
- use the `--` option terminator as the guide's first topic, with examples for dash-prefixed and option-like positional values
- link the guide from the documentation's Essentials section and keep the declaration article focused on defining command interfaces

Fixes #39

## Testing

- `git diff --check` (passed)
- `swift test --skip CountLinesExampleTests.testCountLines` (passed; the skipped fixture is path-sensitive and fails because this checkout path contains spaces)
- `swift package plugin generate-documentation --target ArgumentParser` was attempted previously, but this toolchain reported that the plugin subcommand was unavailable
