### PR TITLE
Fix Bash completion option filtering

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -107,10 +107,10 @@ extension CommandInfoV0 {
                         fi
                     done
                     if "${not_found}"; then
-                        for index in "${!non_repeating_flags[@]}"; do
-                            if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                                unset "non_repeating_flags[${index}]"
-                                non_repeating_flags=("${non_repeating_flags[@]}")
+                        for index in "${!non_repeating_options[@]}"; do
+                            if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                                unset "non_repeating_options[${index}]"
+                                non_repeating_options=("${non_repeating_options[@]}")
                                 break
                             fi
                         done

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -85,10 +85,10 @@ __math_offer_flags_options() {
                     fi
                 done
                 if "${not_found}"; then
-                    for index in "${!non_repeating_flags[@]}"; do
-                        if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                            unset "non_repeating_flags[${index}]"
-                            non_repeating_flags=("${non_repeating_flags[@]}")
+                    for index in "${!non_repeating_options[@]}"; do
+                        if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                            unset "non_repeating_options[${index}]"
+                            non_repeating_options=("${non_repeating_options[@]}")
                             break
                         fi
                     done


### PR DESCRIPTION
Fixes #936.

Summary:
- Search `non_repeating_options` in the fallback branch of the Bash completion parser.
- Remove the matched option from the option array instead of checking the flags array a second time.
- Update the generated Math Bash completion snapshot.

Validation:
- `swift build --product math`
- Generated Bash completion matches the updated snapshot.
- `bash -n` passes for the generated script.
- `git diff --check` passes.

The full XCTest suite could not run in this environment because the installed Command Line Tools do not provide the XCTest module.