### PR TITLE
generate-manual: don't repeat inherited arguments in nested sections

### DIFF
--- a/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathSinglePageManual().mdoc
+++ b/Tests/ArgumentParserGenerateManualTests/Snapshots/testMathSinglePageManual().mdoc
@@ -23,10 +23,6 @@ Print the sum of the values.
 Use hexadecimal notation for the result.
 .It Ar values...
 A group of integers to operate on.
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .El
 .It Em "multiply, mul"
 Print the product of the values.
@@ -35,18 +31,10 @@ Print the product of the values.
 Use hexadecimal notation for the result.
 .It Ar values...
 A group of integers to operate on.
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .El
 .It Em stats
 Calculate descriptive statistics.
 .Bl -tag -width 6n
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .It Em "average, avg"
 Print the average of the values.
 .Bl -tag -width 6n
@@ -55,20 +43,12 @@ The kind of average to provide.
 .Pp
 .It Ar values...
 A group of floating-point values to operate on.
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .El
 .It Em stdev
 Print the standard deviation of the values.
 .Bl -tag -width 6n
 .It Ar values...
 A group of floating-point values to operate on.
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .El
 .It Em quantiles
 Print the quantiles of the values (TBD).
@@ -83,18 +63,12 @@ A group of floating-point values to operate on.
 .It Fl -shell Ar shell
 .It Fl -custom Ar custom
 .It Fl -custom-deprecated Ar custom-deprecated
-.It Fl -version
-Show the version.
-.It Fl h , -help
-Show help information.
 .El
 .El
 .It Em help
 Show subcommand help information.
 .Bl -tag -width 6n
 .It Ar subcommands...
-.It Fl -version
-Show the version.
 .El
 .El
 .Sh AUTHORS

--- a/Tools/generate-manual/DSL/SinglePageDescription.swift
+++ b/Tools/generate-manual/DSL/SinglePageDescription.swift
@@ -15,6 +15,15 @@ import ArgumentParserToolInfo
 struct SinglePageDescription: MDocComponent {
   var command: CommandInfoV0
   var root: Bool
+  /// Arguments which an enclosing command's section already documents.
+  ///
+  /// A single page manual nests each subcommand's arguments within its super
+  /// command's list. Repeating an argument that an ancestor already describes
+  /// verbatim (most notably the synthesized `--version` and `--help` flags)
+  /// only adds noise, so such arguments are documented once, by the outermost
+  /// command which declares them. Multi page manuals are unaffected because
+  /// each command gets a self contained page.
+  var inheritedArguments: Set<ArgumentInfoV0> = []
 
   var body: MDocComponent {
     Section(title: "description") {
@@ -43,7 +52,7 @@ struct SinglePageDescription: MDocComponent {
 
     List {
       for argument in command.arguments ?? [] {
-        if argument.shouldDisplay {
+        if argument.shouldDisplay, !inheritedArguments.contains(argument) {
           MDocMacro.ListItem(title: argument.manualPageDescription)
 
           let discussion = DiscussionText(
@@ -65,11 +74,17 @@ struct SinglePageDescription: MDocComponent {
         }
       }
 
+      let subcommandInheritedArguments = inheritedArguments.union(
+        command.arguments ?? [])
       for subcommand in command.subcommands ?? [] {
         MDocMacro.ListItem(
           title: MDocMacro.Emphasis(
             arguments: [subcommand.manualPageSubcommandLabel]))
-        SinglePageDescription(command: subcommand, root: false).core
+        SinglePageDescription(
+          command: subcommand,
+          root: false,
+          inheritedArguments: subcommandInheritedArguments
+        ).core
       }
     }
   }


### PR DESCRIPTION
Fixes #799.

### Motivation

`SinglePageDescription` nests each subcommand's description inside of its super command's list, and `--experimental-dump-help` reports the synthesized `--version` and `--help` flags in the `arguments` of *every* command. The two flags were therefore repeated at every level of the command tree, which buries the arguments that are actually specific to a subcommand.

This is visible in this repository's own snapshots — before this change, `testMathSinglePageManual().mdoc` listed the pair six times:

```
     stats   Calculate descriptive statistics.

             --version
                     Show the version.

             -h, --help
                     Show help information.

             average
                     Print the average of the values.

                     --kind kind
                             The kind of average to provide.

                     values...
                             A group of floating-point values to operate on.

                     --version
                             Show the version.

                     -h, --help
                             Show help information.
```

### Modifications

`SinglePageDescription` now carries the set of arguments documented by enclosing commands and skips an argument when an ancestor's section already describes an identical one, so it is documented once by the outermost command which declares it.

The rule is expressed generally rather than special-casing the two flag names: `ArgumentInfoV0` is `Hashable`, so entries are compared for full equality. Besides the synthesized flags this also collapses an option shared between a command and its subcommands through a common `@OptionGroup`. Sibling subcommands do not suppress each other — only ancestors suppress descendants — so an option that two subcommands happen to declare separately is still documented under each of them.

Multi-page manuals are deliberately unaffected: `MultiPageDescription` does not recurse, each command gets a self-contained page there, and its arguments still need to be listed in full.

The same rendering, after the change:

```
     stats   Calculate descriptive statistics.

             average
                     Print the average of the values.

                     --kind kind
                             The kind of average to provide.

                     values...
                             A group of floating-point values to operate on.
```

### Result

Global options are documented once, at the top of the page, as the issue asks for.

### Testing

- Re-recorded `testMathSinglePageManual().mdoc`; the other eleven manual snapshots are unchanged, confirming multi-page output and commands without subcommands are untouched.
- Full `swift test` passes.
- Rendered the generated `math` page through `man` to confirm the result reads correctly.
- Separately built a small tool with a subcommand that has no arguments of its own and an `@OptionGroup` shared between a command and its subcommands, to confirm an emptied section does not emit a stray `.Bl`/`.El` pair and that the shared option is documented once.
