### PR TITLE
fix(fish): parse completion tokens with read on Fish 4.1+

### DIFF
--- a/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift
@@ -46,7 +46,18 @@ extension CommandInfoV0 {
     end
 
     function \(tokensFunctionName)
-        if test (string split -m 1 -f 1 -- . "$FISH_VERSION") -gt 3
+        set -l fish_version (string split -- . "$FISH_VERSION")
+        if test "$fish_version[1]" -gt 4
+            commandline $argv | read --tokenize-raw --list tokens
+            printf '%s\\n' $tokens
+        else if test "$fish_version[1]" -eq 4; and test "$fish_version[2]" -ge 1
+            if test "$argv" = -tC
+                commandline $argv
+            else
+                commandline $argv | read --tokenize-raw --list tokens
+                printf '%s\\n' $tokens
+            end
+        else if test "$fish_version[1]" -gt 3
             commandline --tokens-raw $argv
         else
             commandline -o $argv

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathFishCompletionScript().fish
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathFishCompletionScript().fish
@@ -43,7 +43,18 @@ function __math_parse_tokens -S
 end
 
 function __math_tokens
-    if test (string split -m 1 -f 1 -- . "$FISH_VERSION") -gt 3
+    set -l fish_version (string split -- . "$FISH_VERSION")
+    if test "$fish_version[1]" -gt 4
+        commandline $argv | read --tokenize-raw --list tokens
+        printf '%s\n' $tokens
+    else if test "$fish_version[1]" -eq 4; and test "$fish_version[2]" -ge 1
+        if test "$argv" = -tC
+            commandline $argv
+        else
+            commandline $argv | read --tokenize-raw --list tokens
+            printf '%s\n' $tokens
+        end
+    else if test "$fish_version[1]" -gt 3
         commandline --tokens-raw $argv
     else
         commandline -o $argv

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Fish().fish
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Fish().fish
@@ -33,7 +33,18 @@ function __base-test_parse_tokens -S
 end
 
 function __base-test_tokens
-    if test (string split -m 1 -f 1 -- . "$FISH_VERSION") -gt 3
+    set -l fish_version (string split -- . "$FISH_VERSION")
+    if test "$fish_version[1]" -gt 4
+        commandline $argv | read --tokenize-raw --list tokens
+        printf '%s\n' $tokens
+    else if test "$fish_version[1]" -eq 4; and test "$fish_version[2]" -ge 1
+        if test "$argv" = -tC
+            commandline $argv
+        else
+            commandline $argv | read --tokenize-raw --list tokens
+            printf '%s\n' $tokens
+        end
+    else if test "$fish_version[1]" -gt 3
         commandline --tokens-raw $argv
     else
         commandline -o $argv

--- a/Tests/ArgumentParserUnitTests/Snapshots/testDefaultAsFlagCompletion_Fish().fish
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testDefaultAsFlagCompletion_Fish().fish
@@ -29,7 +29,18 @@ function __defaultasflag-test_parse_tokens -S
 end
 
 function __defaultasflag-test_tokens
-    if test (string split -m 1 -f 1 -- . "$FISH_VERSION") -gt 3
+    set -l fish_version (string split -- . "$FISH_VERSION")
+    if test "$fish_version[1]" -gt 4
+        commandline $argv | read --tokenize-raw --list tokens
+        printf '%s\n' $tokens
+    else if test "$fish_version[1]" -eq 4; and test "$fish_version[2]" -ge 1
+        if test "$argv" = -tC
+            commandline $argv
+        else
+            commandline $argv | read --tokenize-raw --list tokens
+            printf '%s\n' $tokens
+        end
+    else if test "$fish_version[1]" -gt 3
         commandline --tokens-raw $argv
     else
         commandline -o $argv


### PR DESCRIPTION
Fixes #819.

Fish 4.1 introduced `read --tokenize-raw` for parsing command lines without losing quoting or redirect operators. This change uses it for Fish 4.1+ completion scripts while preserving the existing paths for Fish 4.0 and Fish 3.x. The `-tC` cursor-position query continues to use `commandline` directly.

Updated the Fish completion snapshots for unit and example coverage.

Validation:
- `swift test --parallel`
- `swift-format lint --strict Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift`
- Fish 4.8 raw redirect and cursor checks
- `git diff --check`