### PR TITLE
Reject manual docc output directories in plugins

### DIFF
--- a/Plugins/GenerateCommon/GeneratePlugin.swift
+++ b/Plugins/GenerateCommon/GeneratePlugin.swift
@@ -52,6 +52,12 @@ extension GeneratePlugin {
       return
     }
 
+    // The plugin computes a distinct output directory for every eligible
+    // product. Reject a manually supplied directory instead of forwarding it
+    // to every tool invocation, where the last duplicate option would silently
+    // override each per-target path.
+    try extractor.rejectPluginManagedOptions()
+
     // Extract configuration argument before making it to the
     // "generate-docc-reference" tool.
     let configuration = try extractor.configuration()

--- a/Plugins/GenerateCommon/GeneratePluginError.swift
+++ b/Plugins/GenerateCommon/GeneratePluginError.swift
@@ -14,6 +14,7 @@ import PackagePlugin
 
 enum GeneratePluginError: Error {
   case unknownBuildConfiguration(String)
+  case pluginManagedOption(String)
   case buildFailed(String)
   case createOutputDirectoryFailed(Error)
   case subprocessFailedNonZeroExit(URL, Int32)
@@ -25,6 +26,9 @@ extension GeneratePluginError: CustomStringConvertible {
     switch self {
     case .unknownBuildConfiguration(let configuration):
       return "Build failed: Unknown build configuration '\(configuration)'."
+    case .pluginManagedOption(let option):
+      return
+        "The GeneratePlugin plugin manages '\(option)' for each target; do not pass it manually."
     case .buildFailed(let logText):
       return "Build failed: \(logText)."
     case .createOutputDirectoryFailed(let error):

--- a/Plugins/GenerateCommon/PackagePlugin+Helpers.swift
+++ b/Plugins/GenerateCommon/PackagePlugin+Helpers.swift
@@ -32,6 +32,12 @@ extension ArgumentExtractor {
       return .release
     }
   }
+
+  mutating func rejectPluginManagedOptions() throws {
+    if !extractOption(named: "output-directory").isEmpty {
+      throw GeneratePluginError.pluginManagedOption("--output-directory")
+    }
+  }
 }
 
 extension URL {


### PR DESCRIPTION
## Summary

Fixes #938.

The common generation-plugin path now rejects a manually supplied `--output-directory` before building or invoking the tool. The plugin owns one output directory per eligible product; forwarding a user-supplied duplicate to every invocation allowed the last flag to silently misroute all generated references.

## Evidence

- `ArgumentExtractor` consumes and rejects the plugin-managed option with a clear error matching the existing help contract.
- `swift build --target GenerateDoccReference`
- `swift test --filter ArgumentParserGenerateDoccReferenceTests` (10 passed)
- `swift package --allow-writing-to-package-directory generate-docc-reference --output-directory <temporary directory>` exits 1 with: `The GeneratePlugin plugin manages '--output-directory' for each target; do not pass it manually.`
- `git diff --check`

No maintainer-only, legal, or contributor-account action is required.
