### PR TITLE
feat: add `helpBanner` to `CommandConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add new items at the end of the relevant section under **Unreleased**.
 
 ## [Unreleased]
 
+### Additions
+
+- `CommandConfiguration` now accepts a `helpBanner`, a string printed verbatim above the overview on a command's help screen and inherited by its subcommands unless they provide their own banner or the empty string.
+
 ---
 
 ## [1.8.2] - 2026-06-04

--- a/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
+++ b/Sources/ArgumentParser/Documentation.docc/Articles/CustomizingCommandHelp.md
@@ -59,6 +59,67 @@ hello!
 ...
 ```
 
+### Adding a Banner Inherited by Subcommands
+
+An abstract and discussion describe a single command. To show information that applies to your whole tool — a copyright notice, for example — pass `helpBanner` to the root command's ``CommandConfiguration``. The banner appears above the overview, and every subcommand inherits it.
+
+```swift
+struct Nodectl: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage nodes and collect diagnostics.",
+        helpBanner: "Acme Corp. Copyright 1234",
+        subcommands: [Probe.self])
+
+    struct Probe: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Probe nodes for health and topology.")
+    }
+}
+```
+
+The banner is shown for the root command and for the subcommand, without being declared twice:
+
+```
+% nodectl --help
+Acme Corp. Copyright 1234
+
+OVERVIEW: Manage nodes and collect diagnostics.
+
+USAGE: nodectl <subcommand>
+
+OPTIONS:
+  -h, --help              Show help information.
+
+SUBCOMMANDS:
+  probe                   Probe nodes for health and topology.
+
+  See 'nodectl help <subcommand>' for detailed help.
+
+% nodectl probe --help
+Acme Corp. Copyright 1234
+
+OVERVIEW: Probe nodes for health and topology.
+
+USAGE: nodectl probe
+
+OPTIONS:
+  -h, --help              Show help information.
+```
+
+Inheritance follows the same rule as `helpNames`: a command with no `helpBanner` of its own uses the banner of its closest ancestor that declares one. A subcommand can declare a different banner to replace the inherited one, or declare the empty string to suppress it:
+
+```swift
+struct Internal: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "An internal command with no banner.",
+        helpBanner: "")
+}
+```
+
+Unlike `abstract` and `discussion`, a banner is printed verbatim and is never wrapped to the width of the terminal, so multi-line banners and ASCII art render exactly as written. If you want a long single-line banner to wrap, insert the line breaks yourself.
+
+Banners appear wherever the help screen is shown — for the help flags, the `help` subcommand, and when a user runs a command that only groups subcommands. They do not appear in the short usage message printed when a user passes invalid arguments.
+
 ### Modifying the Help Flag Names
 
 Users can see the help screen for a command by passing either the `-h` or the `--help` flag, by default. If you need to use one of those flags for another purpose, you can provide alternative names when configuring a root command.

--- a/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
+++ b/Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md
@@ -4,13 +4,14 @@
 
 ### Creating a Configuration
 
-- ``init(commandName:abstract:usage:discussion:version:shouldDisplay:subcommands:groupedSubcommands:defaultSubcommand:helpNames:aliases:)``
+- ``init(commandName:abstract:usage:discussion:helpBanner:version:shouldDisplay:subcommands:groupedSubcommands:defaultSubcommand:helpNames:aliases:)``
 
 ### Customizing the Help Screen
 
 - ``abstract``
 - ``discussion``
 - ``usage``
+- ``helpBanner``
 - ``helpNames``
 
 ### Declaring Subcommands

--- a/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
+++ b/Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift
@@ -43,6 +43,15 @@ public struct CommandConfiguration: Sendable {
   /// a static block of text that extends the description of the argument.
   public var discussion: String
 
+  /// A banner shown at the top of the help display for this command and,
+  /// unless overridden, all of its subcommands.
+  ///
+  /// If `helpBanner` is `nil`, the banner is inherited from the nearest
+  /// ancestor command that specifies one. To suppress an inherited banner, set
+  /// `helpBanner` to the empty string. Unlike `abstract` and `discussion`, a
+  /// banner is printed verbatim and is never wrapped to the terminal width.
+  public var helpBanner: String?
+
   /// Version information for this command.
   public var version: String
 
@@ -97,6 +106,11 @@ public struct CommandConfiguration: Sendable {
   ///     automatically generating a usage description. Passing an empty string
   ///     hides the usage string altogether.
   ///   - discussion: A longer description of the command.
+  ///   - helpBanner: A banner shown at the top of the help display for this
+  ///     command and, unless overridden, all of its subcommands. When
+  ///     `helpBanner` is `nil`, the banner is inherited from the nearest
+  ///     ancestor command that specifies one. Pass the empty string to
+  ///     suppress an inherited banner.
   ///   - version: The version number for this command. When you provide a
   ///     non-empty string, the argument parser prints it if the user provides
   ///     a `--version` flag.
@@ -120,6 +134,7 @@ public struct CommandConfiguration: Sendable {
     abstract: String = "",
     usage: String? = nil,
     discussion: String = "",
+    helpBanner: String? = nil,
     version: String = "",
     shouldDisplay: Bool = true,
     subcommands ungroupedSubcommands: [ParsableCommand.Type] = [],
@@ -132,6 +147,7 @@ public struct CommandConfiguration: Sendable {
     self.abstract = abstract
     self.usage = usage
     self.discussion = discussion
+    self.helpBanner = helpBanner
     self.version = version
     self.shouldDisplay = shouldDisplay
     self.ungroupedSubcommands = ungroupedSubcommands
@@ -149,6 +165,7 @@ public struct CommandConfiguration: Sendable {
     abstract: String = "",
     usage: String? = nil,
     discussion: String = "",
+    helpBanner: String? = nil,
     version: String = "",
     shouldDisplay: Bool = true,
     subcommands ungroupedSubcommands: [ParsableCommand.Type] = [],
@@ -162,6 +179,7 @@ public struct CommandConfiguration: Sendable {
     self.abstract = abstract
     self.usage = usage
     self.discussion = discussion
+    self.helpBanner = helpBanner
     self.version = version
     self.shouldDisplay = shouldDisplay
     self.ungroupedSubcommands = ungroupedSubcommands

--- a/Sources/ArgumentParser/Usage/HelpGenerator.swift
+++ b/Sources/ArgumentParser/Usage/HelpGenerator.swift
@@ -151,6 +151,7 @@ internal struct HelpGenerator {
   var commandStack: [ParsableCommand.Type]
   var abstract: String
   var usage: String
+  var helpBanner: String
   var sections: [Section]
 
   init(commandStack: [ParsableCommand.Type], visibility: ArgumentVisibility) {
@@ -180,6 +181,8 @@ internal struct HelpGenerator {
       }
       self.usage = usage
     }
+
+    self.helpBanner = commandStack.getHelpBanner() ?? ""
 
     self.abstract = currentCommand.configuration.abstract
     if !currentCommand.configuration.discussion.isEmpty {
@@ -387,6 +390,8 @@ internal struct HelpGenerator {
       .map { $0.rendered(screenWidth: screenWidth) }
       .filter { !$0.isEmpty }
       .joined(separator: "\n")
+    // Rendered verbatim: wrapping would break multi-line banners and ASCII art.
+    let renderedBanner = helpBanner.isEmpty ? "" : helpBanner + "\n\n"
     let renderedAbstract =
       abstract.isEmpty
       ? ""
@@ -414,6 +419,7 @@ internal struct HelpGenerator {
       : "USAGE: \(usage.hangingIndentingEachLine(by: 7))\n\n"
 
     return """
+      \(renderedBanner)\
       \(renderedAbstract)\
       \(renderedUsage)\
       \(renderedSections)\(helpSubcommandMessage)
@@ -471,6 +477,14 @@ extension BidirectionalCollection where Element == ParsableCommand.Type {
 
   func getPrimaryHelpName() -> Name? {
     getHelpNames(visibility: .default).preferredName
+  }
+
+  /// Returns the help banner for the top-most command in the command stack
+  /// with a custom help banner.
+  ///
+  /// If the command stack contains no custom help banner, returns `nil`.
+  func getHelpBanner() -> String? {
+    self.lazy.reversed().compactMap { $0.configuration.helpBanner }.first
   }
 
   func versionArgumentDefinition() -> ArgumentDefinition? {

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(UnitTests
   HelpGenerationTests+AtArgument.swift
   HelpGenerationTests+AtOption.swift
   HelpGenerationTests+GroupName.swift
+  HelpGenerationTests+HelpBanner.swift
   NameSpecificationTests.swift
   SplitArgumentTests.swift
   StringSnakeCaseTests.swift

--- a/Tests/ArgumentParserUnitTests/HelpGenerationTests+HelpBanner.swift
+++ b/Tests/ArgumentParserUnitTests/HelpGenerationTests+HelpBanner.swift
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParserTestHelpers
+import Testing
+
+@testable import ArgumentParser
+
+// This set of tests asserts that a `helpBanner` declared on a command is
+// rendered above the overview and is inherited by that command's subcommands.
+
+extension HelpGenerationTests {
+  fileprivate struct Root: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "root",
+      abstract: "Does root things.",
+      helpBanner: "Acme Corp. Copyright 1234",
+      subcommands: [Inherits.self, Overrides.self, Suppresses.self])
+
+    fileprivate struct Inherits: ParsableCommand {
+      static let configuration = CommandConfiguration(
+        abstract: "Inherits the banner.",
+        subcommands: [Nested.self])
+
+      fileprivate struct Nested: ParsableCommand {
+        static let configuration = CommandConfiguration(
+          abstract: "Inherits the banner from its grandparent.")
+      }
+    }
+
+    fileprivate struct Overrides: ParsableCommand {
+      static let configuration = CommandConfiguration(
+        abstract: "Overrides the banner.",
+        helpBanner: "Subsidiary Inc.",
+        subcommands: [Nested.self])
+
+      fileprivate struct Nested: ParsableCommand {
+        static let configuration = CommandConfiguration(
+          abstract: "Inherits the banner from its nearest ancestor.")
+      }
+    }
+
+    fileprivate struct Suppresses: ParsableCommand {
+      static let configuration = CommandConfiguration(
+        abstract: "Suppresses the banner.",
+        helpBanner: "")
+    }
+  }
+
+  @Test func helpBannerOnRoot() async throws {
+    try requireHelp(
+      .default, for: Root.self,
+      equals: """
+        Acme Corp. Copyright 1234
+
+        OVERVIEW: Does root things.
+
+        USAGE: root <subcommand>
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        SUBCOMMANDS:
+          inherits                Inherits the banner.
+          overrides               Overrides the banner.
+          suppresses              Suppresses the banner.
+
+          See 'root help <subcommand>' for detailed help.
+        """)
+  }
+
+  @Test func helpBannerIsInheritedByNestedSubcommand() async throws {
+    try requireHelp(
+      .default, for: Root.Inherits.Nested.self, root: Root.self,
+      equals: """
+        Acme Corp. Copyright 1234
+
+        OVERVIEW: Inherits the banner from its grandparent.
+
+        USAGE: root inherits nested
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+
+  @Test func helpBannerCanBeOverriddenBySubcommand() async throws {
+    try requireHelp(
+      .default, for: Root.Overrides.self, root: Root.self,
+      equals: """
+        Subsidiary Inc.
+
+        OVERVIEW: Overrides the banner.
+
+        USAGE: root overrides <subcommand>
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        SUBCOMMANDS:
+          nested                  Inherits the banner from its nearest ancestor.
+
+          See 'root help overrides <subcommand>' for detailed help.
+        """)
+  }
+
+  /// The nearest ancestor that declares a banner wins, not the root.
+  @Test func helpBannerIsInheritedFromNearestAncestor() async throws {
+    try requireHelp(
+      .default, for: Root.Overrides.Nested.self, root: Root.self,
+      equals: """
+        Subsidiary Inc.
+
+        OVERVIEW: Inherits the banner from its nearest ancestor.
+
+        USAGE: root overrides nested
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+
+  @Test func helpBannerCanBeSuppressedBySubcommand() async throws {
+    try requireHelp(
+      .default, for: Root.Suppresses.self, root: Root.self,
+      equals: """
+        OVERVIEW: Suppresses the banner.
+
+        USAGE: root suppresses
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+
+  fileprivate struct NoBanner: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "no-banner",
+      abstract: "Declares no banner.")
+  }
+
+  @Test func noHelpBannerLeavesHelpUnchanged() async throws {
+    try requireHelp(
+      .default, for: NoBanner.self,
+      equals: """
+        OVERVIEW: Declares no banner.
+
+        USAGE: no-banner
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+
+  fileprivate struct VerbatimBanner: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "verbatim-banner",
+      abstract: "Declares a multi-line banner.",
+      helpBanner: """
+          _
+         / \\  Acme
+        /___\\ A banner line that is considerably longer than the eighty columns of the help screen
+        """)
+  }
+
+  /// A banner is rendered verbatim, so multi-line banners and ASCII art are
+  /// preserved and lines longer than the screen width are not wrapped.
+  @Test func helpBannerIsNotWrapped() async throws {
+    try requireHelp(
+      .default, for: VerbatimBanner.self,
+      equals: """
+          _
+         / \\  Acme
+        /___\\ A banner line that is considerably longer than the eighty columns of the help screen
+
+        OVERVIEW: Declares a multi-line banner.
+
+        USAGE: verbatim-banner
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+
+  fileprivate struct BannerNoAbstract: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "banner-no-abstract",
+      helpBanner: "Acme Corp. Copyright 1234")
+  }
+
+  /// A banner does not introduce a stray blank line when the command has no
+  /// abstract to follow it.
+  @Test func helpBannerWithoutAbstract() async throws {
+    try requireHelp(
+      .default, for: BannerNoAbstract.self,
+      equals: """
+        Acme Corp. Copyright 1234
+
+        USAGE: banner-no-abstract
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """)
+  }
+}


### PR DESCRIPTION
Declare a banner once on the root command and every subcommand inherits it.

```swift
static let configuration = CommandConfiguration(
  commandName: "nodectl",
  abstract: "Manage nodes and collect diagnostics",
  helpBanner: "Acme Corp. Copyright 1234",
  subcommands: [Probe.self])
```

Before:

```sh
$ nodectl
OVERVIEW: Manage nodes and collect diagnostics

USAGE: nodectl <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  probe                   Probe nodes for health and topology

  See 'nodectl help <subcommand>' for detailed help.

$ nodectl probe
OVERVIEW: Probe nodes for health and topology

USAGE: nodectl probe <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  run                     Run a probe against one or more nodes

  See 'nodectl help probe <subcommand>' for detailed help.
```

After:

```sh
$ nodectl
Acme Corp. Copyright 1234

OVERVIEW: Manage nodes and collect diagnostics

USAGE: nodectl <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  probe                   Probe nodes for health and topology

  See 'nodectl help <subcommand>' for detailed help.

$ nodectl probe
Acme Corp. Copyright 1234

OVERVIEW: Probe nodes for health and topology

USAGE: nodectl probe <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  run                     Run a probe against one or more nodes

  See 'nodectl help probe <subcommand>' for detailed help.
```

`nil` means inherit, like `helpNames`. A subcommand can declare its own banner to replace an inherited one, or `""` to suppress it. Banners are rendered verbatim, so multi-line banners and ASCII art are not wrapped.

<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
