### PR TITLE
Fix non-repeating option Bash completions

### DIFF
--- a/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
+++ b/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift
@@ -107,10 +107,10 @@ extension CommandInfoV0 {
                         fi
                     done
                     if "${not_found}"; then
-                        for index in "${!non_repeating_flags[@]}"; do
-                            if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                                unset "non_repeating_flags[${index}]"
-                                non_repeating_flags=("${non_repeating_flags[@]}")
+                        for index in "${!non_repeating_options[@]}"; do
+                            if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                                unset "non_repeating_options[${index}]"
+                                non_repeating_options=("${non_repeating_options[@]}")
                                 break
                             fi
                         done

--- a/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
+++ b/Tests/ArgumentParserExampleTests/Snapshots/testMathBashCompletionScript().bash
@@ -85,10 +85,10 @@ __math_offer_flags_options() {
                     fi
                 done
                 if "${not_found}"; then
-                    for index in "${!non_repeating_flags[@]}"; do
-                        if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                            unset "non_repeating_flags[${index}]"
-                            non_repeating_flags=("${non_repeating_flags[@]}")
+                    for index in "${!non_repeating_options[@]}"; do
+                        if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                            unset "non_repeating_options[${index}]"
+                            non_repeating_options=("${non_repeating_options[@]}")
                             break
                         fi
                     done

--- a/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testBase_Bash().bash
@@ -85,10 +85,10 @@ __base-test_offer_flags_options() {
                     fi
                 done
                 if "${not_found}"; then
-                    for index in "${!non_repeating_flags[@]}"; do
-                        if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                            unset "non_repeating_flags[${index}]"
-                            non_repeating_flags=("${non_repeating_flags[@]}")
+                    for index in "${!non_repeating_options[@]}"; do
+                        if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                            unset "non_repeating_options[${index}]"
+                            non_repeating_options=("${non_repeating_options[@]}")
                             break
                         fi
                     done

--- a/Tests/ArgumentParserUnitTests/Snapshots/testDefaultAsFlagCompletion_Bash().bash
+++ b/Tests/ArgumentParserUnitTests/Snapshots/testDefaultAsFlagCompletion_Bash().bash
@@ -85,10 +85,10 @@ __defaultasflag-test_offer_flags_options() {
                     fi
                 done
                 if "${not_found}"; then
-                    for index in "${!non_repeating_flags[@]}"; do
-                        if [[ "${non_repeating_flags[${index}]}" = "${word}" ]]; then
-                            unset "non_repeating_flags[${index}]"
-                            non_repeating_flags=("${non_repeating_flags[@]}")
+                    for index in "${!non_repeating_options[@]}"; do
+                        if [[ "${non_repeating_options[${index}]}" = "${word}" ]]; then
+                            unset "non_repeating_options[${index}]"
+                            non_repeating_options=("${non_repeating_options[@]}")
                             break
                         fi
                     done


### PR DESCRIPTION
Fixes #936.

Generated Bash completion scripts now remove previously used non-repeating options from the completion candidates. The fallback previously searched `non_repeating_flags` a second time instead of searching `non_repeating_options`.

The affected Bash completion snapshots have been updated to cover the corrected output.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary