### PR TITLE
Migrate more end-to-end test suites to Swift Testing

### DIFF
--- a/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/JoinedEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class JoinedEndToEndTests: XCTestCase {}
+@Suite struct JoinedEndToEndTests {}
 
 // MARK: -
 
@@ -32,68 +31,68 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension JoinedEndToEndTests {
-  func testSingleValueParsing() throws {
-    AssertParse(Foo.self, []) { foo in
-      XCTAssertEqual(foo.file, "")
-      XCTAssertEqual(foo.debug, "")
-      XCTAssertEqual(foo.fdi, false)
+  @Test func singleValueParsing() throws {
+    expectParse(Foo.self, []) { foo in
+      #expect(foo.file == "")
+      #expect(foo.debug == "")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-f", "file", "-d=Debug"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-f", "file", "-d=Debug"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-f", "file", "-d", "Debug"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-f", "file", "-d", "Debug"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-f", "file", "-dDebug"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-f", "file", "-dDebug"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-dDebug", "-f", "file"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-dDebug", "-f", "file"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-dDebug"]) { foo in
-      XCTAssertEqual(foo.file, "")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-dDebug"]) { foo in
+      #expect(foo.file == "")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-fd", "file", "Debug"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, false)
+    expectParse(Foo.self, ["-fd", "file", "Debug"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == false)
     }
 
-    AssertParse(Foo.self, ["-fd", "file", "Debug", "-fdi"]) { foo in
-      XCTAssertEqual(foo.file, "file")
-      XCTAssertEqual(foo.debug, "Debug")
-      XCTAssertEqual(foo.fdi, true)
+    expectParse(Foo.self, ["-fd", "file", "Debug", "-fdi"]) { foo in
+      #expect(foo.file == "file")
+      #expect(foo.debug == "Debug")
+      #expect(foo.fdi == true)
     }
 
-    AssertParse(Foo.self, ["-fdi"]) { foo in
-      XCTAssertEqual(foo.file, "")
-      XCTAssertEqual(foo.debug, "")
-      XCTAssertEqual(foo.fdi, true)
+    expectParse(Foo.self, ["-fdi"]) { foo in
+      #expect(foo.file == "")
+      #expect(foo.debug == "")
+      #expect(foo.fdi == true)
     }
   }
 
-  func testSingleValueParsing_Fails() throws {
-    XCTAssertThrowsError(try Foo.parse(["-f", "-d"]))
-    XCTAssertThrowsError(try Foo.parse(["-f", "file", "-d"]))
-    XCTAssertThrowsError(try Foo.parse(["-fd", "file"]))
-    XCTAssertThrowsError(try Foo.parse(["-fdDebug", "file"]))
-    XCTAssertThrowsError(try Foo.parse(["-fFile"]))
+  @Test func singleValueParsing_Fails() throws {
+    #expect(throws: (any Error).self) { try Foo.parse(["-f", "-d"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["-f", "file", "-d"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["-fd", "file"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["-fdDebug", "file"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["-fFile"]) }
   }
 }
 
@@ -107,27 +106,27 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension JoinedEndToEndTests {
-  func testArrayValueParsing() throws {
-    AssertParse(Bar.self, []) { bar in
-      XCTAssertEqual(bar.debug, [])
+  @Test func arrayValueParsing() throws {
+    expectParse(Bar.self, []) { bar in
+      #expect(bar.debug == [])
     }
 
-    AssertParse(Bar.self, ["-Ddebug1"]) { bar in
-      XCTAssertEqual(bar.debug, ["debug1"])
+    expectParse(Bar.self, ["-Ddebug1"]) { bar in
+      #expect(bar.debug == ["debug1"])
     }
 
-    AssertParse(Bar.self, ["-Ddebug1", "-Ddebug2", "-Ddebug3"]) { bar in
-      XCTAssertEqual(bar.debug, ["debug1", "debug2", "debug3"])
+    expectParse(Bar.self, ["-Ddebug1", "-Ddebug2", "-Ddebug3"]) { bar in
+      #expect(bar.debug == ["debug1", "debug2", "debug3"])
     }
 
-    AssertParse(Bar.self, ["-D", "debug1", "-Ddebug2", "-D", "debug3"]) { bar in
-      XCTAssertEqual(bar.debug, ["debug1", "debug2", "debug3"])
+    expectParse(Bar.self, ["-D", "debug1", "-Ddebug2", "-D", "debug3"]) { bar in
+      #expect(bar.debug == ["debug1", "debug2", "debug3"])
     }
   }
 
-  func testArrayValueParsing_Fails() throws {
-    XCTAssertThrowsError(try Bar.parse(["-D"]))
-    XCTAssertThrowsError(try Bar.parse(["-Ddebug1", "debug2"]))
+  @Test func arrayValueParsing_Fails() throws {
+    #expect(throws: (any Error).self) { try Bar.parse(["-D"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["-Ddebug1", "debug2"]) }
   }
 }
 
@@ -144,31 +143,33 @@ private struct Baz: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension JoinedEndToEndTests {
-  func testArrayUpToNextParsing() throws {
-    AssertParse(Baz.self, []) { baz in
-      XCTAssertEqual(baz.debug, [])
+  @Test func arrayUpToNextParsing() throws {
+    expectParse(Baz.self, []) { baz in
+      #expect(baz.debug == [])
     }
 
-    AssertParse(Baz.self, ["-Ddebug1", "debug2"]) { baz in
-      XCTAssertEqual(baz.debug, ["debug1", "debug2"])
-      XCTAssertEqual(baz.verbose, false)
+    expectParse(Baz.self, ["-Ddebug1", "debug2"]) { baz in
+      #expect(baz.debug == ["debug1", "debug2"])
+      #expect(baz.verbose == false)
     }
 
-    AssertParse(Baz.self, ["-Ddebug1", "debug2", "--verbose"]) { baz in
-      XCTAssertEqual(baz.debug, ["debug1", "debug2"])
-      XCTAssertEqual(baz.verbose, true)
+    expectParse(Baz.self, ["-Ddebug1", "debug2", "--verbose"]) { baz in
+      #expect(baz.debug == ["debug1", "debug2"])
+      #expect(baz.verbose == true)
     }
 
-    AssertParse(Baz.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { baz in
-      XCTAssertEqual(baz.debug, ["debug1", "debug2", "debug3", "debug4"])
+    expectParse(Baz.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4"]) { baz in
+      #expect(baz.debug == ["debug1", "debug2", "debug3", "debug4"])
     }
   }
 
-  func testArrayUpToNextParsing_Fails() throws {
-    XCTAssertThrowsError(try Baz.parse(["-D", "--other"]))
-    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "--other"]))
-    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "--other"]))
-    XCTAssertThrowsError(try Baz.parse(["-Ddebug", "debug", "--other"]))
+  @Test func arrayUpToNextParsing_Fails() throws {
+    #expect(throws: (any Error).self) { try Baz.parse(["-D", "--other"]) }
+    #expect(throws: (any Error).self) { try Baz.parse(["-Ddebug", "--other"]) }
+    #expect(throws: (any Error).self) { try Baz.parse(["-Ddebug", "--other"]) }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["-Ddebug", "debug", "--other"])
+    }
   }
 }
 
@@ -182,24 +183,26 @@ private struct Qux: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension JoinedEndToEndTests {
-  func testArrayRemainingParsing() throws {
-    AssertParse(Qux.self, []) { qux in
-      XCTAssertEqual(qux.debug, [])
+  @Test func arrayRemainingParsing() throws {
+    expectParse(Qux.self, []) { qux in
+      #expect(qux.debug == [])
     }
 
-    AssertParse(Qux.self, ["-Ddebug1", "debug2"]) { qux in
-      XCTAssertEqual(qux.debug, ["debug1", "debug2"])
+    expectParse(Qux.self, ["-Ddebug1", "debug2"]) { qux in
+      #expect(qux.debug == ["debug1", "debug2"])
     }
 
-    AssertParse(
+    expectParse(
       Qux.self, ["-Ddebug1", "debug2", "-Ddebug3", "debug4", "--other"]
     ) { qux in
-      XCTAssertEqual(
-        qux.debug, ["debug1", "debug2", "-Ddebug3", "debug4", "--other"])
+      #expect(
+        qux.debug == ["debug1", "debug2", "-Ddebug3", "debug4", "--other"])
     }
   }
 
-  func testArrayRemainingParsing_Fails() throws {
-    XCTAssertThrowsError(try Baz.parse(["--other", "-Ddebug", "debug"]))
+  @Test func arrayRemainingParsing_Fails() throws {
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--other", "-Ddebug", "debug"])
+    }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/LongNameWithShortDashEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/LongNameWithShortDashEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class LongNameWithSingleDashEndToEndTests: XCTestCase {}
+@Suite struct LongNameWithSingleDashEndToEndTests {}
 
 // MARK: -
 
@@ -32,81 +31,80 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension LongNameWithSingleDashEndToEndTests {
-  func testParsing_empty() throws {
-    AssertParse(Bar.self, []) { options in
-      XCTAssertEqual(options.file, false)
-      XCTAssertEqual(options.force, false)
-      XCTAssertEqual(options.input, false)
+  @Test func parsing_empty() throws {
+    expectParse(Bar.self, []) { options in
+      #expect(options.file == false)
+      #expect(options.force == false)
+      #expect(options.input == false)
     }
   }
 
-  func testParsing_singleOption_1() {
-    AssertParse(Bar.self, ["-file"]) { options in
-      XCTAssertEqual(options.file, true)
-      XCTAssertEqual(options.force, false)
-      XCTAssertEqual(options.input, false)
+  @Test func parsing_singleOption_1() {
+    expectParse(Bar.self, ["-file"]) { options in
+      #expect(options.file == true)
+      #expect(options.force == false)
+      #expect(options.input == false)
     }
   }
 
-  func testParsing_singleOption_2() {
-    AssertParse(Bar.self, ["-f"]) { options in
-      XCTAssertEqual(options.file, false)
-      XCTAssertEqual(options.force, true)
-      XCTAssertEqual(options.input, false)
+  @Test func parsing_singleOption_2() {
+    expectParse(Bar.self, ["-f"]) { options in
+      #expect(options.file == false)
+      #expect(options.force == true)
+      #expect(options.input == false)
     }
   }
 
-  func testParsing_singleOption_3() {
-    AssertParse(Bar.self, ["-i"]) { options in
-      XCTAssertEqual(options.file, false)
-      XCTAssertEqual(options.force, false)
-      XCTAssertEqual(options.input, true)
+  @Test func parsing_singleOption_3() {
+    expectParse(Bar.self, ["-i"]) { options in
+      #expect(options.file == false)
+      #expect(options.force == false)
+      #expect(options.input == true)
     }
   }
 
-  func testParsing_combined_1() {
-    AssertParse(Bar.self, ["-f", "-i"]) { options in
-      XCTAssertEqual(options.file, false)
-      XCTAssertEqual(options.force, true)
-      XCTAssertEqual(options.input, true)
+  @Test func parsing_combined_1() {
+    expectParse(Bar.self, ["-f", "-i"]) { options in
+      #expect(options.file == false)
+      #expect(options.force == true)
+      #expect(options.input == true)
     }
   }
 
-  func testParsing_combined_2() {
-    AssertParse(Bar.self, ["-fi"]) { options in
-      XCTAssertEqual(options.file, false)
-      XCTAssertEqual(options.force, true)
-      XCTAssertEqual(options.input, true)
+  @Test func parsing_combined_2() {
+    expectParse(Bar.self, ["-fi"]) { options in
+      #expect(options.file == false)
+      #expect(options.force == true)
+      #expect(options.input == true)
     }
   }
 
-  func testParsing_combined_3() {
-    AssertParse(Bar.self, ["-file", "-f"]) { options in
-      XCTAssertEqual(options.file, true)
-      XCTAssertEqual(options.force, true)
-      XCTAssertEqual(options.input, false)
+  @Test func parsing_combined_3() {
+    expectParse(Bar.self, ["-file", "-f"]) { options in
+      #expect(options.file == true)
+      #expect(options.force == true)
+      #expect(options.input == false)
     }
   }
 
-  func testParsing_combined_4() {
-    AssertParse(Bar.self, ["-file", "-i"]) { options in
-      XCTAssertEqual(options.file, true)
-      XCTAssertEqual(options.force, false)
-      XCTAssertEqual(options.input, true)
+  @Test func parsing_combined_4() {
+    expectParse(Bar.self, ["-file", "-i"]) { options in
+      #expect(options.file == true)
+      #expect(options.force == false)
+      #expect(options.input == true)
     }
   }
 
-  func testParsing_combined_5() {
-    AssertParse(Bar.self, ["-file", "-fi"]) { options in
-      XCTAssertEqual(options.file, true)
-      XCTAssertEqual(options.force, true)
-      XCTAssertEqual(options.input, true)
+  @Test func parsing_combined_5() {
+    expectParse(Bar.self, ["-file", "-fi"]) { options in
+      #expect(options.file == true)
+      #expect(options.force == true)
+      #expect(options.input == true)
     }
   }
 
-  func testParsing_invalid() throws {
-    //XCTAssertThrowsError(try Bar.parse(["-fil"]))
-    XCTAssertThrowsError(try Bar.parse(["--file"]))
+  @Test func parsing_invalid() throws {
+    #expect(throws: (any Error).self) { try Bar.parse(["--file"]) }
   }
 }
 
@@ -120,11 +118,11 @@ extension LongNameWithSingleDashEndToEndTests {
     var args: [String]
   }
 
-  func testIssue327() {
-    AssertParse(
+  @Test func issue327() {
+    expectParse(
       Issue327.self, ["-argWithAnH", "03ade86c0", "8f2058e3ade86c84ec5b"]
     ) { issue327 in
-      XCTAssertEqual(issue327.args, ["03ade86c0", "8f2058e3ade86c84ec5b"])
+      #expect(issue327.args == ["03ade86c0", "8f2058e3ade86c84ec5b"])
     }
   }
 
@@ -133,9 +131,9 @@ extension LongNameWithSingleDashEndToEndTests {
     var arg: String
   }
 
-  func testJoinedItem_Issue327() {
-    AssertParse(JoinedItem.self, ["-argWithAnH=foo"]) { joinedItem in
-      XCTAssertEqual(joinedItem.arg, "foo")
+  @Test func joinedItem_Issue327() {
+    expectParse(JoinedItem.self, ["-argWithAnH=foo"]) { joinedItem in
+      #expect(joinedItem.arg == "foo")
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/ShortNameEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ShortNameEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class ShortNameEndToEndTests: XCTestCase {
-}
+@Suite struct ShortNameEndToEndTests {}
 
 // MARK: -
 
@@ -33,57 +31,57 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension ShortNameEndToEndTests {
-  func testParsing_withLongNames() throws {
-    AssertParse(Bar.self, ["foo"]) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertNil(options.file)
-      XCTAssertEqual(options.name, "foo")
+  @Test func parsing_withLongNames() throws {
+    expectParse(Bar.self, ["foo"]) { options in
+      #expect(options.verbose == false)
+      #expect(options.file == nil)
+      #expect(options.name == "foo")
     }
 
-    AssertParse(Bar.self, ["--verbose", "--file", "myfile", "foo"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
-    }
-  }
-
-  func testParsing_simple() throws {
-    AssertParse(Bar.self, ["-v", "foo"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertNil(options.file)
-      XCTAssertEqual(options.name, "foo")
-    }
-
-    AssertParse(Bar.self, ["-f", "myfile", "foo"]) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
-    }
-
-    AssertParse(Bar.self, ["-v", "-f", "myfile", "foo"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
+    expectParse(Bar.self, ["--verbose", "--file", "myfile", "foo"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
     }
   }
 
-  func testParsing_combined() throws {
-    AssertParse(Bar.self, ["-vf", "myfile", "foo"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
+  @Test func parsing_simple() throws {
+    expectParse(Bar.self, ["-v", "foo"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == nil)
+      #expect(options.name == "foo")
     }
 
-    AssertParse(Bar.self, ["-fv", "myfile", "foo"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
+    expectParse(Bar.self, ["-f", "myfile", "foo"]) { options in
+      #expect(options.verbose == false)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
     }
 
-    AssertParse(Bar.self, ["foo", "-fv", "myfile"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.file, "myfile")
-      XCTAssertEqual(options.name, "foo")
+    expectParse(Bar.self, ["-v", "-f", "myfile", "foo"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
+    }
+  }
+
+  @Test func parsing_combined() throws {
+    expectParse(Bar.self, ["-vf", "myfile", "foo"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
+    }
+
+    expectParse(Bar.self, ["-fv", "myfile", "foo"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
+    }
+
+    expectParse(Bar.self, ["foo", "-fv", "myfile"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.file == "myfile")
+      #expect(options.name == "foo")
     }
   }
 }
@@ -104,41 +102,41 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension ShortNameEndToEndTests {
-  func testParsing_combinedShortNames() throws {
-    AssertParse(Foo.self, ["-nfc", "name", "file", "city"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+  @Test func parsing_combinedShortNames() throws {
+    expectParse(Foo.self, ["-nfc", "name", "file", "city"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
 
-    AssertParse(Foo.self, ["-ncf", "name", "city", "file"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+    expectParse(Foo.self, ["-ncf", "name", "city", "file"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
 
-    AssertParse(Foo.self, ["-fnc", "file", "name", "city"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+    expectParse(Foo.self, ["-fnc", "file", "name", "city"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
 
-    AssertParse(Foo.self, ["-fcn", "file", "city", "name"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+    expectParse(Foo.self, ["-fcn", "file", "city", "name"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
 
-    AssertParse(Foo.self, ["-cnf", "city", "name", "file"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+    expectParse(Foo.self, ["-cnf", "city", "name", "file"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
 
-    AssertParse(Foo.self, ["-cfn", "city", "file", "name"]) { options in
-      XCTAssertEqual(options.name, "name")
-      XCTAssertEqual(options.file, "file")
-      XCTAssertEqual(options.city, "city")
+    expectParse(Foo.self, ["-cfn", "city", "file", "name"]) { options in
+      #expect(options.name == "name")
+      #expect(options.file == "file")
+      #expect(options.city == "city")
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class SimpleEndToEndTests: XCTestCase {}
+@Suite struct SimpleEndToEndTests {}
 
 // MARK: Single value String
 
@@ -25,27 +24,41 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension SimpleEndToEndTests {
-  func testParsing_SingleOption() throws {
-    AssertParse(Bar.self, ["--name", "Bar"]) { bar in
-      XCTAssertEqual(bar.name, "Bar")
+  @Test func parsing_SingleOption() throws {
+    expectParse(Bar.self, ["--name", "Bar"]) { bar in
+      #expect(bar.name == "Bar")
     }
-    AssertParse(Bar.self, ["--name", " foo "]) { bar in
-      XCTAssertEqual(bar.name, " foo ")
+    expectParse(Bar.self, ["--name", " foo "]) { bar in
+      #expect(bar.name == " foo ")
     }
   }
 
-  func testParsing_SingleOption_Fails() throws {
-    XCTAssertThrowsError(try Bar.parse([]))
-    XCTAssertThrowsError(try Bar.parse(["--name"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "--foo"]))
-    XCTAssertThrowsError(try Bar.parse(["Bar"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "Bar", "Baz"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "Bar", "--foo"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "Bar", "--foo", "Foo"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "Bar", "-f"]))
-    XCTAssertThrowsError(try Bar.parse(["--foo", "--name", "Bar"]))
-    XCTAssertThrowsError(try Bar.parse(["--foo", "Foo", "--name", "Bar"]))
-    XCTAssertThrowsError(try Bar.parse(["-f", "--name", "Bar"]))
+  @Test func parsing_SingleOption_Fails() throws {
+    #expect(throws: (any Error).self) { try Bar.parse([]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name", "--foo"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["Bar"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "Bar", "Baz"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "Bar", "--foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "Bar", "--foo", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "Bar", "-f"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--foo", "--name", "Bar"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--foo", "Foo", "--name", "Bar"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["-f", "--name", "Bar"])
+    }
   }
 }
 
@@ -58,24 +71,38 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension SimpleEndToEndTests {
-  func testParsing_SingleOption_Int() throws {
-    AssertParse(Foo.self, ["--count", "42"]) { foo in
-      XCTAssertEqual(foo.count, 42)
+  @Test func parsing_SingleOption_Int() throws {
+    expectParse(Foo.self, ["--count", "42"]) { foo in
+      #expect(foo.count == 42)
     }
   }
 
-  func testParsing_SingleOption_Int_Fails() throws {
-    XCTAssertThrowsError(try Foo.parse([]))
-    XCTAssertThrowsError(try Foo.parse(["--count"]))
-    XCTAssertThrowsError(try Foo.parse(["--count", "a"]))
-    XCTAssertThrowsError(try Foo.parse(["Bar"]))
-    XCTAssertThrowsError(try Foo.parse(["--count", "42", "Baz"]))
-    XCTAssertThrowsError(try Foo.parse(["--count", "42", "--foo"]))
-    XCTAssertThrowsError(try Foo.parse(["--count", "42", "--foo", "Foo"]))
-    XCTAssertThrowsError(try Foo.parse(["--count", "42", "-f"]))
-    XCTAssertThrowsError(try Foo.parse(["--foo", "--count", "42"]))
-    XCTAssertThrowsError(try Foo.parse(["--foo", "Foo", "--count", "42"]))
-    XCTAssertThrowsError(try Foo.parse(["-f", "--count", "42"]))
+  @Test func parsing_SingleOption_Int_Fails() throws {
+    #expect(throws: (any Error).self) { try Foo.parse([]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["--count"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["--count", "a"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["Bar"]) }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--count", "42", "Baz"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--count", "42", "--foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--count", "42", "--foo", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--count", "42", "-f"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--foo", "--count", "42"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--foo", "Foo", "--count", "42"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["-f", "--count", "42"])
+    }
   }
 }
 
@@ -89,38 +116,59 @@ private struct Baz: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension SimpleEndToEndTests {
-  func testParsing_TwoOptions_1() throws {
-    AssertParse(Baz.self, ["--name", "Bar", "--format", "Foo"]) { baz in
-      XCTAssertEqual(baz.name, "Bar")
-      XCTAssertEqual(baz.format, "Foo")
+  @Test func parsing_TwoOptions_1() throws {
+    expectParse(Baz.self, ["--name", "Bar", "--format", "Foo"]) { baz in
+      #expect(baz.name == "Bar")
+      #expect(baz.format == "Foo")
     }
   }
 
-  func testParsing_TwoOptions_2() throws {
-    AssertParse(Baz.self, ["--format", "Foo", "--name", "Bar"]) { baz in
-      XCTAssertEqual(baz.name, "Bar")
-      XCTAssertEqual(baz.format, "Foo")
+  @Test func parsing_TwoOptions_2() throws {
+    expectParse(Baz.self, ["--format", "Foo", "--name", "Bar"]) { baz in
+      #expect(baz.name == "Bar")
+      #expect(baz.format == "Foo")
     }
   }
 
-  func testParsing_TwoOptions_Fails() throws {
-    XCTAssertThrowsError(try Baz.parse(["--nam", "Bar", "--format", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["--name", "Bar", "--forma", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["--name", "Bar"]))
-    XCTAssertThrowsError(try Baz.parse(["--format", "Foo"]))
+  @Test func parsing_TwoOptions_Fails() throws {
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--nam", "Bar", "--format", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "Bar", "--forma", "Foo"])
+    }
+    #expect(throws: (any Error).self) { try Baz.parse(["--name", "Bar"]) }
+    #expect(throws: (any Error).self) { try Baz.parse(["--format", "Foo"]) }
 
-    XCTAssertThrowsError(try Baz.parse(["--name", "--format", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["--name", "Bar", "--format"]))
-    XCTAssertThrowsError(
-      try Baz.parse(["--name", "Bar", "--format", "Foo", "Baz"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar", "--name", "--format", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar", "--name", "Foo", "--format"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar", "Foo", "--name", "--format"]))
-    XCTAssertThrowsError(
-      try Baz.parse(["--name", "--name", "Bar", "--format", "Foo"]))
-    XCTAssertThrowsError(
-      try Baz.parse(["--name", "Bar", "--format", "--format", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["--format", "--name", "Bar", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["--name", "--format", "Bar", "Foo"]))
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "--format", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "Bar", "--format"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "Bar", "--format", "Foo", "Baz"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["Bar", "--name", "--format", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["Bar", "--name", "Foo", "--format"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["Bar", "Foo", "--name", "--format"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "--name", "Bar", "--format", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "Bar", "--format", "--format", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--format", "--name", "Bar", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "--format", "Bar", "Foo"])
+    }
   }
 }

--- a/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/CountLinesExampleTests.swift
@@ -17,7 +17,7 @@ import Testing
 
 @testable import ArgumentParser
 
-@Suite struct CountLinesExampleTests {
+@Suite(.serialized) struct CountLinesExampleTests {
   init() {
     Platform.Environment[.columns] = nil
   }

--- a/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RepeatExampleTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 @testable import ArgumentParser
 
-@Suite struct RepeatExampleTests {
+@Suite(.serialized) struct RepeatExampleTests {
   init() {
     Platform.Environment[.columns] = nil
   }

--- a/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
+++ b/Tests/ArgumentParserExampleTests/RollDiceExampleTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 @testable import ArgumentParser
 
-@Suite struct RollDiceExampleTests {
+@Suite(.serialized) struct RollDiceExampleTests {
   init() {
     Platform.Environment[.columns] = nil
   }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.
--->

Migrate four `ArgumentParserEndToEndTests` suites from XCTest to
Swift Testing:

- `ShortNameEndToEndTests`
- `JoinedEndToEndTests`
- `LongNameWithSingleDashEndToEndTests`
- `SimpleEndToEndTests`

Each file previously imported both `Testing` and `XCTest` from earlier
prep work but still used `XCTestCase` and `XCTAssert*`. Convert to
`@Suite struct` + `@Test func`, `AssertParse` → `expectParse`,
`XCTAssertEqual` → `#expect(a == b)`, and `XCTAssertThrowsError` →
`#expect(throws: (any Error).self)`. No new helpers required.

Relates to #710

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>