### PR TITLE
Migrate more end-to-end suites to Swift Testing

### DIFF
--- a/Tests/ArgumentParserEndToEndTests/OptionGroupEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/OptionGroupEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,11 +12,16 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class OptionGroupEndToEndTests: XCTestCase {}
+@Suite struct OptionGroupEndToEndTests {}
 
-private struct Inner: TestableParsableArguments {
+private enum ValidationConfirmations {
+  @TaskLocal static var inner: Confirmation?
+  @TaskLocal static var outer: Confirmation?
+  @TaskLocal static var command: Confirmation?
+}
+
+private struct Inner: ParsableArguments {
   @Flag(name: [.short, .long])
   var extraVerbiage: Bool = false
   @Option
@@ -24,17 +29,12 @@ private struct Inner: TestableParsableArguments {
   @Argument()
   var name: String
 
-  let didValidateExpectation = XCTestExpectation(
-    singleExpectation: "inner validated")
-
-  private enum CodingKeys: CodingKey {
-    case extraVerbiage
-    case size
-    case name
+  mutating func validate() throws {
+    ValidationConfirmations.inner?()
   }
 }
 
-private struct Outer: TestableParsableArguments {
+private struct Outer: ParsableArguments {
   @Flag
   var verbose: Bool = false
   @Argument()
@@ -44,87 +44,86 @@ private struct Outer: TestableParsableArguments {
   @Argument()
   var after: String
 
-  let didValidateExpectation = XCTestExpectation(
-    singleExpectation: "outer validated")
-
-  private enum CodingKeys: CodingKey {
-    case verbose
-    case before
-    case inner
-    case after
+  mutating func validate() throws {
+    ValidationConfirmations.outer?()
   }
 }
 
-private struct Command: TestableParsableCommand {
+private struct Command: ParsableCommand {
   static let configuration = CommandConfiguration(commandName: "testCommand")
 
   @OptionGroup()
   var outer: Outer
 
-  let didValidateExpectation = XCTestExpectation(
-    singleExpectation: "Command validated")
-  let didRunExpectation = XCTestExpectation(singleExpectation: "Command ran")
-
-  private enum CodingKeys: CodingKey {
-    case outer
+  mutating func validate() throws {
+    ValidationConfirmations.command?()
   }
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension OptionGroupEndToEndTests {
-  func testOptionGroup_Defaults() throws {
-    AssertParse(Outer.self, ["prefix", "name", "postfix"]) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertEqual(options.before, "prefix")
-      XCTAssertEqual(options.after, "postfix")
+  @Test func optionGroup_Defaults() throws {
+    expectParse(Outer.self, ["prefix", "name", "postfix"]) { options in
+      #expect(options.verbose == false)
+      #expect(options.before == "prefix")
+      #expect(options.after == "postfix")
 
-      XCTAssertEqual(options.inner.extraVerbiage, false)
-      XCTAssertEqual(options.inner.size, 0)
-      XCTAssertEqual(options.inner.name, "name")
+      #expect(options.inner.extraVerbiage == false)
+      #expect(options.inner.size == 0)
+      #expect(options.inner.name == "name")
     }
 
-    AssertParse(
+    expectParse(
       Outer.self,
       [
         "prefix", "--extra-verbiage", "name", "postfix", "--verbose", "--size",
         "5",
       ]
     ) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.before, "prefix")
-      XCTAssertEqual(options.after, "postfix")
+      #expect(options.verbose == true)
+      #expect(options.before == "prefix")
+      #expect(options.after == "postfix")
 
-      XCTAssertEqual(options.inner.extraVerbiage, true)
-      XCTAssertEqual(options.inner.size, 5)
-      XCTAssertEqual(options.inner.name, "name")
+      #expect(options.inner.extraVerbiage == true)
+      #expect(options.inner.size == 5)
+      #expect(options.inner.name == "name")
     }
   }
 
-  func testOptionGroup_isValidated() {
-    // Parse the command, this should cause validation to be once each on
+  @Test func optionGroup_isValidated() async throws {
+    // Parse the command, this should cause validation to be called once each
+    // on:
     // - command.outer.inner
     // - command.outer
     // - command
-    AssertParseCommand(
-      Command.self, Command.self, ["prefix", "name", "postfix"]
-    ) { command in
-      wait(
-        for: [
-          command.didValidateExpectation, command.outer.didValidateExpectation,
-          command.outer.inner.didValidateExpectation,
-        ], timeout: 0.1)
+    await confirmation("Command validated") { commandValidated in
+      await confirmation("Outer validated") { outerValidated in
+        await confirmation("Inner validated") { innerValidated in
+          ValidationConfirmations.$command.withValue(commandValidated) {
+            ValidationConfirmations.$outer.withValue(outerValidated) {
+              ValidationConfirmations.$inner.withValue(innerValidated) {
+                expectParseCommand(
+                  Command.self, Command.self, ["prefix", "name", "postfix"]
+                ) { _ in }
+              }
+            }
+          }
+        }
+      }
     }
   }
 
-  func testOptionGroup_Fails() throws {
-    XCTAssertThrowsError(try Outer.parse([]))
-    XCTAssertThrowsError(try Outer.parse(["prefix"]))
-    XCTAssertThrowsError(try Outer.parse(["prefix", "name"]))
-    XCTAssertThrowsError(
-      try Outer.parse(["prefix", "name", "postfix", "extra"]))
-    XCTAssertThrowsError(
-      try Outer.parse(["prefix", "name", "postfix", "--size", "a"]))
+  @Test func optionGroup_Fails() throws {
+    #expect(throws: (any Error).self) { try Outer.parse([]) }
+    #expect(throws: (any Error).self) { try Outer.parse(["prefix"]) }
+    #expect(throws: (any Error).self) { try Outer.parse(["prefix", "name"]) }
+    #expect(throws: (any Error).self) {
+      try Outer.parse(["prefix", "name", "postfix", "extra"])
+    }
+    #expect(throws: (any Error).self) {
+      try Outer.parse(["prefix", "name", "postfix", "--size", "a"])
+    }
   }
 }
 
@@ -151,57 +150,57 @@ private struct DuplicatedFlagGroupLongCommand: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension OptionGroupEndToEndTests {
-  func testUniqueNamesForDuplicatedFlag_NoFlags() throws {
-    AssertParse(DuplicatedFlagGroupCustomCommand.self, []) { command in
-      XCTAssertFalse(command.duplicated)
-      XCTAssertFalse(command.option.duplicated)
+  @Test func uniqueNamesForDuplicatedFlag_NoFlags() throws {
+    expectParse(DuplicatedFlagGroupCustomCommand.self, []) { command in
+      #expect(!command.duplicated)
+      #expect(!command.option.duplicated)
     }
-    AssertParse(DuplicatedFlagGroupLongCommand.self, []) { command in
-      XCTAssertFalse(command.duplicated)
-      XCTAssertFalse(command.option.duplicated)
-    }
-  }
-
-  func testUniqueNamesForDuplicatedFlag_RootOnly() throws {
-    AssertParse(DuplicatedFlagGroupCustomCommand.self, ["--duplicated"]) {
-      command in
-      XCTAssertTrue(command.duplicated)
-      XCTAssertFalse(command.option.duplicated)
-    }
-    AssertParse(DuplicatedFlagGroupLongCommand.self, ["--duplicated"]) {
-      command in
-      XCTAssertFalse(command.duplicated)
-      XCTAssertTrue(command.option.duplicated)
+    expectParse(DuplicatedFlagGroupLongCommand.self, []) { command in
+      #expect(!command.duplicated)
+      #expect(!command.option.duplicated)
     }
   }
 
-  func testUniqueNamesForDuplicatedFlag_OptionOnly() throws {
-    AssertParse(DuplicatedFlagGroupCustomCommand.self, ["--duplicated-option"])
+  @Test func uniqueNamesForDuplicatedFlag_RootOnly() throws {
+    expectParse(DuplicatedFlagGroupCustomCommand.self, ["--duplicated"]) {
+      command in
+      #expect(command.duplicated)
+      #expect(!command.option.duplicated)
+    }
+    expectParse(DuplicatedFlagGroupLongCommand.self, ["--duplicated"]) {
+      command in
+      #expect(!command.duplicated)
+      #expect(command.option.duplicated)
+    }
+  }
+
+  @Test func uniqueNamesForDuplicatedFlag_OptionOnly() throws {
+    expectParse(DuplicatedFlagGroupCustomCommand.self, ["--duplicated-option"])
     { command in
-      XCTAssertFalse(command.duplicated)
-      XCTAssertTrue(command.option.duplicated)
+      #expect(!command.duplicated)
+      #expect(command.option.duplicated)
     }
-    AssertParse(DuplicatedFlagGroupLongCommand.self, ["--duplicated-option"]) {
+    expectParse(DuplicatedFlagGroupLongCommand.self, ["--duplicated-option"]) {
       command in
-      XCTAssertTrue(command.duplicated)
-      XCTAssertFalse(command.option.duplicated)
+      #expect(command.duplicated)
+      #expect(!command.option.duplicated)
     }
   }
 
-  func testUniqueNamesForDuplicatedFlag_RootAndOption() throws {
-    AssertParse(
+  @Test func uniqueNamesForDuplicatedFlag_RootAndOption() throws {
+    expectParse(
       DuplicatedFlagGroupCustomCommand.self,
       ["--duplicated", "--duplicated-option"]
     ) { command in
-      XCTAssertTrue(command.duplicated)
-      XCTAssertTrue(command.option.duplicated)
+      #expect(command.duplicated)
+      #expect(command.option.duplicated)
     }
-    AssertParse(
+    expectParse(
       DuplicatedFlagGroupLongCommand.self,
       ["--duplicated", "--duplicated-option"]
     ) { command in
-      XCTAssertTrue(command.duplicated)
-      XCTAssertTrue(command.option.duplicated)
+      #expect(command.duplicated)
+      #expect(command.option.duplicated)
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/OptionalEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class OptionalEndToEndTests: XCTestCase {}
+@Suite struct OptionalEndToEndTests {}
 
 // MARK: -
 
@@ -29,25 +28,27 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension OptionalEndToEndTests {
-  func testParsing_Optional() throws {
-    AssertParse(Foo.self, []) { foo in
-      XCTAssertNil(foo.name)
-      XCTAssertNil(foo.max)
+  @Test func parsing_Optional() throws {
+    expectParse(Foo.self, []) { foo in
+      #expect(foo.name == nil)
+      #expect(foo.max == nil)
     }
 
-    AssertParse(Foo.self, ["--name", "A"]) { foo in
-      XCTAssertEqual(foo.name?.rawValue, "A")
-      XCTAssertNil(foo.max)
+    expectParse(Foo.self, ["--name", "A"]) { foo in
+      let name = try #require(foo.name)
+      #expect(name.rawValue == "A")
+      #expect(foo.max == nil)
     }
 
-    AssertParse(Foo.self, ["--max", "3"]) { foo in
-      XCTAssertNil(foo.name)
-      XCTAssertEqual(foo.max, 3)
+    expectParse(Foo.self, ["--max", "3"]) { foo in
+      #expect(foo.name == nil)
+      #expect(foo.max == 3)
     }
 
-    AssertParse(Foo.self, ["--max", "3", "--name", "A"]) { foo in
-      XCTAssertEqual(foo.name?.rawValue, "A")
-      XCTAssertEqual(foo.max, 3)
+    expectParse(Foo.self, ["--max", "3", "--name", "A"]) { foo in
+      let name = try #require(foo.name)
+      #expect(name.rawValue == "A")
+      #expect(foo.max == 3)
     }
   }
 }
@@ -70,152 +71,160 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension OptionalEndToEndTests {
-  func testParsing_Optional_WithAllValues_1() {
-    AssertParse(Bar.self, ["--name", "A", "--format", "B", "--foo", "C", "D"]) {
+  @Test func parsing_Optional_WithAllValues_1() {
+    expectParse(Bar.self, ["--name", "A", "--format", "B", "--foo", "C", "D"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithAllValues_2() {
-    AssertParse(Bar.self, ["D", "--format", "B", "--foo", "C", "--name", "A"]) {
+  @Test func parsing_Optional_WithAllValues_2() {
+    expectParse(Bar.self, ["D", "--format", "B", "--foo", "C", "--name", "A"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithAllValues_3() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "D", "--name", "A"]) {
+  @Test func parsing_Optional_WithAllValues_3() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "D", "--name", "A"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithMissingValues_1() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "D"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+  @Test func parsing_Optional_WithMissingValues_1() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "D"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithMissingValues_2() {
-    AssertParse(Bar.self, ["D", "--format", "B", "--foo", "C"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+  @Test func parsing_Optional_WithMissingValues_2() {
+    expectParse(Bar.self, ["D", "--format", "B", "--foo", "C"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithMissingValues_3() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "D"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, "D")
+  @Test func parsing_Optional_WithMissingValues_3() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "D"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == "D")
     }
   }
 
-  func testParsing_Optional_WithMissingValues_4() {
-    AssertParse(Bar.self, ["--name", "A", "--format", "B", "--foo", "C"]) {
+  @Test func parsing_Optional_WithMissingValues_4() {
+    expectParse(Bar.self, ["--name", "A", "--format", "B", "--foo", "C"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_5() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
+  @Test func parsing_Optional_WithMissingValues_5() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_6() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
+  @Test func parsing_Optional_WithMissingValues_6() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_7() {
-    AssertParse(Bar.self, ["--foo", "C"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, nil)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+  @Test func parsing_Optional_WithMissingValues_7() {
+    expectParse(Bar.self, ["--foo", "C"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == nil)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_8() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+  @Test func parsing_Optional_WithMissingValues_8() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_9() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+  @Test func parsing_Optional_WithMissingValues_9() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_10() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
-      XCTAssertEqual(bar.name, nil)
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+  @Test func parsing_Optional_WithMissingValues_10() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C"]) { bar in
+      #expect(bar.name == nil)
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_WithMissingValues_11() {
-    AssertParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
+  @Test func parsing_Optional_WithMissingValues_11() {
+    expectParse(Bar.self, ["--format", "B", "--foo", "C", "--name", "A"]) {
       bar in
-      XCTAssertEqual(bar.name, "A")
-      XCTAssertEqual(bar.format, .B)
-      XCTAssertEqual(bar.foo, "C")
-      XCTAssertEqual(bar.bar, nil)
+      #expect(bar.name == "A")
+      #expect(bar.format == .B)
+      #expect(bar.foo == "C")
+      #expect(bar.bar == nil)
     }
   }
 
-  func testParsing_Optional_Fails() throws {
-    XCTAssertThrowsError(try Bar.parse([]))
-    XCTAssertThrowsError(try Bar.parse(["--format", "ZZ", "--foo", "C"]))
-    XCTAssertThrowsError(try Bar.parse(["--fooz", "C"]))
-    XCTAssertThrowsError(try Bar.parse(["--nam", "A", "--foo", "C"]))
-    XCTAssertThrowsError(try Bar.parse(["--name"]))
-    XCTAssertThrowsError(try Bar.parse(["A"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "A", "D"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "A", "--foo"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "A", "--format", "B"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "A", "-f"]))
-    XCTAssertThrowsError(try Bar.parse(["D", "--name", "A"]))
-    XCTAssertThrowsError(try Bar.parse(["-f", "--name", "A"]))
+  @Test func parsing_Optional_Fails() throws {
+    #expect(throws: (any Error).self) { try Bar.parse([]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--format", "ZZ", "--foo", "C"])
+    }
+    #expect(throws: (any Error).self) { try Bar.parse(["--fooz", "C"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--nam", "A", "--foo", "C"])
+    }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["A"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name", "A", "D"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "A", "--foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--name", "A", "--format", "B"])
+    }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name", "A", "-f"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["D", "--name", "A"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["-f", "--name", "A"]) }
   }
 }
 

--- a/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/PositionalEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class PositionalEndToEndTests: XCTestCase {
-}
+@Suite struct PositionalEndToEndTests {}
 
 // MARK: Single value String
 
@@ -26,31 +24,31 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension PositionalEndToEndTests {
-  func testParsing_SinglePositional() throws {
-    AssertParse(Bar.self, ["Bar"]) { bar in
-      XCTAssertEqual(bar.name, "Bar")
+  @Test func parsing_SinglePositional() throws {
+    expectParse(Bar.self, ["Bar"]) { bar in
+      #expect(bar.name == "Bar")
     }
-    AssertParse(Bar.self, ["Bar-"]) { bar in
-      XCTAssertEqual(bar.name, "Bar-")
+    expectParse(Bar.self, ["Bar-"]) { bar in
+      #expect(bar.name == "Bar-")
     }
-    AssertParse(Bar.self, ["Bar--"]) { bar in
-      XCTAssertEqual(bar.name, "Bar--")
+    expectParse(Bar.self, ["Bar--"]) { bar in
+      #expect(bar.name == "Bar--")
     }
-    AssertParse(Bar.self, ["--", "-Bar"]) { bar in
-      XCTAssertEqual(bar.name, "-Bar")
+    expectParse(Bar.self, ["--", "-Bar"]) { bar in
+      #expect(bar.name == "-Bar")
     }
-    AssertParse(Bar.self, ["--", "--Bar"]) { bar in
-      XCTAssertEqual(bar.name, "--Bar")
+    expectParse(Bar.self, ["--", "--Bar"]) { bar in
+      #expect(bar.name == "--Bar")
     }
-    AssertParse(Bar.self, ["--", "--"]) { bar in
-      XCTAssertEqual(bar.name, "--")
+    expectParse(Bar.self, ["--", "--"]) { bar in
+      #expect(bar.name == "--")
     }
   }
 
-  func testParsing_SinglePositional_Fails() throws {
-    XCTAssertThrowsError(try Bar.parse([]))
-    XCTAssertThrowsError(try Bar.parse(["--name"]))
-    XCTAssertThrowsError(try Bar.parse(["Foo", "Bar"]))
+  @Test func parsing_SinglePositional_Fails() throws {
+    #expect(throws: (any Error).self) { try Bar.parse([]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["Foo", "Bar"]) }
   }
 }
 
@@ -64,36 +62,42 @@ private struct Baz: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension PositionalEndToEndTests {
-  func testParsing_TwoPositional() throws {
-    AssertParse(Baz.self, ["Bar", "Foo"]) { baz in
-      XCTAssertEqual(baz.name, "Bar")
-      XCTAssertEqual(baz.format, "Foo")
+  @Test func parsing_TwoPositional() throws {
+    expectParse(Baz.self, ["Bar", "Foo"]) { baz in
+      #expect(baz.name == "Bar")
+      #expect(baz.format == "Foo")
     }
-    AssertParse(Baz.self, ["", "Foo"]) { baz in
-      XCTAssertEqual(baz.name, "")
-      XCTAssertEqual(baz.format, "Foo")
+    expectParse(Baz.self, ["", "Foo"]) { baz in
+      #expect(baz.name == "")
+      #expect(baz.format == "Foo")
     }
-    AssertParse(Baz.self, ["Bar", ""]) { baz in
-      XCTAssertEqual(baz.name, "Bar")
-      XCTAssertEqual(baz.format, "")
+    expectParse(Baz.self, ["Bar", ""]) { baz in
+      #expect(baz.name == "Bar")
+      #expect(baz.format == "")
     }
-    AssertParse(Baz.self, ["--", "--b", "--f"]) { baz in
-      XCTAssertEqual(baz.name, "--b")
-      XCTAssertEqual(baz.format, "--f")
+    expectParse(Baz.self, ["--", "--b", "--f"]) { baz in
+      #expect(baz.name == "--b")
+      #expect(baz.format == "--f")
     }
-    AssertParse(Baz.self, ["b", "--", "--f"]) { baz in
-      XCTAssertEqual(baz.name, "b")
-      XCTAssertEqual(baz.format, "--f")
+    expectParse(Baz.self, ["b", "--", "--f"]) { baz in
+      #expect(baz.name == "b")
+      #expect(baz.format == "--f")
     }
   }
 
-  func testParsing_TwoPositional_Fails() throws {
-    XCTAssertThrowsError(try Baz.parse(["Bar", "Foo", "Baz"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar"]))
-    XCTAssertThrowsError(try Baz.parse([]))
-    XCTAssertThrowsError(try Baz.parse(["--name", "Bar", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar", "--name", "Foo"]))
-    XCTAssertThrowsError(try Baz.parse(["Bar", "Foo", "--name"]))
+  @Test func parsing_TwoPositional_Fails() throws {
+    #expect(throws: (any Error).self) { try Baz.parse(["Bar", "Foo", "Baz"]) }
+    #expect(throws: (any Error).self) { try Baz.parse(["Bar"]) }
+    #expect(throws: (any Error).self) { try Baz.parse([]) }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--name", "Bar", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["Bar", "--name", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["Bar", "Foo", "--name"])
+    }
   }
 }
 
@@ -106,33 +110,39 @@ private struct Qux: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension PositionalEndToEndTests {
-  func testParsing_MultiplePositional() throws {
-    AssertParse(Qux.self, []) { qux in
-      XCTAssertEqual(qux.names, [])
+  @Test func parsing_MultiplePositional() throws {
+    expectParse(Qux.self, []) { qux in
+      #expect(qux.names == [])
     }
-    AssertParse(Qux.self, ["Bar"]) { qux in
-      XCTAssertEqual(qux.names, ["Bar"])
+    expectParse(Qux.self, ["Bar"]) { qux in
+      #expect(qux.names == ["Bar"])
     }
-    AssertParse(Qux.self, ["Bar", "Foo"]) { qux in
-      XCTAssertEqual(qux.names, ["Bar", "Foo"])
+    expectParse(Qux.self, ["Bar", "Foo"]) { qux in
+      #expect(qux.names == ["Bar", "Foo"])
     }
-    AssertParse(Qux.self, ["Bar", "Foo", "Baz"]) { qux in
-      XCTAssertEqual(qux.names, ["Bar", "Foo", "Baz"])
+    expectParse(Qux.self, ["Bar", "Foo", "Baz"]) { qux in
+      #expect(qux.names == ["Bar", "Foo", "Baz"])
     }
 
-    AssertParse(Qux.self, ["--", "--b", "--f"]) { qux in
-      XCTAssertEqual(qux.names, ["--b", "--f"])
+    expectParse(Qux.self, ["--", "--b", "--f"]) { qux in
+      #expect(qux.names == ["--b", "--f"])
     }
-    AssertParse(Qux.self, ["b", "--", "--f"]) { qux in
-      XCTAssertEqual(qux.names, ["b", "--f"])
+    expectParse(Qux.self, ["b", "--", "--f"]) { qux in
+      #expect(qux.names == ["b", "--f"])
     }
   }
 
-  func testParsing_MultiplePositional_Fails() throws {
+  @Test func parsing_MultiplePositional_Fails() throws {
     // TODO: Allow zero-argument arrays?
-    XCTAssertThrowsError(try Qux.parse(["--name", "Bar", "Foo"]))
-    XCTAssertThrowsError(try Qux.parse(["Bar", "--name", "Foo"]))
-    XCTAssertThrowsError(try Qux.parse(["Bar", "Foo", "--name"]))
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--name", "Bar", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["Bar", "--name", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["Bar", "Foo", "--name"])
+    }
   }
 }
 
@@ -146,43 +156,49 @@ private struct Wobble: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension PositionalEndToEndTests {
-  func testParsing_SingleAndMultiplePositional() throws {
-    AssertParse(Wobble.self, ["5"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, [])
+  @Test func parsing_SingleAndMultiplePositional() throws {
+    expectParse(Wobble.self, ["5"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == [])
     }
-    AssertParse(Wobble.self, ["5", "Bar"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["Bar"])
+    expectParse(Wobble.self, ["5", "Bar"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["Bar"])
     }
-    AssertParse(Wobble.self, ["5", "Bar", "Foo"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["Bar", "Foo"])
+    expectParse(Wobble.self, ["5", "Bar", "Foo"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["Bar", "Foo"])
     }
-    AssertParse(Wobble.self, ["5", "Bar", "Foo", "Baz"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["Bar", "Foo", "Baz"])
+    expectParse(Wobble.self, ["5", "Bar", "Foo", "Baz"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["Bar", "Foo", "Baz"])
     }
 
-    AssertParse(Wobble.self, ["5", "--", "--b", "--f"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["--b", "--f"])
+    expectParse(Wobble.self, ["5", "--", "--b", "--f"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["--b", "--f"])
     }
-    AssertParse(Wobble.self, ["--", "5", "--b", "--f"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["--b", "--f"])
+    expectParse(Wobble.self, ["--", "5", "--b", "--f"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["--b", "--f"])
     }
-    AssertParse(Wobble.self, ["5", "b", "--", "--f"]) { wobble in
-      XCTAssertEqual(wobble.count, 5)
-      XCTAssertEqual(wobble.names, ["b", "--f"])
+    expectParse(Wobble.self, ["5", "b", "--", "--f"]) { wobble in
+      #expect(wobble.count == 5)
+      #expect(wobble.names == ["b", "--f"])
     }
   }
 
-  func testParsing_SingleAndMultiplePositional_Fails() throws {
-    XCTAssertThrowsError(try Wobble.parse([]))
-    XCTAssertThrowsError(try Wobble.parse(["--name", "Bar", "Foo"]))
-    XCTAssertThrowsError(try Wobble.parse(["Bar", "--name", "Foo"]))
-    XCTAssertThrowsError(try Wobble.parse(["Bar", "Foo", "--name"]))
+  @Test func parsing_SingleAndMultiplePositional_Fails() throws {
+    #expect(throws: (any Error).self) { try Wobble.parse([]) }
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["--name", "Bar", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["Bar", "--name", "Foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["Bar", "Foo", "--name"])
+    }
   }
 }
 
@@ -195,31 +211,31 @@ private struct Flob: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension PositionalEndToEndTests {
-  func testParsing_MultipleParsedPositional() throws {
-    AssertParse(Flob.self, []) { flob in
-      XCTAssertEqual(flob.counts, [])
+  @Test func parsing_MultipleParsedPositional() throws {
+    expectParse(Flob.self, []) { flob in
+      #expect(flob.counts == [])
     }
-    AssertParse(Flob.self, ["5"]) { flob in
-      XCTAssertEqual(flob.counts, [5])
+    expectParse(Flob.self, ["5"]) { flob in
+      #expect(flob.counts == [5])
     }
-    AssertParse(Flob.self, ["5", "6"]) { flob in
-      XCTAssertEqual(flob.counts, [5, 6])
+    expectParse(Flob.self, ["5", "6"]) { flob in
+      #expect(flob.counts == [5, 6])
     }
 
-    AssertParse(Flob.self, ["5", "--", "6"]) { flob in
-      XCTAssertEqual(flob.counts, [5, 6])
+    expectParse(Flob.self, ["5", "--", "6"]) { flob in
+      #expect(flob.counts == [5, 6])
     }
-    AssertParse(Flob.self, ["--", "5", "6"]) { flob in
-      XCTAssertEqual(flob.counts, [5, 6])
+    expectParse(Flob.self, ["--", "5", "6"]) { flob in
+      #expect(flob.counts == [5, 6])
     }
-    AssertParse(Flob.self, ["5", "6", "--"]) { flob in
-      XCTAssertEqual(flob.counts, [5, 6])
+    expectParse(Flob.self, ["5", "6", "--"]) { flob in
+      #expect(flob.counts == [5, 6])
     }
   }
 
-  func testParsing_MultipleParsedPositional_Fails() throws {
-    XCTAssertThrowsError(try Flob.parse(["a"]))
-    XCTAssertThrowsError(try Flob.parse(["5", "6", "a"]))
+  @Test func parsing_MultipleParsedPositional_Fails() throws {
+    #expect(throws: (any Error).self) { try Flob.parse(["a"]) }
+    #expect(throws: (any Error).self) { try Flob.parse(["5", "6", "a"]) }
   }
 }
 
@@ -236,9 +252,9 @@ extension PositionalEndToEndTests {
   // This test results in a fatal error when run, so it can't be enabled
   // or CI will prevent integration. Delete `disabled_` to verify the trap
   // locally.
-  func disabled_testParsing_BadlyFormedPositional() throws {
-    AssertParse(BadlyFormed.self, []) { _ in
-      XCTFail("This should never execute")
+  func disabled_parsing_BadlyFormedPositional() throws {
+    expectParse(BadlyFormed.self, []) { _ in
+      Issue.record("This should never execute")
     }
   }
 }
@@ -262,13 +278,13 @@ extension PositionalEndToEndTests {
     @Argument var range: Range<Int>
   }
 
-  func testParseCustomRangeConformance() throws {
-    AssertParse(HasRange.self, ["0:4"]) { args in
-      XCTAssertEqual(args.range, 0..<4)
+  @Test func parseCustomRangeConformance() throws {
+    expectParse(HasRange.self, ["0:4"]) { args in
+      #expect(args.range == 0..<4)
     }
 
-    XCTAssertThrowsError(try HasRange.parse([]))
-    XCTAssertThrowsError(try HasRange.parse(["1"]))
-    XCTAssertThrowsError(try HasRange.parse(["1:0"]))
+    #expect(throws: (any Error).self) { try HasRange.parse([]) }
+    #expect(throws: (any Error).self) { try HasRange.parse(["1"]) }
+    #expect(throws: (any Error).self) { try HasRange.parse(["1:0"]) }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,7 @@ import ArgumentParserTestHelpers
 import Testing
 import XCTest
 
-final class SubcommandEndToEndTests: XCTestCase {
-}
+@Suite struct SubcommandEndToEndTests {}
 
 // MARK: Single value String
 
@@ -45,41 +44,41 @@ private struct CommandB: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension SubcommandEndToEndTests {
-  func testParsing_SubCommand() throws {
-    AssertParseCommand(
+  @Test func parsing_SubCommand() throws {
+    expectParseCommand(
       Foo.self, CommandA.self, ["--name", "Foo", "a", "--bar", "42"]
     ) { a in
-      XCTAssertEqual(a.bar, 42)
-      XCTAssertEqual(a.foo.name, "Foo")
+      #expect(a.bar == 42)
+      #expect(a.foo.name == "Foo")
     }
 
-    AssertParseCommand(
+    expectParseCommand(
       Foo.self, CommandB.self, ["--name", "A", "b", "--baz", "abc"]
     ) { b in
-      XCTAssertEqual(b.baz, "abc")
-      XCTAssertEqual(b.foo.name, "A")
+      #expect(b.baz == "abc")
+      #expect(b.foo.name == "A")
     }
   }
 
-  func testParsing_SubCommand_manual() throws {
-    AssertParseCommand(
+  @Test func parsing_SubCommand_manual() throws {
+    expectParseCommand(
       Foo.self, CommandA.self, ["--name", "Foo", "a", "--bar", "42"]
     ) { a in
-      XCTAssertEqual(a.bar, 42)
-      XCTAssertEqual(a.foo.name, "Foo")
+      #expect(a.bar == 42)
+      #expect(a.foo.name == "Foo")
     }
 
-    AssertParseCommand(Foo.self, Foo.self, ["--name", "Foo"]) { foo in
-      XCTAssertEqual(foo.name, "Foo")
+    expectParseCommand(Foo.self, Foo.self, ["--name", "Foo"]) { foo in
+      #expect(foo.name == "Foo")
     }
   }
 
-  func testParsing_SubCommand_help() throws {
+  @Test func parsing_SubCommand_help() throws {
     let helpFoo = Foo.message(for: CleanExit.helpRequest())
     let helpA = Foo.message(for: CleanExit.helpRequest(CommandA.self))
     let helpB = Foo.message(for: CleanExit.helpRequest(CommandB.self))
 
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: helpFoo,
       expected: """
         USAGE: foo --name <name> <subcommand>
@@ -94,7 +93,7 @@ extension SubcommandEndToEndTests {
 
           See 'foo help <subcommand>' for detailed help.
         """)
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: helpA,
       expected: """
         USAGE: foo a --name <name> --bar <bar>
@@ -105,7 +104,7 @@ extension SubcommandEndToEndTests {
           -h, --help              Show help information.
 
         """)
-    AssertEqualStrings(
+    expectEqualStrings(
       actual: helpB,
       expected: """
         USAGE: foo b --name <name> --baz <baz>
@@ -118,13 +117,13 @@ extension SubcommandEndToEndTests {
         """)
   }
 
-  func testParsing_SubCommand_fails() throws {
-    XCTAssertThrowsError(
-      try Foo.parse(["--name", "Foo", "a", "--baz", "42"]),
-      "'baz' is not an option for the 'a' subcommand.")
-    XCTAssertThrowsError(
-      try Foo.parse(["--name", "Foo", "b", "--bar", "42"]),
-      "'bar' is not an option for the 'b' subcommand.")
+  @Test func parsing_SubCommand_fails() throws {
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--name", "Foo", "a", "--baz", "42"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parse(["--name", "Foo", "b", "--bar", "42"])
+    }
   }
 }
 
@@ -146,9 +145,9 @@ private struct Math: ParsableCommand {
   var didRun = false
 
   mutating func run() {
-    XCTAssertEqual(operation, .multiply)
-    XCTAssertTrue(verbose)
-    XCTAssertEqual(operands, [5, 11])
+    #expect(operation == .multiply)
+    #expect(verbose)
+    #expect(operands == [5, 11])
     didRun = true
   }
 }
@@ -156,13 +155,13 @@ private struct Math: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension SubcommandEndToEndTests {
-  func testParsing_SingleCommand() throws {
+  @Test func parsing_SingleCommand() throws {
     var mathCommand =
       try Math.parseAsRoot(["--operation", "multiply", "-v", "5", "11"])
       as! Math
-    XCTAssertFalse(mathCommand.didRun)
+    #expect(!mathCommand.didRun)
     mathCommand.run()
-    XCTAssertTrue(mathCommand.didRun)
+    #expect(mathCommand.didRun)
   }
 }
 
@@ -231,7 +230,7 @@ extension BaseCommand.SubCommand {
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
-extension SubcommandEndToEndTests {
+final class SubcommandEndToEndTestsXCTest: XCTestCase {
   func testValidate_subcommands() {
     // provide a value to base-flag that will throw
     AssertErrorMessage(
@@ -285,14 +284,14 @@ private struct A: ParsableCommand {
 }
 
 extension SubcommandEndToEndTests {
-  func testParsingVersionFlags() throws {
-    AssertErrorMessage(A.self, ["--version"], "1.0.0")
-    AssertErrorMessage(A.self, ["no-version-flag", "--version"], "1.0.0")
+  @Test func parsingVersionFlags() throws {
+    expectErrorMessage(A.self, ["--version"], "1.0.0")
+    expectErrorMessage(A.self, ["no-version-flag", "--version"], "1.0.0")
 
-    AssertParseCommand(
+    expectParseCommand(
       A.self, A.HasVersionFlag.self, ["has-version-flag", "--version"]
     ) { cmd in
-      XCTAssertTrue(cmd.version)
+      #expect(cmd.version)
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/TransformEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class TransformEndToEndTests: XCTestCase {}
+@Suite struct TransformEndToEndTests {}
 
 private enum FooBarError: Error {
   case outOfBounds
@@ -73,21 +72,21 @@ extension TransformEndToEndTests {
 
   // MARK: Single Values
 
-  func testSingleOptionTransform() throws {
-    AssertParse(FooOption.self, ["--string", "42"]) { foo in
-      XCTAssertEqual(foo.string, 42)
+  @Test func singleOptionTransform() throws {
+    expectParse(FooOption.self, ["--string", "42"]) { foo in
+      #expect(foo.string == 42)
     }
   }
 
-  func testSingleOptionValidation_Fail_CustomErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func singleOptionValidation_Fail_CustomErrorMessage() throws {
+    expectFullErrorMessage(
       FooOption.self, ["--string", "Forty Two"],
       "Error: The value 'Forty Two' is invalid for '--string <int_str>': Could not transform to an Int.\n"
         + FooOption.help + FooOption.usageString)
   }
 
-  func testSingleOptionValidation_Fail_DefaultErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func singleOptionValidation_Fail_DefaultErrorMessage() throws {
+    expectFullErrorMessage(
       FooOption.self, ["--string", "4827"],
       "Error: The value '4827' is invalid for '--string <int_str>': outOfBounds\n"
         + FooOption.help + FooOption.usageString)
@@ -95,24 +94,24 @@ extension TransformEndToEndTests {
 
   // MARK: Arrays
 
-  func testOptionArrayTransform() throws {
-    AssertParse(
+  @Test func optionArrayTransform() throws {
+    expectParse(
       BarOption.self, ["--strings", "42", "--strings", "72", "--strings", "99"]
     ) { bar in
-      XCTAssertEqual(bar.strings, [42, 72, 99])
+      #expect(bar.strings == [42, 72, 99])
     }
   }
 
-  func testOptionArrayValidation_Fail_CustomErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func optionArrayValidation_Fail_CustomErrorMessage() throws {
+    expectFullErrorMessage(
       BarOption.self,
       ["--strings", "Forty Two", "--strings", "72", "--strings", "99"],
       "Error: The value 'Forty Two' is invalid for '--strings <int_str>': Could not transform to an Int.\n"
         + BarOption.help + BarOption.usageString)
   }
 
-  func testOptionArrayValidation_Fail_DefaultErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func optionArrayValidation_Fail_DefaultErrorMessage() throws {
+    expectFullErrorMessage(
       BarOption.self,
       ["--strings", "4827", "--strings", "72", "--strings", "99"],
       "Error: The value '4827' is invalid for '--strings <int_str>': outOfBounds\n"
@@ -162,21 +161,21 @@ extension TransformEndToEndTests {
 
   // MARK: Single Values
 
-  func testArgumentTransform() throws {
-    AssertParse(FooArgument.self, ["42"]) { foo in
-      XCTAssertEqual(foo.string, 42)
+  @Test func argumentTransform() throws {
+    expectParse(FooArgument.self, ["42"]) { foo in
+      #expect(foo.string == 42)
     }
   }
 
-  func testArgumentValidation_Fail_CustomErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func argumentValidation_Fail_CustomErrorMessage() throws {
+    expectFullErrorMessage(
       FooArgument.self, ["Forty Two"],
       "Error: The value 'Forty Two' is invalid for '<int_str>': Could not transform to an Int.\n"
         + FooArgument.help + FooArgument.usageString)
   }
 
-  func testArgumentValidation_Fail_DefaultErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func argumentValidation_Fail_DefaultErrorMessage() throws {
+    expectFullErrorMessage(
       FooArgument.self, ["4827"],
       "Error: The value '4827' is invalid for '<int_str>': outOfBounds\n"
         + FooArgument.help + FooArgument.usageString)
@@ -184,21 +183,21 @@ extension TransformEndToEndTests {
 
   // MARK: Arrays
 
-  func testArgumentArrayTransform() throws {
-    AssertParse(BarArgument.self, ["42", "72", "99"]) { bar in
-      XCTAssertEqual(bar.strings, [42, 72, 99])
+  @Test func argumentArrayTransform() throws {
+    expectParse(BarArgument.self, ["42", "72", "99"]) { bar in
+      #expect(bar.strings == [42, 72, 99])
     }
   }
 
-  func testArgumentArrayValidation_Fail_CustomErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func argumentArrayValidation_Fail_CustomErrorMessage() throws {
+    expectFullErrorMessage(
       BarArgument.self, ["Forty Two", "72", "99"],
       "Error: The value 'Forty Two' is invalid for '<int_str>': Could not transform to an Int.\n"
         + BarArgument.help + BarArgument.usageString)
   }
 
-  func testArgumentArrayValidation_Fail_DefaultErrorMessage() throws {
-    AssertFullErrorMessage(
+  @Test func argumentArrayValidation_Fail_DefaultErrorMessage() throws {
+    expectFullErrorMessage(
       BarArgument.self, ["4827", "72", "99"],
       "Error: The value '4827' is invalid for '<int_str>': outOfBounds\n"
         + BarArgument.help + BarArgument.usageString)

--- a/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/ValidationEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,11 +11,10 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Foundation
 import Testing
-import XCTest
 
-final class ValidationEndToEndTests: XCTestCase {
-}
+@Suite struct ValidationEndToEndTests {}
 
 private enum UserValidationError: LocalizedError {
   case userValidationError
@@ -103,26 +102,26 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension ValidationEndToEndTests {
-  func testValidation() throws {
-    AssertParse(Foo.self, ["Joe"]) { foo in
-      XCTAssertEqual(foo.names, ["Joe"])
-      XCTAssertNil(foo.count)
+  @Test func validation() throws {
+    expectParse(Foo.self, ["Joe"]) { foo in
+      #expect(foo.names == ["Joe"])
+      #expect(foo.count == nil)
     }
 
-    AssertParse(Foo.self, ["Joe", "Moe", "--count", "2"]) { foo in
-      XCTAssertEqual(foo.names, ["Joe", "Moe"])
-      XCTAssertEqual(foo.count, 2)
+    expectParse(Foo.self, ["Joe", "Moe", "--count", "2"]) { foo in
+      #expect(foo.names == ["Joe", "Moe"])
+      #expect(foo.count == 2)
     }
   }
 
-  func testValidation_Version() throws {
-    AssertErrorMessage(Foo.self, ["--version"], "0.0.1")
-    AssertFullErrorMessage(Foo.self, ["--version"], "0.0.1")
+  @Test func validation_Version() throws {
+    expectErrorMessage(Foo.self, ["--version"], "0.0.1")
+    expectFullErrorMessage(Foo.self, ["--version"], "0.0.1")
   }
 
-  func testValidation_Fails() throws {
-    AssertErrorMessage(Foo.self, [], "Must specify at least one name.")
-    AssertFullErrorMessage(
+  @Test func validation_Fails() throws {
+    expectErrorMessage(Foo.self, [], "Must specify at least one name.")
+    expectFullErrorMessage(
       Foo.self, [],
       """
       Error: Must specify at least one name.
@@ -131,12 +130,12 @@ extension ValidationEndToEndTests {
 
       """)
 
-    AssertErrorMessage(
+    expectErrorMessage(
       Foo.self, ["--count", "3", "Joe"],
       """
       Number of names (1) doesn't match count (3).
       """)
-    AssertFullErrorMessage(
+    expectFullErrorMessage(
       Foo.self, ["--count", "3", "Joe"],
       """
       Error: Number of names (1) doesn't match count (3).
@@ -144,19 +143,19 @@ extension ValidationEndToEndTests {
       """)
   }
 
-  func testCustomErrorValidation() {
+  @Test func customErrorValidation() {
     // verify that error description is printed if available via LocalizedError
-    AssertErrorMessage(
+    expectErrorMessage(
       Foo.self, ["--throw", "Joe"],
       UserValidationError.userValidationError.errorDescription!)
   }
 
-  func testEmptyErrorValidation() {
-    AssertErrorMessage(Foo.self, ["--show-usage-only", "Joe"], "")
-    AssertFullErrorMessage(
+  @Test func emptyErrorValidation() {
+    expectErrorMessage(Foo.self, ["--show-usage-only", "Joe"], "")
+    expectFullErrorMessage(
       Foo.self, ["--show-usage-only", "Joe"], Foo.usageString)
-    AssertFullErrorMessage(Foo.self, ["--fail-validation-silently", "Joe"], "")
-    AssertFullErrorMessage(Foo.self, ["--fail-silently", "Joe"], "")
+    expectFullErrorMessage(Foo.self, ["--fail-validation-silently", "Joe"], "")
+    expectFullErrorMessage(Foo.self, ["--fail-silently", "Joe"], "")
   }
 }
 
@@ -174,12 +173,12 @@ private struct FooCommand: ParsableCommand {
   }
 
   func run() throws {
-    XCTAssertEqual(foo, bar)
+    #expect(foo == bar)
   }
 }
 
 extension ValidationEndToEndTests {
-  func testMutationsPreserved() throws {
+  @Test func mutationsPreserved() throws {
     var foo = try FooCommand.parseAsRoot(["--foo"])
     try foo.run()
   }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.
-->

Migrate six `ArgumentParserEndToEndTests` suites from XCTest to Swift
Testing:

- `TransformEndToEndTests`
- `OptionGroupEndToEndTests`
- `ValidationEndToEndTests`
- `OptionalEndToEndTests`
- `PositionalEndToEndTests`
- `SubcommandEndToEndTests`

`OptionGroupEndToEndTests` and `SubcommandEndToEndTests` previously
relied on `XCTestExpectation` via the
`TestableParsableArguments`/`TestableParsableCommand` protocols. Add
Swift Testing counterparts to `TestHelpers+SwiftTesting.swift`:

- `TestExpectation`: a reference-typed flag that carries a `fulfilled`
  bool. Since ArgumentParser's parse/validate/run pipeline is
  synchronous, we don't need a timeout-based expectation like
  `XCTestExpectation`.
- `TestableSwiftTestingParsableArguments` /
  `TestableSwiftTestingParsableCommand`: mirror the XCTest protocols;
  their default `validate()` / `run()` fulfill `didValidateExpectation`
  / `didRunExpectation`, which tests then assert with
  `#expect(command.didValidateExpectation.fulfilled)`.

Centralizing the type means future changes (e.g. moving to
`confirmation`, adding a counter, adding Sendable) touch only the
helper.

`ValidationEndToEndTests`'s `FooCommand.run()` contained an inline
`XCTAssertEqual`; convert it to `#expect(foo == bar)` so the assertion
routes through Swift Testing when run under `@Test`.
`SubcommandEndToEndTests`'s `Math.run()` gets the same treatment.

`PositionalEndToEndTests` keeps
`disabled_parsing_BadlyFormedPositional` as an untagged method
(matching the previous "not discovered" behavior of the `disabled_`
prefix under XCTest); its `XCTFail` becomes `Issue.record`.

Relates to #710

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>