### PR TITLE
Migrate large end-to-end suites to Swift Testing

### DIFF
--- a/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/DefaultSubcommandEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,12 +12,10 @@
 import ArgumentParserTestHelpers
 import ArgumentParserToolInfo
 import Testing
-import XCTest
 
 @testable import ArgumentParser
 
-final class DefaultSubcommandEndToEndTests: XCTestCase {
-}
+@Suite struct DefaultSubcommandEndToEndTests {}
 
 // MARK: -
 
@@ -40,37 +38,39 @@ private struct Foo: ParsableCommand {}
 private struct Bar: ParsableCommand {}
 
 extension DefaultSubcommandEndToEndTests {
-  func testDefaultSubcommand() {
-    AssertParseCommand(Main.self, Default.self, []) { def in
-      XCTAssertEqual(.foo, def.mode)
+  @Test func defaultSubcommand() {
+    expectParseCommand(Main.self, Default.self, []) { def in
+      #expect(def.mode == .foo)
     }
 
-    AssertParseCommand(Main.self, Default.self, ["--mode=bar"]) { def in
-      XCTAssertEqual(.bar, def.mode)
+    expectParseCommand(Main.self, Default.self, ["--mode=bar"]) { def in
+      #expect(def.mode == .bar)
     }
 
-    AssertParseCommand(Main.self, Default.self, ["--mode", "bar"]) { def in
-      XCTAssertEqual(.bar, def.mode)
+    expectParseCommand(Main.self, Default.self, ["--mode", "bar"]) { def in
+      #expect(def.mode == .bar)
     }
 
-    AssertParseCommand(Main.self, Default.self, ["--mode", "baz"]) { def in
-      XCTAssertEqual(.baz, def.mode)
+    expectParseCommand(Main.self, Default.self, ["--mode", "baz"]) { def in
+      #expect(def.mode == .baz)
     }
   }
 
-  func testNonDefaultSubcommand() {
-    AssertParseCommand(Main.self, Foo.self, ["foo"]) { _ in }
-    AssertParseCommand(Main.self, Bar.self, ["bar"]) { _ in }
+  @Test func nonDefaultSubcommand() {
+    expectParseCommand(Main.self, Foo.self, ["foo"]) { _ in }
+    expectParseCommand(Main.self, Bar.self, ["bar"]) { _ in }
 
-    AssertParseCommand(Main.self, Default.self, ["default", "--mode", "bar"]) {
+    expectParseCommand(Main.self, Default.self, ["default", "--mode", "bar"]) {
       def in
-      XCTAssertEqual(.bar, def.mode)
+      #expect(def.mode == .bar)
     }
   }
 
-  func testParsingFailure() {
-    XCTAssertThrowsError(try Main.parseAsRoot(["--mode", "qux"]))
-    XCTAssertThrowsError(try Main.parseAsRoot(["qux"]))
+  @Test func parsingFailure() {
+    #expect(throws: (any Error).self) {
+      try Main.parseAsRoot(["--mode", "qux"])
+    }
+    #expect(throws: (any Error).self) { try Main.parseAsRoot(["qux"]) }
   }
 }
 
@@ -124,183 +124,187 @@ extension DefaultSubcommandEndToEndTests {
     @ParentCommand var notMyParent: Other
   }
 
-  func testAccessToParent() throws {
-    AssertParseCommand(
+  @Test func accessToParent() throws {
+    expectParseCommand(
       MyCommand.self, Child.self, ["--verbose", "--foo=bar", "child"]
     ) { child in
-      XCTAssertEqual(child.parent.foo, "bar")
-      XCTAssertEqual(child.parent.options.verbose, true)
+      #expect(child.parent.foo == "bar")
+      #expect(child.parent.options.verbose == true)
     }
   }
 
-  func testNotMyParent() {
-    AssertParseCommandErrorMessage(
-      MyCommand.self, BadParent.self, ["--verbose", "bad-parent"],
-      "Command 'Other' is not a parent of the current command.")
+  @Test func notMyParent() {
+    // migrate to `#expect(throws:expression)`
+    #expect {
+      _ = try MyCommand.parseAsRoot(["--verbose", "bad-parent"])
+    } throws: { error in
+      let message = MyCommand.message(for: error)
+      return message
+        == "Command 'Other' is not a parent of the current command."
+    }
+    // do {
+    //   _ = try MyCommand.parseAsRoot(["--verbose", "bad-parent"])
+    //   Issue.record("Parsing should have failed.")
+    // } catch {
+    //   let message = MyCommand.message(for: error)
+    //   #expect(
+    //     message == "Command 'Other' is not a parent of the current command.")
+    // }
   }
 
-  func testNotLeakingParentOptions() throws {
+  @Test func notLeakingParentOptions() throws {
     // Verify that the help for the child command doesn't leak the parent command's options in the help
     let childHelp = MyCommand.message(for: CleanExit.helpRequest(Child.self))
-    XCTAssertEqual(
-      childHelp,
-      """
-      USAGE: my-command child
+    #expect(
+      childHelp == """
+        USAGE: my-command child
 
-      OPTIONS:
-        -h, --help              Show help information.
+        OPTIONS:
+          -h, --help              Show help information.
 
-      """)
+        """)
 
     // Now check that the foo option doesn't leak into the JSON dump
     let toolInfo = ToolInfoV0(commandStack: [MyCommand.self.asCommand])
 
-    let arguments = toolInfo.command.arguments
-    guard let arguments else {
-      XCTFail(
-        "MyCommand is expected to have a top-level command arguments in its tool info"
-      )
-      return
-    }
+    let arguments = try #require(
+      toolInfo.command.arguments,
+      "MyCommand is expected to have a top-level command arguments in its tool info"
+    )
 
-    let subcommands = toolInfo.command.subcommands
-    guard let subcommands else {
-      XCTFail(
-        "MyCommand is expected to have a top-level command arguments in its tool info"
-      )
-      return
-    }
+    let subcommands = try #require(
+      toolInfo.command.subcommands,
+      "MyCommand is expected to have a top-level command arguments in its tool info"
+    )
 
     // The foo option is present int he parent
-    XCTAssertNotNil(arguments.first { $0.valueName == "foo" })
+    #expect(arguments.first { $0.valueName == "foo" } != nil)
 
-    let childInfo = subcommands.first { cmd in
-      cmd.commandName == "child"
-    }
+    let childInfo = try #require(
+      subcommands.first { cmd in
+        cmd.commandName == "child"
+      },
+      "The child subcommand is expected to be present in the tool info")
 
-    guard let childInfo else {
-      XCTFail("The child subcommand is expected to be present in the tool info")
-      return
-    }
-
-    guard let childArguments = childInfo.arguments else {
-      XCTFail(
-        "The child subcommand is expected to have arguments in the tool info")
-      return
-    }
+    let childArguments = try #require(
+      childInfo.arguments,
+      "The child subcommand is expected to have arguments in the tool info")
 
     // It's not there in the child subcommand
-    XCTAssertNil(childArguments.first { $0.valueName == "foo" })
+    #expect(childArguments.first { $0.valueName == "foo" } == nil)
   }
 
-  func testRemainingDefaultImplicit() throws {
-    AssertParseCommand(MyCommand.self, Plugin.self, ["my-plugin"]) { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, [])
-      XCTAssertEqual(plugin.options.verbose, false)
+  @Test func remainingDefaultImplicit() throws {
+    expectParseCommand(MyCommand.self, Plugin.self, ["my-plugin"]) { plugin in
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == [])
+      #expect(plugin.options.verbose == false)
     }
-    AssertParseCommand(MyCommand.self, Plugin.self, ["my-plugin", "--verbose"])
+    expectParseCommand(MyCommand.self, Plugin.self, ["my-plugin", "--verbose"])
     { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
-      XCTAssertEqual(plugin.options.verbose, false)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--verbose"])
+      #expect(plugin.options.verbose == false)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, Plugin.self, ["--verbose", "my-plugin", "--verbose"]
     ) { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
-      XCTAssertEqual(plugin.options.verbose, true)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--verbose"])
+      #expect(plugin.options.verbose == true)
     }
-    AssertParseCommand(MyCommand.self, Plugin.self, ["my-plugin", "--help"]) {
+    expectParseCommand(MyCommand.self, Plugin.self, ["my-plugin", "--help"]) {
       plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--help"])
-      XCTAssertEqual(plugin.options.verbose, false)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--help"])
+      #expect(plugin.options.verbose == false)
     }
   }
 
-  func testRemainingDefaultExplicit() throws {
-    AssertParseCommand(MyCommand.self, Plugin.self, ["plugin", "my-plugin"]) {
+  @Test func remainingDefaultExplicit() throws {
+    expectParseCommand(MyCommand.self, Plugin.self, ["plugin", "my-plugin"]) {
       plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, [])
-      XCTAssertEqual(plugin.options.verbose, false)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == [])
+      #expect(plugin.options.verbose == false)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, Plugin.self, ["plugin", "my-plugin", "--verbose"]
     ) { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
-      XCTAssertEqual(plugin.options.verbose, false)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--verbose"])
+      #expect(plugin.options.verbose == false)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, Plugin.self,
       ["--verbose", "plugin", "my-plugin", "--verbose"]
     ) { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--verbose"])
-      XCTAssertEqual(plugin.options.verbose, true)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--verbose"])
+      #expect(plugin.options.verbose == true)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, Plugin.self,
       ["--verbose", "plugin", "my-plugin", "--help"]
     ) { plugin in
-      XCTAssertEqual(plugin.pluginName, "my-plugin")
-      XCTAssertEqual(plugin.pluginArguments, ["--help"])
-      XCTAssertEqual(plugin.options.verbose, true)
+      #expect(plugin.pluginName == "my-plugin")
+      #expect(plugin.pluginArguments == ["--help"])
+      #expect(plugin.options.verbose == true)
     }
   }
 
-  func testRemainingNonDefault() throws {
-    AssertParseCommand(
+  @Test func remainingNonDefault() throws {
+    expectParseCommand(
       MyCommand.self, NonDefault.self, ["non-default", "my-plugin"]
     ) { nondef in
-      XCTAssertEqual(nondef.pluginName, "my-plugin")
-      XCTAssertEqual(nondef.pluginArguments, [])
-      XCTAssertEqual(nondef.options.verbose, false)
+      #expect(nondef.pluginName == "my-plugin")
+      #expect(nondef.pluginArguments == [])
+      #expect(nondef.options.verbose == false)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, NonDefault.self,
       ["non-default", "my-plugin", "--verbose"]
     ) { nondef in
-      XCTAssertEqual(nondef.pluginName, "my-plugin")
-      XCTAssertEqual(nondef.pluginArguments, ["--verbose"])
-      XCTAssertEqual(nondef.options.verbose, false)
+      #expect(nondef.pluginName == "my-plugin")
+      #expect(nondef.pluginArguments == ["--verbose"])
+      #expect(nondef.options.verbose == false)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, NonDefault.self,
       ["--verbose", "non-default", "my-plugin", "--verbose"]
     ) { nondef in
-      XCTAssertEqual(nondef.pluginName, "my-plugin")
-      XCTAssertEqual(nondef.pluginArguments, ["--verbose"])
-      XCTAssertEqual(nondef.options.verbose, true)
+      #expect(nondef.pluginName == "my-plugin")
+      #expect(nondef.pluginArguments == ["--verbose"])
+      #expect(nondef.options.verbose == true)
     }
-    AssertParseCommand(
+    expectParseCommand(
       MyCommand.self, NonDefault.self,
       ["--verbose", "non-default", "my-plugin", "--help"]
     ) { nondef in
-      XCTAssertEqual(nondef.pluginName, "my-plugin")
-      XCTAssertEqual(nondef.pluginArguments, ["--help"])
-      XCTAssertEqual(nondef.options.verbose, true)
+      #expect(nondef.pluginName == "my-plugin")
+      #expect(nondef.pluginArguments == ["--help"])
+      #expect(nondef.options.verbose == true)
     }
   }
 
-  func testRemainingDefaultOther() throws {
-    AssertParseCommand(MyCommand.self, Other.self, ["other"]) { other in
-      XCTAssertEqual(other.options.verbose, false)
+  @Test func remainingDefaultOther() throws {
+    expectParseCommand(MyCommand.self, Other.self, ["other"]) { other in
+      #expect(other.options.verbose == false)
     }
-    AssertParseCommand(MyCommand.self, Other.self, ["other", "--verbose"]) {
+    expectParseCommand(MyCommand.self, Other.self, ["other", "--verbose"]) {
       other in
-      XCTAssertEqual(other.options.verbose, true)
+      #expect(other.options.verbose == true)
     }
   }
 
-  func testRemainingDefaultFailure() {
-    XCTAssertThrowsError(try MyCommand.parseAsRoot([]))
-    XCTAssertThrowsError(try MyCommand.parseAsRoot(["--verbose"]))
-    XCTAssertThrowsError(
-      try MyCommand.parseAsRoot(["plugin", "--verbose", "my-plugin"]))
+  @Test func remainingDefaultFailure() {
+    #expect(throws: (any Error).self) { try MyCommand.parseAsRoot([]) }
+    #expect(throws: (any Error).self) {
+      try MyCommand.parseAsRoot(["--verbose"])
+    }
+    #expect(throws: (any Error).self) {
+      try MyCommand.parseAsRoot(["plugin", "--verbose", "my-plugin"])
+    }
   }
 }
 
@@ -319,14 +323,14 @@ extension DefaultSubcommandEndToEndTests {
   }
 
   // Test fix for https://github.com/apple/swift-package-manager/issues/7218
-  func testHelpWithPassthroughDefault() throws {
-    AssertParseCommand(
+  @Test func helpWithPassthroughDefault() throws {
+    expectParseCommand(
       RootWithPassthroughDefault.self, HelpCommand.self, ["-h"]
     ) { _ in }
-    AssertParseCommand(
+    expectParseCommand(
       RootWithPassthroughDefault.self, HelpCommand.self, ["-help"]
     ) { _ in }
-    AssertParseCommand(
+    expectParseCommand(
       RootWithPassthroughDefault.self, HelpCommand.self, ["--help"]
     ) { _ in }
   }
@@ -354,24 +358,24 @@ extension DefaultSubcommandEndToEndTests {
   }
 
   // Test fix for https://github.com/apple/swift-argument-parser/issues/865
-  func testHelpWithNestedDefaultSubcommand() throws {
-    AssertParseCommand(
+  @Test func helpWithNestedDefaultSubcommand() throws {
+    expectParseCommand(
       NestedDefaultSubcommandHelp.self, HelpCommand.self, ["--help"]
     ) { command in
-      XCTAssert(command.commandStack.count == 1)
-      XCTAssert(
+      #expect(command.commandStack.count == 1)
+      #expect(
         type(of: command.commandStack[0])
           == NestedDefaultSubcommandHelp.Type.self)
     }
 
-    AssertParseCommand(
+    expectParseCommand(
       NestedDefaultSubcommandHelp.self, HelpCommand.self, ["nested", "--help"]
     ) { command in
-      XCTAssert(command.commandStack.count == 2)
-      XCTAssert(
+      #expect(command.commandStack.count == 2)
+      #expect(
         type(of: command.commandStack[0])
           == NestedDefaultSubcommandHelp.Type.self)
-      XCTAssert(
+      #expect(
         type(of: command.commandStack[1])
           == NestedDefaultSubcommandHelp.Nested.Type.self)
     }

--- a/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/FlagsEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class FlagsEndToEndTests: XCTestCase {
-}
+@Suite struct FlagsEndToEndTests {}
 
 // MARK: -
 
@@ -36,62 +34,62 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension FlagsEndToEndTests {
-  func testParsing_defaultValue() throws {
-    AssertParse(Bar.self, []) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertEqual(options.extattr, false)
-      XCTAssertEqual(options.extattr2, nil)
+  @Test func parsing_defaultValue() throws {
+    expectParse(Bar.self, []) { options in
+      #expect(options.verbose == false)
+      #expect(options.extattr == false)
+      #expect(options.extattr2 == nil)
     }
   }
 
-  func testParsing_settingValue() throws {
-    AssertParse(Bar.self, ["--verbose"]) { options in
-      XCTAssertEqual(options.verbose, true)
-      XCTAssertEqual(options.extattr, false)
-      XCTAssertEqual(options.extattr2, nil)
+  @Test func parsing_settingValue() throws {
+    expectParse(Bar.self, ["--verbose"]) { options in
+      #expect(options.verbose == true)
+      #expect(options.extattr == false)
+      #expect(options.extattr2 == nil)
     }
 
-    AssertParse(Bar.self, ["--extattr"]) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertEqual(options.extattr, true)
-      XCTAssertEqual(options.extattr2, nil)
+    expectParse(Bar.self, ["--extattr"]) { options in
+      #expect(options.verbose == false)
+      #expect(options.extattr == true)
+      #expect(options.extattr2 == nil)
     }
 
-    AssertParse(Bar.self, ["--extattr2"]) { options in
-      XCTAssertEqual(options.verbose, false)
-      XCTAssertEqual(options.extattr, false)
-      XCTAssertEqual(options.extattr2, .some(true))
+    expectParse(Bar.self, ["--extattr2"]) { options in
+      #expect(options.verbose == false)
+      #expect(options.extattr == false)
+      #expect(options.extattr2 == .some(true))
     }
   }
 
-  func testParsing_invert() throws {
-    AssertParse(Bar.self, ["--no-extattr"]) { options in
-      XCTAssertEqual(options.extattr, false)
+  @Test func parsing_invert() throws {
+    expectParse(Bar.self, ["--no-extattr"]) { options in
+      #expect(options.extattr == false)
     }
-    AssertParse(Bar.self, ["--extattr", "--no-extattr"]) { options in
-      XCTAssertEqual(options.extattr, false)
+    expectParse(Bar.self, ["--extattr", "--no-extattr"]) { options in
+      #expect(options.extattr == false)
     }
-    AssertParse(Bar.self, ["--extattr", "--no-extattr", "--no-extattr"]) {
+    expectParse(Bar.self, ["--extattr", "--no-extattr", "--no-extattr"]) {
       options in
-      XCTAssertEqual(options.extattr, false)
+      #expect(options.extattr == false)
     }
-    AssertParse(Bar.self, ["--no-extattr", "--no-extattr", "--extattr"]) {
+    expectParse(Bar.self, ["--no-extattr", "--no-extattr", "--extattr"]) {
       options in
-      XCTAssertEqual(options.extattr, true)
+      #expect(options.extattr == true)
     }
-    AssertParse(Bar.self, ["--extattr", "--no-extattr", "--extattr"]) {
+    expectParse(Bar.self, ["--extattr", "--no-extattr", "--extattr"]) {
       options in
-      XCTAssertEqual(options.extattr, true)
+      #expect(options.extattr == true)
     }
-    AssertParse(Bar.self, ["--enable-logging"]) { options in
-      XCTAssertEqual(options.logging, true)
+    expectParse(Bar.self, ["--enable-logging"]) { options in
+      #expect(options.logging == true)
     }
-    AssertParse(Bar.self, ["--no-extattr2", "--no-extattr2"]) { options in
-      XCTAssertEqual(options.extattr2, false)
+    expectParse(Bar.self, ["--no-extattr2", "--no-extattr2"]) { options in
+      #expect(options.extattr2 == false)
     }
-    AssertParse(Bar.self, ["--disable-logging", "--enable-logging"]) {
+    expectParse(Bar.self, ["--disable-logging", "--enable-logging"]) {
       options in
-      XCTAssertEqual(options.logging, false)
+      #expect(options.logging == false)
     }
   }
 }
@@ -110,49 +108,49 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension FlagsEndToEndTests {
-  func testParsingEnableDisable_defaultValue() throws {
-    AssertParse(Foo.self, ["--enable-required-element"]) { options in
-      XCTAssertEqual(options.index, false)
-      XCTAssertEqual(options.sandbox, true)
-      XCTAssertEqual(options.requiredElement, true)
-      XCTAssertNil(options.optional)
+  @Test func parsingEnableDisable_defaultValue() throws {
+    expectParse(Foo.self, ["--enable-required-element"]) { options in
+      #expect(options.index == false)
+      #expect(options.sandbox == true)
+      #expect(options.requiredElement == true)
+      #expect(options.optional == nil)
     }
   }
 
-  func testParsingEnableDisable_disableAll() throws {
-    AssertParse(
+  @Test func parsingEnableDisable_disableAll() throws {
+    expectParse(
       Foo.self,
       [
         "--disable-index", "--disable-sandbox", "--disable-required-element",
         "--disable-optional",
       ]
     ) { options in
-      XCTAssertEqual(options.index, false)
-      XCTAssertEqual(options.sandbox, false)
-      XCTAssertEqual(options.requiredElement, false)
-      XCTAssertEqual(options.optional, false)
+      #expect(options.index == false)
+      #expect(options.sandbox == false)
+      #expect(options.requiredElement == false)
+      #expect(options.optional == false)
     }
   }
 
-  func testParsingEnableDisable_enableAll() throws {
-    AssertParse(
+  @Test func parsingEnableDisable_enableAll() throws {
+    expectParse(
       Foo.self,
       [
         "--enable-index", "--enable-sandbox", "--enable-required-element",
         "--enable-optional",
       ]
     ) { options in
-      XCTAssertEqual(options.index, true)
-      XCTAssertEqual(options.sandbox, true)
-      XCTAssertEqual(options.requiredElement, true)
-      XCTAssertEqual(options.optional, true)
+      #expect(options.index == true)
+      #expect(options.sandbox == true)
+      #expect(options.requiredElement == true)
+      #expect(options.optional == true)
     }
   }
 
-  func testParsingEnableDisable_Fails() throws {
-    XCTAssertThrowsError(try Foo.parse([]))
-    XCTAssertThrowsError(try Foo.parse(["--disable-index"]))
-    XCTAssertThrowsError(try Foo.parse(["--disable-sandbox"]))
+  @Test func parsingEnableDisable_Fails() throws {
+    #expect(throws: (any Error).self) { try Foo.parse([]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["--disable-index"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["--disable-sandbox"]) }
   }
 }
 
@@ -214,76 +212,73 @@ private struct Baz: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension FlagsEndToEndTests {
-  func testParsingCaseIterable_defaultValues() throws {
-    AssertParse(Baz.self, ["--pink"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .small)
-      XCTAssertEqual(options.shape, nil)
+  @Test func parsingCaseIterable_defaultValues() throws {
+    expectParse(Baz.self, ["--pink"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .small)
+      #expect(options.shape == nil)
     }
 
-    AssertParse(Baz.self, ["--pink", "--medium"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .medium)
-      XCTAssertEqual(options.shape, nil)
+    expectParse(Baz.self, ["--pink", "--medium"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .medium)
+      #expect(options.shape == nil)
     }
 
-    AssertParse(Baz.self, ["--pink", "--round"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .small)
-      XCTAssertEqual(options.shape, .round)
-    }
-  }
-
-  func testParsingCaseIterable_AllValues() throws {
-    AssertParse(Baz.self, ["--pink", "--small", "--round"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .small)
-      XCTAssertEqual(options.shape, .round)
-    }
-
-    AssertParse(Baz.self, ["--purple", "--medium", "--square"]) { options in
-      XCTAssertEqual(options.color, .purple)
-      XCTAssertEqual(options.size, .medium)
-      XCTAssertEqual(options.shape, .square)
-    }
-
-    AssertParse(Baz.self, ["--silver", "--large", "--oblong"]) { options in
-      XCTAssertEqual(options.color, .silver)
-      XCTAssertEqual(options.size, .large)
-      XCTAssertEqual(options.shape, .oblong)
+    expectParse(Baz.self, ["--pink", "--round"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .small)
+      #expect(options.shape == .round)
     }
   }
 
-  func testParsingCaseIterable_CustomName() throws {
-    AssertParse(Baz.self, ["--pink", "--extra-large"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .extraLarge)
-      XCTAssertEqual(options.shape, nil)
+  @Test func parsingCaseIterable_AllValues() throws {
+    expectParse(Baz.self, ["--pink", "--small", "--round"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .small)
+      #expect(options.shape == .round)
     }
 
-    AssertParse(Baz.self, ["--pink", "--huge"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .humongous)
-      XCTAssertEqual(options.shape, nil)
+    expectParse(Baz.self, ["--purple", "--medium", "--square"]) { options in
+      #expect(options.color == .purple)
+      #expect(options.size == .medium)
+      #expect(options.shape == .square)
     }
 
-    AssertParse(Baz.self, ["--pink", "--humongous"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .humongous)
-      XCTAssertEqual(options.shape, nil)
-    }
-
-    AssertParse(Baz.self, ["--pink", "--huge", "--humongous"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.size, .humongous)
-      XCTAssertEqual(options.shape, nil)
+    expectParse(Baz.self, ["--silver", "--large", "--oblong"]) { options in
+      #expect(options.color == .silver)
+      #expect(options.size == .large)
+      #expect(options.shape == .oblong)
     }
   }
-}
 
-@Suite
-struct FlagsEndToEndTestsSWT {
-  @Test func testParsingCaseIterable_Help() async throws {
+  @Test func parsingCaseIterable_CustomName() throws {
+    expectParse(Baz.self, ["--pink", "--extra-large"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .extraLarge)
+      #expect(options.shape == nil)
+    }
+
+    expectParse(Baz.self, ["--pink", "--huge"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .humongous)
+      #expect(options.shape == nil)
+    }
+
+    expectParse(Baz.self, ["--pink", "--humongous"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .humongous)
+      #expect(options.shape == nil)
+    }
+
+    expectParse(Baz.self, ["--pink", "--huge", "--humongous"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.size == .humongous)
+      #expect(options.shape == nil)
+    }
+  }
+
+  @Test func parsingCaseIterable_Help() async throws {
     try requireHelp(
       .default, for: Baz.self,
       equals: """
@@ -301,20 +296,27 @@ struct FlagsEndToEndTestsSWT {
 
         """)
   }
-}
 
-// swift-format-ignore: AlwaysUseLowerCamelCase
-extension FlagsEndToEndTests {
-  func testParsingCaseIterable_Fails() throws {
+  @Test func parsingCaseIterable_Fails() throws {
     // Missing color
-    XCTAssertThrowsError(try Baz.parse([]))
-    XCTAssertThrowsError(try Baz.parse(["--large", "--square"]))
+    #expect(throws: (any Error).self) { try Baz.parse([]) }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--large", "--square"])
+    }
     // Repeating flags
-    XCTAssertThrowsError(try Baz.parse(["--pink", "--purple"]))
-    XCTAssertThrowsError(try Baz.parse(["--pink", "--small", "--large"]))
-    XCTAssertThrowsError(try Baz.parse(["--pink", "--round", "--square"]))
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--pink", "--purple"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--pink", "--small", "--large"])
+    }
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--pink", "--round", "--square"])
+    }
     // Case name instead of raw value
-    XCTAssertThrowsError(try Baz.parse(["--pink", "--extraLarge"]))
+    #expect(throws: (any Error).self) {
+      try Baz.parse(["--pink", "--extraLarge"])
+    }
   }
 }
 
@@ -329,33 +331,35 @@ private struct Qux: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension FlagsEndToEndTests {
-  func testParsingCaseIterableArray_Values() throws {
-    AssertParse(Qux.self, []) { options in
-      XCTAssertEqual(options.color, [])
-      XCTAssertEqual(options.size, [.small, .medium])
+  @Test func parsingCaseIterableArray_Values() throws {
+    expectParse(Qux.self, []) { options in
+      #expect(options.color == [])
+      #expect(options.size == [.small, .medium])
     }
-    AssertParse(Qux.self, ["--pink"]) { options in
-      XCTAssertEqual(options.color, [.pink])
-      XCTAssertEqual(options.size, [.small, .medium])
+    expectParse(Qux.self, ["--pink"]) { options in
+      #expect(options.color == [.pink])
+      #expect(options.size == [.small, .medium])
     }
-    AssertParse(Qux.self, ["--pink", "--purple", "--small"]) { options in
-      XCTAssertEqual(options.color, [.pink, .purple])
-      XCTAssertEqual(options.size, [.small])
+    expectParse(Qux.self, ["--pink", "--purple", "--small"]) { options in
+      #expect(options.color == [.pink, .purple])
+      #expect(options.size == [.small])
     }
-    AssertParse(Qux.self, ["--pink", "--small", "--purple", "--medium"]) {
+    expectParse(Qux.self, ["--pink", "--small", "--purple", "--medium"]) {
       options in
-      XCTAssertEqual(options.color, [.pink, .purple])
-      XCTAssertEqual(options.size, [.small, .medium])
+      #expect(options.color == [.pink, .purple])
+      #expect(options.size == [.small, .medium])
     }
-    AssertParse(Qux.self, ["--pink", "--pink", "--purple", "--pink"]) {
+    expectParse(Qux.self, ["--pink", "--pink", "--purple", "--pink"]) {
       options in
-      XCTAssertEqual(options.color, [.pink, .pink, .purple, .pink])
-      XCTAssertEqual(options.size, [.small, .medium])
+      #expect(options.color == [.pink, .pink, .purple, .pink])
+      #expect(options.size == [.small, .medium])
     }
   }
 
-  func testParsingCaseIterableArray_Fails() throws {
-    XCTAssertThrowsError(try Qux.parse(["--pink", "--small", "--bloop"]))
+  @Test func parsingCaseIterableArray_Fails() throws {
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--pink", "--small", "--bloop"])
+    }
   }
 }
 
@@ -373,20 +377,20 @@ private struct RepeatOK: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension FlagsEndToEndTests {
-  func testParsingCaseIterable_RepeatableFlags() throws {
-    AssertParse(RepeatOK.self, ["--pink", "--purple", "--square"]) { options in
-      XCTAssertEqual(options.color, .pink)
-      XCTAssertEqual(options.shape, .square)
+  @Test func parsingCaseIterable_RepeatableFlags() throws {
+    expectParse(RepeatOK.self, ["--pink", "--purple", "--square"]) { options in
+      #expect(options.color == .pink)
+      #expect(options.shape == .square)
     }
 
-    AssertParse(RepeatOK.self, ["--round", "--oblong", "--silver"]) { options in
-      XCTAssertEqual(options.color, .silver)
-      XCTAssertEqual(options.shape, .oblong)
+    expectParse(RepeatOK.self, ["--round", "--oblong", "--silver"]) { options in
+      #expect(options.color == .silver)
+      #expect(options.shape == .oblong)
     }
 
-    AssertParse(RepeatOK.self, ["--large", "--pink", "--round", "-l"]) {
+    expectParse(RepeatOK.self, ["--large", "--pink", "--round", "-l"]) {
       options in
-      XCTAssertEqual(options.size, .large)
+      #expect(options.size == .large)
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/NestedCommandEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class NestedCommandEndToEndTests: XCTestCase {}
+@Suite struct NestedCommandEndToEndTests {}
 
 // MARK: Single value String
 
@@ -54,195 +53,229 @@ private struct Foo: ParsableCommand {
   }
 }
 
-// swift-format-ignore: AlwaysUseLowerCamelCase
-private func AssertParseFooCommand<A>(
-  _ type: A.Type, _ arguments: [String], file: StaticString = #filePath,
-  line: UInt = #line, closure: (A) throws -> Void
+private func expectParseFooCommand<A>(
+  _ type: A.Type, _ arguments: [String],
+  sourceLocation: SourceLocation = #_sourceLocation,
+  closure: (A) throws -> Void
 ) where A: ParsableCommand {
-  AssertParseCommand(
-    Foo.self, type, arguments, file: file, line: line, closure: closure)
+  expectParseCommand(
+    Foo.self, type, arguments, sourceLocation: sourceLocation, closure: closure)
 }
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension NestedCommandEndToEndTests {
-  func testParsing_package() throws {
-    AssertParseFooCommand(Foo.Package.self, ["package"]) { package in
-      XCTAssertFalse(package.force)
+  @Test func parsing_package() throws {
+    expectParseFooCommand(Foo.Package.self, ["package"]) { package in
+      #expect(package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.self, ["pkg"]) { package in
-      XCTAssertFalse(package.force)
+    expectParseFooCommand(Foo.Package.self, ["pkg"]) { package in
+      #expect(package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Clean.self, ["package", "clean"]) {
+    expectParseFooCommand(Foo.Package.Clean.self, ["package", "clean"]) {
       clean in
-      XCTAssertEqual(clean.foo.verbose, false)
-      XCTAssertEqual(clean.package.force, false)
+      #expect(clean.foo.verbose == false)
+      #expect(clean.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Clean.self, ["pkg", "clean"]) { clean in
-      XCTAssertEqual(clean.foo.verbose, false)
-      XCTAssertEqual(clean.package.force, false)
+    expectParseFooCommand(Foo.Package.Clean.self, ["pkg", "clean"]) { clean in
+      #expect(clean.foo.verbose == false)
+      #expect(clean.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Clean.self, ["package", "-f", "clean"]) {
+    expectParseFooCommand(Foo.Package.Clean.self, ["package", "-f", "clean"]) {
       clean in
-      XCTAssertEqual(clean.foo.verbose, false)
-      XCTAssertEqual(clean.package.force, true)
+      #expect(clean.foo.verbose == false)
+      #expect(clean.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Clean.self, ["pkg", "-f", "clean"]) {
+    expectParseFooCommand(Foo.Package.Clean.self, ["pkg", "-f", "clean"]) {
       clean in
-      XCTAssertEqual(clean.foo.verbose, false)
-      XCTAssertEqual(clean.package.force, true)
+      #expect(clean.foo.verbose == false)
+      #expect(clean.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["package", "-v", "config"])
+    expectParseFooCommand(Foo.Package.Config.self, ["package", "-v", "config"])
     { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-v", "cfg"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-v", "cfg"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["package", "config", "-v"])
+    expectParseFooCommand(Foo.Package.Config.self, ["package", "config", "-v"])
     { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "cfg", "-v"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "cfg", "-v"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["-v", "package", "config"])
+    expectParseFooCommand(Foo.Package.Config.self, ["-v", "package", "config"])
     { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["-v", "pkg", "cfg"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["-v", "pkg", "cfg"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, false)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == false)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["package", "-f", "config"])
+    expectParseFooCommand(Foo.Package.Config.self, ["package", "-f", "config"])
     { config in
-      XCTAssertEqual(config.foo.verbose, false)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == false)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-f", "cfg"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-f", "cfg"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, false)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == false)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["package", "config", "-f"])
+    expectParseFooCommand(Foo.Package.Config.self, ["package", "config", "-f"])
     { config in
-      XCTAssertEqual(config.foo.verbose, false)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == false)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "cfg", "-f"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "cfg", "-f"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, false)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == false)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(
+    expectParseFooCommand(
       Foo.Package.Config.self, ["package", "-v", "config", "-f"]
     ) { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-v", "cfg", "-f"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-v", "cfg", "-f"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(
+    expectParseFooCommand(
       Foo.Package.Config.self, ["package", "-f", "config", "-v"]
     ) { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-f", "cfg", "-v"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-f", "cfg", "-v"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(
+    expectParseFooCommand(
       Foo.Package.Config.self, ["package", "-vf", "config"]
     ) { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-vf", "cfg"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-vf", "cfg"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(
+    expectParseFooCommand(
       Foo.Package.Config.self, ["package", "-fv", "config"]
     ) { config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
 
-    AssertParseFooCommand(Foo.Package.Config.self, ["pkg", "-fv", "cfg"]) {
+    expectParseFooCommand(Foo.Package.Config.self, ["pkg", "-fv", "cfg"]) {
       config in
-      XCTAssertEqual(config.foo.verbose, true)
-      XCTAssertEqual(config.package.force, true)
+      #expect(config.foo.verbose == true)
+      #expect(config.package.force == true)
     }
   }
 
-  func testParsing_build() throws {
-    AssertParseFooCommand(Foo.Build.self, ["build", "file"]) { build in
-      XCTAssertEqual(build.foo.verbose, false)
-      XCTAssertEqual(build.input, "file")
+  @Test func parsing_build() throws {
+    expectParseFooCommand(Foo.Build.self, ["build", "file"]) { build in
+      #expect(build.foo.verbose == false)
+      #expect(build.input == "file")
     }
   }
 
-  func testParsing_fails() throws {
-    XCTAssertThrowsError(try Foo.parseAsRoot(["clean", "package"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["clean", "pkg"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["config", "package"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["cfg", "pkg"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "c"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "c"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "build", "clean"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "build", "clean"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "clean", "foo"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "clean", "foo"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "config", "bar"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "cfg", "bar"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["package", "clean", "build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["pkg", "clean", "build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["build", "-f"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["build", "--build"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["build", "--build", "12"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["-f", "package", "clean"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["-f", "pkg", "clean"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["-f", "package", "config"]))
-    XCTAssertThrowsError(try Foo.parseAsRoot(["-f", "pkg", "config"]))
+  @Test func parsing_fails() throws {
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["clean", "package"])
+    }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["clean", "pkg"]) }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["config", "package"])
+    }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["cfg", "pkg"]) }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["package", "c"]) }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["pkg", "c"]) }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["package", "build"])
+    }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["pkg", "build"]) }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["package", "build", "clean"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["pkg", "build", "clean"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["package", "clean", "foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["pkg", "clean", "foo"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["package", "config", "bar"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["pkg", "cfg", "bar"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["package", "clean", "build"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["pkg", "clean", "build"])
+    }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["build"]) }
+    #expect(throws: (any Error).self) { try Foo.parseAsRoot(["build", "-f"]) }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["build", "--build"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["build", "--build", "12"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["-f", "package", "clean"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["-f", "pkg", "clean"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["-f", "package", "config"])
+    }
+    #expect(throws: (any Error).self) {
+      try Foo.parseAsRoot(["-f", "pkg", "config"])
+    }
   }
 }
 
@@ -273,29 +306,29 @@ private struct Super: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension NestedCommandEndToEndTests {
-  func testParsing_SharedOptions() throws {
-    AssertParseCommand(Super.self, Super.self, []) { sup in
-      XCTAssertNil(sup.options.firstName)
+  @Test func parsing_SharedOptions() throws {
+    expectParseCommand(Super.self, Super.self, []) { sup in
+      #expect(sup.options.firstName == nil)
     }
 
-    AssertParseCommand(Super.self, Super.self, ["--first-name", "Foo"]) { sup in
-      XCTAssertEqual("Foo", sup.options.firstName)
+    expectParseCommand(Super.self, Super.self, ["--first-name", "Foo"]) { sup in
+      #expect(sup.options.firstName == "Foo")
     }
 
-    AssertParseCommand(Super.self, Super.Sub1.self, ["sub1"]) { sub1 in
-      XCTAssertNil(sub1.options.firstName)
+    expectParseCommand(Super.self, Super.Sub1.self, ["sub1"]) { sub1 in
+      #expect(sub1.options.firstName == nil)
     }
 
-    AssertParseCommand(
+    expectParseCommand(
       Super.self, Super.Sub1.self, ["sub1", "--first-name", "Foo"]
     ) { sub1 in
-      XCTAssertEqual("Foo", sub1.options.firstName)
+      #expect(sub1.options.firstName == "Foo")
     }
 
-    AssertParseCommand(
+    expectParseCommand(
       Super.self, Super.Sub2.self, ["sub2", "--last-name", "Foo"]
     ) { sub2 in
-      XCTAssertEqual("Foo", sub2.options.lastName)
+      #expect(sub2.options.lastName == "Foo")
     }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests+ParsingStrategy.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests+ParsingStrategy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,6 @@
 
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
 @testable import ArgumentParser
 
@@ -33,48 +32,49 @@ private struct AllUnrecognizedArgs: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingAllUnrecognized() throws {
-    AssertParse(AllUnrecognizedArgs.self, []) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertFalse(cmd.hoopla)
-      XCTAssertEqual(cmd.names, [])
+  @Test func parsing_repeatingAllUnrecognized() throws {
+    expectParse(AllUnrecognizedArgs.self, []) { cmd in
+      #expect(cmd.verbose == false)
+      #expect(cmd.hoopla == false)
+      #expect(cmd.names == [])
     }
-    AssertParse(
+    expectParse(
       AllUnrecognizedArgs.self,
       ["foo", "--verbose", "-fi", "bar", "-z", "--other"]
     ) { cmd in
-      XCTAssertTrue(cmd.verbose)
-      XCTAssertTrue(cmd.useFiles)
-      XCTAssertTrue(cmd.useStandardInput)
-      XCTAssertFalse(cmd.hoopla)
-      XCTAssertEqual(cmd.names, ["foo", "bar", "-z", "--other"])
+      #expect(cmd.verbose)
+      #expect(cmd.useFiles)
+      #expect(cmd.useStandardInput)
+      #expect(cmd.hoopla == false)
+      #expect(cmd.names == ["foo", "bar", "-z", "--other"])
     }
   }
 
-  func testParsing_repeatingAllUnrecognized_Builtin() throws {
-    AssertParse(
+  @Test func parsing_repeatingAllUnrecognized_Builtin() throws {
+    expectParse(
       AllUnrecognizedArgs.self, ["foo", "--verbose", "bar", "-z", "-h"]
     ) { cmd in
-      XCTAssertTrue(cmd.verbose)
-      XCTAssertFalse(cmd.useFiles)
-      XCTAssertFalse(cmd.useStandardInput)
-      XCTAssertTrue(cmd.hoopla)
-      XCTAssertEqual(cmd.names, ["foo", "bar", "-z"])
+      #expect(cmd.verbose)
+      #expect(cmd.useFiles == false)
+      #expect(cmd.useStandardInput == false)
+      #expect(cmd.hoopla)
+      #expect(cmd.names == ["foo", "bar", "-z"])
     }
 
-    AssertParseCommand(
+    expectParseCommand(
       AllUnrecognizedArgs.self, HelpCommand.self,
       ["foo", "--verbose", "bar", "-z", "--help"]
     ) { cmd in
       // No need to test HelpCommand properties
     }
-    XCTAssertThrowsError(
-      try AllUnrecognizedArgs.parse(["foo", "--verbose", "--version"]))
+    #expect(throws: (any Error).self) {
+      try AllUnrecognizedArgs.parse(["foo", "--verbose", "--version"])
+    }
   }
 
-  func testParsing_repeatingAllUnrecognized_Fails() throws {
+  @Test func parsing_repeatingAllUnrecognized_Fails() throws {
     // Only partially matches the `-fib` argument
-    XCTAssertThrowsError(try PassthroughArgs.parse(["-fib"]))
+    #expect(throws: (any Error).self) { try PassthroughArgs.parse(["-fib"]) }
   }
 }
 
@@ -96,31 +96,32 @@ private struct AllUnrecognizedRoot: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingAllUnrecognized_Nested() throws {
-    AssertParseCommand(
+  @Test func parsing_repeatingAllUnrecognized_Nested() throws {
+    expectParseCommand(
       AllUnrecognizedRoot.self, AllUnrecognizedRoot.Child.self,
       ["child"]
     ) { cmd in
-      XCTAssertFalse(cmd.root.verbose)
-      XCTAssertFalse(cmd.includeExtras)
-      XCTAssertEqual(cmd.config, "debug")
-      XCTAssertEqual(cmd.extras, [])
+      #expect(cmd.root.verbose == false)
+      #expect(cmd.includeExtras == false)
+      #expect(cmd.config == "debug")
+      #expect(cmd.extras == [])
     }
-    AssertParseCommand(
+    expectParseCommand(
       AllUnrecognizedRoot.self, AllUnrecognizedRoot.Child.self,
       ["child", "--verbose", "--other", "one", "two", "--config", "prod"]
     ) { cmd in
-      XCTAssertTrue(cmd.root.verbose)
-      XCTAssertFalse(cmd.includeExtras)
-      XCTAssertEqual(cmd.config, "prod")
-      XCTAssertEqual(cmd.extras, ["--other", "one", "two"])
+      #expect(cmd.root.verbose)
+      #expect(cmd.includeExtras == false)
+      #expect(cmd.config == "prod")
+      #expect(cmd.extras == ["--other", "one", "two"])
     }
   }
 
-  func testParsing_repeatingAllUnrecognized_Nested_Fails() throws {
+  @Test func parsing_repeatingAllUnrecognized_Nested_Fails() throws {
     // Extra arguments need to make it to the child
-    XCTAssertThrowsError(
-      try AllUnrecognizedRoot.parse(["--verbose", "--other"]))
+    #expect(throws: (any Error).self) {
+      try AllUnrecognizedRoot.parse(["--verbose", "--other"])
+    }
   }
 }
 
@@ -138,43 +139,46 @@ private struct PostTerminatorArgs: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingPostTerminator() throws {
-    AssertParse(PostTerminatorArgs.self, []) { cmd in
-      XCTAssertNil(cmd.title)
-      XCTAssertEqual(cmd.names, [])
+  @Test func parsing_repeatingPostTerminator() throws {
+    expectParse(PostTerminatorArgs.self, []) { cmd in
+      #expect(cmd.title == nil)
+      #expect(cmd.names == [])
     }
-    AssertParse(PostTerminatorArgs.self, ["--", "-fi"]) { cmd in
-      XCTAssertNil(cmd.title)
-      XCTAssertEqual(cmd.names, ["-fi"])
+    expectParse(PostTerminatorArgs.self, ["--", "-fi"]) { cmd in
+      #expect(cmd.title == nil)
+      #expect(cmd.names == ["-fi"])
     }
-    AssertParse(PostTerminatorArgs.self, ["-fi", "--", "-fi", "--"]) { cmd in
-      XCTAssertTrue(cmd.useFiles)
-      XCTAssertTrue(cmd.useStandardInput)
-      XCTAssertNil(cmd.title)
-      XCTAssertEqual(cmd.names, ["-fi", "--"])
+    expectParse(PostTerminatorArgs.self, ["-fi", "--", "-fi", "--"]) { cmd in
+      #expect(cmd.useFiles)
+      #expect(cmd.useStandardInput)
+      #expect(cmd.title == nil)
+      #expect(cmd.names == ["-fi", "--"])
     }
-    AssertParse(PostTerminatorArgs.self, ["-fi", "title", "--", "title"]) {
+    expectParse(PostTerminatorArgs.self, ["-fi", "title", "--", "title"]) {
       cmd in
-      XCTAssertTrue(cmd.useFiles)
-      XCTAssertTrue(cmd.useStandardInput)
-      XCTAssertEqual(cmd.title, "title")
-      XCTAssertEqual(cmd.names, ["title"])
+      #expect(cmd.useFiles)
+      #expect(cmd.useStandardInput)
+      #expect(cmd.title == "title")
+      #expect(cmd.names == ["title"])
     }
-    AssertParse(
+    expectParse(
       PostTerminatorArgs.self, ["--config", "config", "--", "--config", "post"]
     ) { cmd in
-      XCTAssertEqual(cmd.config, "config")
-      XCTAssertNil(cmd.title)
-      XCTAssertEqual(cmd.names, ["--config", "post"])
+      #expect(cmd.config == "config")
+      #expect(cmd.title == nil)
+      #expect(cmd.names == ["--config", "post"])
     }
   }
 
-  func testParsing_repeatingPostTerminator_Fails() throws {
+  @Test func parsing_repeatingPostTerminator_Fails() throws {
     // Only partially matches the `-fib` argument
-    XCTAssertThrowsError(try PostTerminatorArgs.parse(["-fib"]))
+    #expect(throws: (any Error).self) {
+      try PostTerminatorArgs.parse(["-fib"])
+    }
     // The post-terminator input can't provide the option's value
-    XCTAssertThrowsError(
-      try PostTerminatorArgs.parse(["--config", "--", "config"]))
+    #expect(throws: (any Error).self) {
+      try PostTerminatorArgs.parse(["--config", "--", "config"])
+    }
   }
 }
 
@@ -191,122 +195,121 @@ private struct PassthroughArgs: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingCaptureForPassthrough() throws {
-    AssertParse(PassthroughArgs.self, []) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertEqual(cmd.names, [])
+  @Test func parsing_repeatingCaptureForPassthrough() throws {
+    expectParse(PassthroughArgs.self, []) { cmd in
+      #expect(cmd.verbose == false)
+      #expect(cmd.names == [])
     }
 
-    AssertParse(PassthroughArgs.self, ["--other"]) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertEqual(cmd.names, ["--other"])
+    expectParse(PassthroughArgs.self, ["--other"]) { cmd in
+      #expect(cmd.verbose == false)
+      #expect(cmd.names == ["--other"])
     }
 
-    AssertParse(PassthroughArgs.self, ["--verbose", "one", "two", "three"]) {
+    expectParse(PassthroughArgs.self, ["--verbose", "one", "two", "three"]) {
       cmd in
-      XCTAssertTrue(cmd.verbose)
-      XCTAssertEqual(cmd.names, ["one", "two", "three"])
+      #expect(cmd.verbose)
+      #expect(cmd.names == ["one", "two", "three"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self, ["one", "two", "three", "--other", "--verbose"]
     ) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertEqual(
-        cmd.names, ["one", "two", "three", "--other", "--verbose"])
+      #expect(cmd.verbose == false)
+      #expect(cmd.names == ["one", "two", "three", "--other", "--verbose"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self, ["--verbose", "--other", "one", "two", "three"]
     ) { cmd in
-      XCTAssertTrue(cmd.verbose)
-      XCTAssertEqual(cmd.names, ["--other", "one", "two", "three"])
+      #expect(cmd.verbose)
+      #expect(cmd.names == ["--other", "one", "two", "three"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self,
       ["--verbose", "--other", "one", "--", "two", "three"]
     ) { cmd in
-      XCTAssertTrue(cmd.verbose)
-      XCTAssertEqual(cmd.names, ["--other", "one", "--", "two", "three"])
+      #expect(cmd.verbose)
+      #expect(cmd.names == ["--other", "one", "--", "two", "three"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self,
       ["--other", "one", "--", "two", "three", "--verbose"]
     ) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertEqual(
-        cmd.names, ["--other", "one", "--", "two", "three", "--verbose"])
+      #expect(cmd.verbose == false)
+      #expect(
+        cmd.names == ["--other", "one", "--", "two", "three", "--verbose"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self,
       ["--", "--verbose", "--other", "one", "two", "three"]
     ) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertEqual(
-        cmd.names, ["--", "--verbose", "--other", "one", "two", "three"])
+      #expect(cmd.verbose == false)
+      #expect(
+        cmd.names == ["--", "--verbose", "--other", "one", "two", "three"])
     }
 
-    AssertParse(PassthroughArgs.self, ["-one", "-two", "three"]) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertFalse(cmd.useFiles)
-      XCTAssertFalse(cmd.useStandardInput)
-      XCTAssertEqual(cmd.names, ["-one", "-two", "three"])
+    expectParse(PassthroughArgs.self, ["-one", "-two", "three"]) { cmd in
+      #expect(cmd.verbose == false)
+      #expect(cmd.useFiles == false)
+      #expect(cmd.useStandardInput == false)
+      #expect(cmd.names == ["-one", "-two", "three"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self,
       ["--config", "release", "one", "two", "--config", "debug"]
     ) { cmd in
-      XCTAssertEqual(cmd.config, "release")
-      XCTAssertEqual(cmd.names, ["one", "two", "--config", "debug"])
+      #expect(cmd.config == "release")
+      #expect(cmd.names == ["one", "two", "--config", "debug"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self,
       ["--config", "release", "--config", "debug", "one", "two"]
     ) { cmd in
-      XCTAssertEqual(cmd.config, "debug")
-      XCTAssertEqual(cmd.names, ["one", "two"])
+      #expect(cmd.config == "debug")
+      #expect(cmd.names == ["one", "two"])
     }
 
-    AssertParse(PassthroughArgs.self, ["-if", "-one", "-two", "three"]) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertTrue(cmd.useFiles)
-      XCTAssertTrue(cmd.useStandardInput)
-      XCTAssertEqual(cmd.names, ["-one", "-two", "three"])
+    expectParse(PassthroughArgs.self, ["-if", "-one", "-two", "three"]) { cmd in
+      #expect(cmd.verbose == false)
+      #expect(cmd.useFiles)
+      #expect(cmd.useStandardInput)
+      #expect(cmd.names == ["-one", "-two", "three"])
     }
 
-    AssertParse(PassthroughArgs.self, ["-one", "-two", "-three", "-if"]) {
+    expectParse(PassthroughArgs.self, ["-one", "-two", "-three", "-if"]) {
       cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertFalse(cmd.useFiles)
-      XCTAssertFalse(cmd.useStandardInput)
-      XCTAssertEqual(cmd.names, ["-one", "-two", "-three", "-if"])
+      #expect(cmd.verbose == false)
+      #expect(cmd.useFiles == false)
+      #expect(cmd.useStandardInput == false)
+      #expect(cmd.names == ["-one", "-two", "-three", "-if"])
     }
 
-    AssertParse(
+    expectParse(
       PassthroughArgs.self, ["-one", "-two", "-three", "-if", "--help"]
     ) { cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertFalse(cmd.useFiles)
-      XCTAssertFalse(cmd.useStandardInput)
-      XCTAssertEqual(cmd.names, ["-one", "-two", "-three", "-if", "--help"])
+      #expect(cmd.verbose == false)
+      #expect(cmd.useFiles == false)
+      #expect(cmd.useStandardInput == false)
+      #expect(cmd.names == ["-one", "-two", "-three", "-if", "--help"])
     }
 
-    AssertParse(PassthroughArgs.self, ["-one", "-two", "-three", "-if", "-h"]) {
+    expectParse(PassthroughArgs.self, ["-one", "-two", "-three", "-if", "-h"]) {
       cmd in
-      XCTAssertFalse(cmd.verbose)
-      XCTAssertFalse(cmd.useFiles)
-      XCTAssertFalse(cmd.useStandardInput)
-      XCTAssertEqual(cmd.names, ["-one", "-two", "-three", "-if", "-h"])
+      #expect(cmd.verbose == false)
+      #expect(cmd.useFiles == false)
+      #expect(cmd.useStandardInput == false)
+      #expect(cmd.names == ["-one", "-two", "-three", "-if", "-h"])
     }
   }
 
-  func testParsing_repeatingCaptureForPassthrough_Fails() throws {
+  @Test func parsing_repeatingCaptureForPassthrough_Fails() throws {
     // Only partially matches the `-fib` argument
-    XCTAssertThrowsError(try PassthroughArgs.parse(["-fib"]))
+    #expect(throws: (any Error).self) { try PassthroughArgs.parse(["-fib"]) }
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/RepeatingEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,11 +11,10 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
+import Foundation
 import Testing
-import XCTest
 
-final class RepeatingEndToEndTests: XCTestCase {
-}
+@Suite struct RepeatingEndToEndTests {}
 
 // MARK: -
 
@@ -26,20 +25,20 @@ private struct Bar: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingString() throws {
-    AssertParse(Bar.self, []) { bar in
-      XCTAssertTrue(bar.name.isEmpty)
+  @Test func parsing_repeatingString() throws {
+    expectParse(Bar.self, []) { bar in
+      #expect(bar.name.isEmpty)
     }
 
-    AssertParse(Bar.self, ["--name", "Bar"]) { bar in
-      XCTAssertEqual(bar.name.count, 1)
-      XCTAssertEqual(bar.name.first, "Bar")
+    expectParse(Bar.self, ["--name", "Bar"]) { bar in
+      #expect(bar.name.count == 1)
+      #expect(bar.name.first == "Bar")
     }
 
-    AssertParse(Bar.self, ["--name", "Bar", "--name", "Foo"]) { bar in
-      XCTAssertEqual(bar.name.count, 2)
-      XCTAssertEqual(bar.name.first, "Bar")
-      XCTAssertEqual(bar.name.last, "Foo")
+    expectParse(Bar.self, ["--name", "Bar", "--name", "Foo"]) { bar in
+      #expect(bar.name.count == 2)
+      #expect(bar.name.first == "Bar")
+      #expect(bar.name.last == "Foo")
     }
   }
 }
@@ -54,15 +53,15 @@ private struct Foo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_incrementInteger() throws {
-    AssertParse(Foo.self, []) { options in
-      XCTAssertEqual(options.verbose, 0)
+  @Test func parsing_incrementInteger() throws {
+    expectParse(Foo.self, []) { options in
+      #expect(options.verbose == 0)
     }
-    AssertParse(Foo.self, ["--verbose"]) { options in
-      XCTAssertEqual(options.verbose, 1)
+    expectParse(Foo.self, ["--verbose"]) { options in
+      #expect(options.verbose == 1)
     }
-    AssertParse(Foo.self, ["--verbose", "--verbose"]) { options in
-      XCTAssertEqual(options.verbose, 2)
+    expectParse(Foo.self, ["--verbose", "--verbose"]) { options in
+      #expect(options.verbose == 2)
     }
   }
 }
@@ -77,64 +76,63 @@ private struct Baz: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingStringRemaining_1() {
-    AssertParse(Baz.self, []) { baz in
-      XCTAssertFalse(baz.verbose)
-      XCTAssertTrue(baz.names.isEmpty)
+  @Test func parsing_repeatingStringRemaining_1() {
+    expectParse(Baz.self, []) { baz in
+      #expect(!baz.verbose)
+      #expect(baz.names.isEmpty)
     }
   }
 
-  func testParsing_repeatingStringRemaining_2() {
-    AssertParse(Baz.self, ["--names"]) { baz in
-      XCTAssertFalse(baz.verbose)
-      XCTAssertTrue(baz.names.isEmpty)
+  @Test func parsing_repeatingStringRemaining_2() {
+    expectParse(Baz.self, ["--names"]) { baz in
+      #expect(!baz.verbose)
+      #expect(baz.names.isEmpty)
     }
   }
 
-  func testParsing_repeatingStringRemaining_3() {
-    AssertParse(Baz.self, ["--names", "one"]) { baz in
-      XCTAssertFalse(baz.verbose)
-      XCTAssertEqual(baz.names, ["one"])
+  @Test func parsing_repeatingStringRemaining_3() {
+    expectParse(Baz.self, ["--names", "one"]) { baz in
+      #expect(!baz.verbose)
+      #expect(baz.names == ["one"])
     }
   }
 
-  func testParsing_repeatingStringRemaining_4() {
-    AssertParse(Baz.self, ["--names", "one", "two"]) { baz in
-      XCTAssertFalse(baz.verbose)
-      XCTAssertEqual(baz.names, ["one", "two"])
+  @Test func parsing_repeatingStringRemaining_4() {
+    expectParse(Baz.self, ["--names", "one", "two"]) { baz in
+      #expect(!baz.verbose)
+      #expect(baz.names == ["one", "two"])
     }
   }
 
-  func testParsing_repeatingStringRemaining_5() {
-    AssertParse(Baz.self, ["--verbose", "--names", "one", "two"]) { baz in
-      XCTAssertTrue(baz.verbose)
-      XCTAssertEqual(baz.names, ["one", "two"])
+  @Test func parsing_repeatingStringRemaining_5() {
+    expectParse(Baz.self, ["--verbose", "--names", "one", "two"]) { baz in
+      #expect(baz.verbose)
+      #expect(baz.names == ["one", "two"])
     }
   }
 
-  func testParsing_repeatingStringRemaining_6() {
-    AssertParse(Baz.self, ["--names", "one", "two", "--verbose"]) { baz in
-      XCTAssertFalse(baz.verbose)
-      XCTAssertEqual(baz.names, ["one", "two", "--verbose"])
+  @Test func parsing_repeatingStringRemaining_6() {
+    expectParse(Baz.self, ["--names", "one", "two", "--verbose"]) { baz in
+      #expect(!baz.verbose)
+      #expect(baz.names == ["one", "two", "--verbose"])
     }
   }
 
-  func testParsing_repeatingStringRemaining_7() {
-    AssertParse(Baz.self, ["--verbose", "--names", "one", "two", "--verbose"]) {
+  @Test func parsing_repeatingStringRemaining_7() {
+    expectParse(Baz.self, ["--verbose", "--names", "one", "two", "--verbose"]) {
       baz in
-      XCTAssertTrue(baz.verbose)
-      XCTAssertEqual(baz.names, ["one", "two", "--verbose"])
+      #expect(baz.verbose)
+      #expect(baz.names == ["one", "two", "--verbose"])
     }
   }
 
-  func testParsing_repeatingStringRemaining_8() {
-    AssertParse(
+  @Test func parsing_repeatingStringRemaining_8() {
+    expectParse(
       Baz.self,
       ["--verbose", "--names", "one", "two", "--verbose", "--other", "three"]
     ) { baz in
-      XCTAssertTrue(baz.verbose)
-      XCTAssertEqual(
-        baz.names, ["one", "two", "--verbose", "--other", "three"])
+      #expect(baz.verbose)
+      #expect(baz.names == ["one", "two", "--verbose", "--other", "three"])
     }
   }
 }
@@ -156,13 +154,13 @@ private struct Inner: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_subcommandRemaining() {
-    AssertParseCommand(
+  @Test func parsing_subcommandRemaining() {
+    expectParseCommand(
       Outer.self, Inner.self,
       ["inner", "--verbose", "one", "two", "--", "three", "--other"]
     ) { inner in
-      XCTAssertTrue(inner.verbose)
-      XCTAssertEqual(inner.files, ["one", "two", "--", "three", "--other"])
+      #expect(inner.verbose)
+      #expect(inner.files == ["one", "two", "--", "three", "--other"])
     }
   }
 }
@@ -178,93 +176,101 @@ private struct Qux: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingStringUpToNext() throws {
-    AssertParse(Qux.self, []) { qux in
-      XCTAssertFalse(qux.verbose)
-      XCTAssertTrue(qux.names.isEmpty)
-      XCTAssertNil(qux.extra)
+  @Test func parsing_repeatingStringUpToNext() throws {
+    expectParse(Qux.self, []) { qux in
+      #expect(!qux.verbose)
+      #expect(qux.names.isEmpty)
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--names", "one"]) { qux in
-      XCTAssertFalse(qux.verbose)
-      XCTAssertEqual(qux.names, ["one"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--names", "one"]) { qux in
+      #expect(!qux.verbose)
+      #expect(qux.names == ["one"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(
+    expectParse(
       Qux.self,
       [
         "--names", "one", "two", "--verbose", "--names", "three", "--names",
         "four",
       ]
     ) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two", "three", "four"])
-      XCTAssertNil(qux.extra)
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two", "three", "four"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(
+    expectParse(
       Qux.self,
       [
         "extra", "--names", "one", "--names", "two", "--verbose", "--names",
         "three", "four",
       ]
     ) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two", "three", "four"])
-      XCTAssertEqual(qux.extra, "extra")
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two", "three", "four"])
+      #expect(qux.extra == "extra")
     }
 
-    AssertParse(Qux.self, ["--names", "one", "two"]) { qux in
-      XCTAssertFalse(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--names", "one", "two"]) { qux in
+      #expect(!qux.verbose)
+      #expect(qux.names == ["one", "two"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--names", "one", "two", "--verbose"]) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--names", "one", "two", "--verbose"]) { qux in
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--names", "one", "two", "--verbose", "three"]) {
+    expectParse(Qux.self, ["--names", "one", "two", "--verbose", "three"]) {
       qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two"])
-      XCTAssertEqual(qux.extra, "three")
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two"])
+      #expect(qux.extra == "three")
     }
 
-    AssertParse(Qux.self, ["--verbose", "--names", "one", "two"]) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--verbose", "--names", "one", "two"]) { qux in
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--verbose", "--names=one"]) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--verbose", "--names=one"]) { qux in
+      #expect(qux.verbose)
+      #expect(qux.names == ["one"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--verbose", "--names=one", "two"]) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one", "two"])
-      XCTAssertNil(qux.extra)
+    expectParse(Qux.self, ["--verbose", "--names=one", "two"]) { qux in
+      #expect(qux.verbose)
+      #expect(qux.names == ["one", "two"])
+      #expect(qux.extra == nil)
     }
 
-    AssertParse(Qux.self, ["--names=one", "--verbose", "two"]) { qux in
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.names, ["one"])
-      XCTAssertEqual(qux.extra, "two")
+    expectParse(Qux.self, ["--names=one", "--verbose", "two"]) { qux in
+      #expect(qux.verbose)
+      #expect(qux.names == ["one"])
+      #expect(qux.extra == "two")
     }
   }
 
-  func testParsing_repeatingStringUpToNext_Fails() throws {
-    XCTAssertThrowsError(try Qux.parse(["--names", "one", "--other"]))
-    XCTAssertThrowsError(try Qux.parse(["--names", "one", "two", "--other"]))
-    XCTAssertThrowsError(try Qux.parse(["--names", "--other"]))
-    XCTAssertThrowsError(try Qux.parse(["--names", "--verbose"]))
-    XCTAssertThrowsError(try Qux.parse(["--names", "--verbose", "three"]))
+  @Test func parsing_repeatingStringUpToNext_Fails() throws {
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--names", "one", "--other"])
+    }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--names", "one", "two", "--other"])
+    }
+    #expect(throws: (any Error).self) { try Qux.parse(["--names", "--other"]) }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--names", "--verbose"])
+    }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--names", "--verbose", "three"])
+    }
   }
 }
 
@@ -290,78 +296,81 @@ private struct Wobble: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingWithTransform() throws {
+  @Test func parsing_repeatingWithTransform() throws {
     let names = ["--names", "one", "--names", "two"]
     let moreNames = ["--more-names", "three", "four", "five"]
     let evenMoreNames = ["--even-more-names", "six", "--seven", "--eight"]
 
-    AssertParse(Wobble.self, []) { wobble in
-      XCTAssertTrue(wobble.names.isEmpty)
-      XCTAssertTrue(wobble.moreNames.isEmpty)
-      XCTAssertTrue(wobble.evenMoreNames.isEmpty)
+    expectParse(Wobble.self, []) { wobble in
+      #expect(wobble.names.isEmpty)
+      #expect(wobble.moreNames.isEmpty)
+      #expect(wobble.evenMoreNames.isEmpty)
     }
 
-    AssertParse(Wobble.self, names) { wobble in
-      XCTAssertEqual(wobble.names.map { $0.value }, ["one", "two"])
-      XCTAssertTrue(wobble.moreNames.isEmpty)
-      XCTAssertTrue(wobble.evenMoreNames.isEmpty)
+    expectParse(Wobble.self, names) { wobble in
+      #expect(wobble.names.map { $0.value } == ["one", "two"])
+      #expect(wobble.moreNames.isEmpty)
+      #expect(wobble.evenMoreNames.isEmpty)
     }
 
-    AssertParse(Wobble.self, moreNames) { wobble in
-      XCTAssertTrue(wobble.names.isEmpty)
-      XCTAssertEqual(
-        wobble.moreNames.map { $0.value }, ["three", "four", "five"])
-      XCTAssertTrue(wobble.evenMoreNames.isEmpty)
+    expectParse(Wobble.self, moreNames) { wobble in
+      #expect(wobble.names.isEmpty)
+      #expect(wobble.moreNames.map { $0.value } == ["three", "four", "five"])
+      #expect(wobble.evenMoreNames.isEmpty)
     }
 
-    AssertParse(Wobble.self, evenMoreNames) { wobble in
-      XCTAssertTrue(wobble.names.isEmpty)
-      XCTAssertTrue(wobble.moreNames.isEmpty)
-      XCTAssertEqual(
-        wobble.evenMoreNames.map { $0.value }, ["six", "--seven", "--eight"])
+    expectParse(Wobble.self, evenMoreNames) { wobble in
+      #expect(wobble.names.isEmpty)
+      #expect(wobble.moreNames.isEmpty)
+      #expect(
+        wobble.evenMoreNames.map { $0.value } == ["six", "--seven", "--eight"])
     }
 
-    AssertParse(Wobble.self, Array([names, moreNames, evenMoreNames].joined()))
+    expectParse(Wobble.self, Array([names, moreNames, evenMoreNames].joined()))
     { wobble in
-      XCTAssertEqual(wobble.names.map { $0.value }, ["one", "two"])
-      XCTAssertEqual(
-        wobble.moreNames.map { $0.value }, ["three", "four", "five"])
-      XCTAssertEqual(
-        wobble.evenMoreNames.map { $0.value }, ["six", "--seven", "--eight"])
+      #expect(wobble.names.map { $0.value } == ["one", "two"])
+      #expect(wobble.moreNames.map { $0.value } == ["three", "four", "five"])
+      #expect(
+        wobble.evenMoreNames.map { $0.value } == ["six", "--seven", "--eight"])
     }
 
-    AssertParse(Wobble.self, Array([moreNames, names, evenMoreNames].joined()))
+    expectParse(Wobble.self, Array([moreNames, names, evenMoreNames].joined()))
     { wobble in
-      XCTAssertEqual(wobble.names.map { $0.value }, ["one", "two"])
-      XCTAssertEqual(
-        wobble.moreNames.map { $0.value }, ["three", "four", "five"])
-      XCTAssertEqual(
-        wobble.evenMoreNames.map { $0.value }, ["six", "--seven", "--eight"])
+      #expect(wobble.names.map { $0.value } == ["one", "two"])
+      #expect(wobble.moreNames.map { $0.value } == ["three", "four", "five"])
+      #expect(
+        wobble.evenMoreNames.map { $0.value } == ["six", "--seven", "--eight"])
     }
 
-    AssertParse(Wobble.self, Array([moreNames, evenMoreNames, names].joined()))
+    expectParse(Wobble.self, Array([moreNames, evenMoreNames, names].joined()))
     { wobble in
-      XCTAssertTrue(wobble.names.isEmpty)
-      XCTAssertEqual(
-        wobble.moreNames.map { $0.value }, ["three", "four", "five"])
-      XCTAssertEqual(
-        wobble.evenMoreNames.map { $0.value },
-        ["six", "--seven", "--eight", "--names", "one", "--names", "two"])
+      #expect(wobble.names.isEmpty)
+      #expect(wobble.moreNames.map { $0.value } == ["three", "four", "five"])
+      #expect(
+        wobble.evenMoreNames.map { $0.value }
+          == ["six", "--seven", "--eight", "--names", "one", "--names", "two"])
     }
   }
 
-  func testParsing_repeatingWithTransform_Fails() throws {
-    XCTAssertThrowsError(try Wobble.parse(["--names", "one", "--other"]))
-    XCTAssertThrowsError(try Wobble.parse(["--more-names", "one", "--other"]))
+  @Test func parsing_repeatingWithTransform_Fails() throws {
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["--names", "one", "--other"])
+    }
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["--more-names", "one", "--other"])
+    }
 
-    XCTAssertThrowsError(
-      try Wobble.parse(["--names", "one", "--names", "bad"]))
-    XCTAssertThrowsError(
-      try Wobble.parse(["--more-names", "one", "two", "bad", "--names", "one"]))
-    XCTAssertThrowsError(
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["--names", "one", "--names", "bad"])
+    }
+    #expect(throws: (any Error).self) {
+      try Wobble.parse(["--more-names", "one", "two", "bad", "--names", "one"])
+    }
+    #expect(throws: (any Error).self) {
       try Wobble.parse([
         "--even-more-names", "one", "two", "--names", "one", "bad",
-      ]))
+      ])
+    }
   }
 }
 
@@ -375,23 +384,22 @@ private struct Weazle: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
-  func testParsing_repeatingArgument() throws {
-    AssertParse(Weazle.self, ["one", "two", "three", "--verbose"]) { weazle in
-      XCTAssertTrue(weazle.verbose)
-      XCTAssertEqual(weazle.names, ["one", "two", "three"])
+  @Test func parsing_repeatingArgument() throws {
+    expectParse(Weazle.self, ["one", "two", "three", "--verbose"]) { weazle in
+      #expect(weazle.verbose)
+      #expect(weazle.names == ["one", "two", "three"])
     }
 
-    AssertParse(Weazle.self, ["--verbose", "one", "two", "three"]) { weazle in
-      XCTAssertTrue(weazle.verbose)
-      XCTAssertEqual(weazle.names, ["one", "two", "three"])
+    expectParse(Weazle.self, ["--verbose", "one", "two", "three"]) { weazle in
+      #expect(weazle.verbose)
+      #expect(weazle.names == ["one", "two", "three"])
     }
 
-    AssertParse(
+    expectParse(
       Weazle.self, ["one", "two", "three", "--", "--other", "--verbose"]
     ) { weazle in
-      XCTAssertFalse(weazle.verbose)
-      XCTAssertEqual(
-        weazle.names, ["one", "two", "three", "--other", "--verbose"])
+      #expect(!weazle.verbose)
+      #expect(weazle.names == ["one", "two", "three", "--other", "--verbose"])
     }
   }
 }
@@ -418,18 +426,18 @@ private func time(_ body: () -> Void) -> TimeInterval {
 // https://github.com/apple/swift-argument-parser/issues/710
 extension RepeatingEndToEndTests {
   // A regression test against array parsing performance going non-linear.
-  func testParsing_repeatingPerformance() throws {
+  @Test func parsing_repeatingPerformance() throws {
     let timeFor20 = time {
-      AssertParse(PerformanceTest.self, argumentGenerator(100)) { test in
-        XCTAssertEqual(100, test.bundleIdentifiers.count)
+      expectParse(PerformanceTest.self, argumentGenerator(100)) { test in
+        #expect(test.bundleIdentifiers.count == 100)
       }
     }
     let timeFor40 = time {
-      AssertParse(PerformanceTest.self, argumentGenerator(200)) { test in
-        XCTAssertEqual(200, test.bundleIdentifiers.count)
+      expectParse(PerformanceTest.self, argumentGenerator(200)) { test in
+        #expect(test.bundleIdentifiers.count == 200)
       }
     }
 
-    XCTAssertLessThan(timeFor40, timeFor20 * 10)
+    #expect(timeFor40 < timeFor20 * 10)
   }
 }

--- a/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SourceCompatEndToEndTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,11 +11,11 @@
 
 import ArgumentParser
 import ArgumentParserTestHelpers
-import XCTest
+import Testing
 
 // The goal of this test class is to validate source compatibility. By running
 // this class's tests, all property wrapper initializers should be called.
-final class SourceCompatEndToEndTests: XCTestCase {}
+@Suite struct SourceCompatEndToEndTests {}
 
 // MARK: - Property Wrapper Initializers
 
@@ -225,7 +225,7 @@ struct AllFlags: ParsableArguments {
 }
 
 extension SourceCompatEndToEndTests {
-  func testParsingAll() throws {
+  @Test func parsingAll() throws {
     // This is just checking building the argument definitions, not the actual
     // validation or usage of these definitions, which would fail.
     _ = AlmostAllArguments()

--- a/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
+++ b/Tests/ArgumentParserEndToEndTests/UnparsedValuesEndToEndTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Argument Parser open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,8 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
-final class UnparsedValuesEndToEndTests: XCTestCase {}
+@Suite struct UnparsedValuesEndToEndTests {}
 
 // MARK: Two values + unparsed variable
 
@@ -34,30 +33,34 @@ private struct Quizzo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testParsing_TwoPlusUnparsed() throws {
-    AssertParse(Qux.self, ["--name", "Qux"]) { qux in
-      XCTAssertEqual(qux.name, "Qux")
-      XCTAssertFalse(qux.verbose)
-      XCTAssertEqual(qux.count, 0)
+  @Test func parsing_TwoPlusUnparsed() throws {
+    expectParse(Qux.self, ["--name", "Qux"]) { qux in
+      #expect(qux.name == "Qux")
+      #expect(qux.verbose == false)
+      #expect(qux.count == 0)
     }
-    AssertParse(Qux.self, ["--name", "Qux", "--verbose"]) { qux in
-      XCTAssertEqual(qux.name, "Qux")
-      XCTAssertTrue(qux.verbose)
-      XCTAssertEqual(qux.count, 0)
+    expectParse(Qux.self, ["--name", "Qux", "--verbose"]) { qux in
+      #expect(qux.name == "Qux")
+      #expect(qux.verbose)
+      #expect(qux.count == 0)
     }
 
-    AssertParse(Quizzo.self, ["--name", "Qux", "--verbose"]) { quizzo in
-      XCTAssertEqual(quizzo.name, "Qux")
-      XCTAssertTrue(quizzo.verbose)
-      XCTAssertEqual(quizzo.count, 0)
+    expectParse(Quizzo.self, ["--name", "Qux", "--verbose"]) { quizzo in
+      #expect(quizzo.name == "Qux")
+      #expect(quizzo.verbose)
+      #expect(quizzo.count == 0)
     }
   }
 
-  func testParsing_TwoPlusUnparsed_Fails() throws {
-    XCTAssertThrowsError(try Qux.parse([]))
-    XCTAssertThrowsError(try Qux.parse(["--name"]))
-    XCTAssertThrowsError(try Qux.parse(["--name", "Qux", "--count"]))
-    XCTAssertThrowsError(try Qux.parse(["--name", "Qux", "--count", "2"]))
+  @Test func parsing_TwoPlusUnparsed_Fails() throws {
+    #expect(throws: (any Error).self) { try Qux.parse([]) }
+    #expect(throws: (any Error).self) { try Qux.parse(["--name"]) }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--name", "Qux", "--count"])
+    }
+    #expect(throws: (any Error).self) {
+      try Qux.parse(["--name", "Qux", "--count", "2"])
+    }
   }
 }
 
@@ -88,52 +91,57 @@ private struct Piyo: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testParsing_TwoPlusOptionalUnparsed() throws {
-    AssertParse(Hogeraa.self, []) { hogeraa in
-      XCTAssertEqual(hogeraa.fullName, "Full Name")
+  @Test func parsing_TwoPlusOptionalUnparsed() throws {
+    expectParse(Hogeraa.self, []) { hogeraa in
+      #expect(hogeraa.fullName == "Full Name")
     }
 
-    AssertParse(Hogera.self, ["--first-name", "Hogera"]) { hogera in
-      XCTAssertEqual(hogera.firstName, "Hogera")
-      XCTAssertFalse(hogera.hasLastName)
-      XCTAssertNil(hogera.fullName)
+    expectParse(Hogera.self, ["--first-name", "Hogera"]) { hogera in
+      #expect(hogera.firstName == "Hogera")
+      #expect(hogera.hasLastName == false)
+      #expect(hogera.fullName == nil)
     }
-    AssertParse(Hogera.self, ["--first-name", "Hogera", "--has-last-name"]) {
+    expectParse(Hogera.self, ["--first-name", "Hogera", "--has-last-name"]) {
       hogera in
-      XCTAssertEqual(hogera.firstName, "Hogera")
-      XCTAssertTrue(hogera.hasLastName)
-      XCTAssertEqual(hogera.fullName, "Hogera LastName")
+      #expect(hogera.firstName == "Hogera")
+      #expect(hogera.hasLastName)
+      #expect(hogera.fullName == "Hogera LastName")
     }
 
-    AssertParse(Piyo.self, ["--first-name", "Hogera"]) { piyo in
-      XCTAssertEqual(piyo.firstName, "Hogera")
-      XCTAssertFalse(piyo.hasLastName)
-      XCTAssertEqual(piyo.fullName, "Hogera")
+    expectParse(Piyo.self, ["--first-name", "Hogera"]) { piyo in
+      #expect(piyo.firstName == "Hogera")
+      #expect(piyo.hasLastName == false)
+      #expect(piyo.fullName == "Hogera")
     }
-    AssertParse(Piyo.self, ["--first-name", "Hogera", "--has-last-name"]) {
+    expectParse(Piyo.self, ["--first-name", "Hogera", "--has-last-name"]) {
       piyo in
-      XCTAssertEqual(piyo.firstName, "Hogera")
-      XCTAssertTrue(piyo.hasLastName)
-      XCTAssertEqual(piyo.fullName, "Hogera LastName")
+      #expect(piyo.firstName == "Hogera")
+      #expect(piyo.hasLastName)
+      #expect(piyo.fullName == "Hogera LastName")
     }
   }
 
-  func testParsing_TwoPlusOptionalUnparsed_Fails() throws {
-    XCTAssertThrowsError(try Hogeraa.parse(["--full-name"]))
-    XCTAssertThrowsError(try Hogeraa.parse(["--full-name", "Hogera Piyo"]))
-    XCTAssertThrowsError(try Hogera.parse([]))
-    XCTAssertThrowsError(try Hogera.parse(["--first-name"]))
-    XCTAssertThrowsError(
-      try Hogera.parse(["--first-name", "Hogera", "--full-name"]))
-    XCTAssertThrowsError(
+  @Test func parsing_TwoPlusOptionalUnparsed_Fails() throws {
+    #expect(throws: (any Error).self) { try Hogeraa.parse(["--full-name"]) }
+    #expect(throws: (any Error).self) {
+      try Hogeraa.parse(["--full-name", "Hogera Piyo"])
+    }
+    #expect(throws: (any Error).self) { try Hogera.parse([]) }
+    #expect(throws: (any Error).self) { try Hogera.parse(["--first-name"]) }
+    #expect(throws: (any Error).self) {
+      try Hogera.parse(["--first-name", "Hogera", "--full-name"])
+    }
+    #expect(throws: (any Error).self) {
       try Hogera.parse(["--first-name", "Hogera", "--full-name", "Hogera Piyo"])
-    )
-    XCTAssertThrowsError(try Piyo.parse([]))
-    XCTAssertThrowsError(try Piyo.parse(["--first-name"]))
-    XCTAssertThrowsError(
-      try Piyo.parse(["--first-name", "Hogera", "--full-name"]))
-    XCTAssertThrowsError(
-      try Piyo.parse(["--first-name", "Hogera", "--full-name", "Hogera Piyo"]))
+    }
+    #expect(throws: (any Error).self) { try Piyo.parse([]) }
+    #expect(throws: (any Error).self) { try Piyo.parse(["--first-name"]) }
+    #expect(throws: (any Error).self) {
+      try Piyo.parse(["--first-name", "Hogera", "--full-name"])
+    }
+    #expect(throws: (any Error).self) {
+      try Piyo.parse(["--first-name", "Hogera", "--full-name", "Hogera Piyo"])
+    }
   }
 }
 
@@ -164,30 +172,30 @@ private struct DefaultedArguments: ParsableArguments {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testUnparsedNestedValues() {
-    AssertParse(Foo.self, []) { foo in
-      XCTAssertFalse(foo.foo)
-      XCTAssertNil(foo.opt.title)
-      XCTAssertNil(foo.opt.edition)
-      XCTAssertEqual(1, foo.def.one)
-      XCTAssertEqual(2, foo.def.two)
+  @Test func unparsedNestedValues() {
+    expectParse(Foo.self, []) { foo in
+      #expect(foo.foo == false)
+      #expect(foo.opt.title == nil)
+      #expect(foo.opt.edition == nil)
+      #expect(foo.def.one == 1)
+      #expect(foo.def.two == 2)
     }
 
-    AssertParse(
+    expectParse(
       Foo.self,
       ["--foo", "--edition", "5", "Hello", "--one", "2", "--two", "1"]
     ) { foo in
-      XCTAssertTrue(foo.foo)
-      XCTAssertEqual("Hello", foo.opt.title)
-      XCTAssertEqual(5, foo.opt.edition)
-      XCTAssertEqual(2, foo.def.one)
-      XCTAssertEqual(1, foo.def.two)
+      #expect(foo.foo)
+      #expect(foo.opt.title == "Hello")
+      #expect(foo.opt.edition == 5)
+      #expect(foo.def.one == 2)
+      #expect(foo.def.two == 1)
     }
   }
 
-  func testUnparsedNestedValues_Fails() {
-    XCTAssertThrowsError(try Foo.parse(["--edition", "aaa"]))
-    XCTAssertThrowsError(try Foo.parse(["--one", "aaa"]))
+  @Test func unparsedNestedValues_Fails() {
+    #expect(throws: (any Error).self) { try Foo.parse(["--edition", "aaa"]) }
+    #expect(throws: (any Error).self) { try Foo.parse(["--one", "aaa"]) }
   }
 }
 
@@ -222,61 +230,90 @@ private struct Bazz: Decodable {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testUnparsedNestedOptionalValue() {
-    AssertParse(Barr.self, []) { barr in
-      XCTAssertNotNil(barr.baz)
-      XCTAssertEqual(barr.baz?.age, 105)
-      XCTAssertEqual(barr.baz?.name, "Some Name")
+  @Test func unparsedNestedOptionalValue() {
+    expectParse(Barr.self, []) { barr in
+      let baz = try #require(barr.baz)
+
+      #expect(baz.age == 105)
+      #expect(baz.name == "Some Name")
     }
 
-    AssertParse(Bar.self, []) { bar in
-      XCTAssertFalse(bar.bar)
-      XCTAssertNil(bar.baz)
-      XCTAssertNil(bar.baz?.age)
-      XCTAssertNil(bar.baz?.name)
-      XCTAssertNil(bar.bazz)
-      XCTAssertNil(bar.bazz?.age)
-      XCTAssertNil(bar.bazz?.name)
+    expectParse(Bar.self, []) { bar in
+      #expect(bar.bar == false)
+      #expect(bar.baz == nil)
+      #expect(bar.baz?.age == nil)
+      #expect(bar.baz?.name == nil)
+      #expect(bar.bazz == nil)
+      #expect(bar.bazz?.age == nil)
+      #expect(bar.bazz?.name == nil)
     }
 
-    AssertParse(Bar.self, ["--bar"]) { bar in
-      XCTAssertTrue(bar.bar)
-      XCTAssertNotNil(bar.baz)
-      XCTAssertEqual(bar.baz?.name, "Some")
-      XCTAssertEqual(bar.baz?.age, 100)
-      XCTAssertNotNil(bar.bazz)
-      XCTAssertEqual(bar.bazz?.name, "Other")
-      XCTAssertEqual(bar.bazz?.age, 101)
+    expectParse(Bar.self, ["--bar"]) { bar in
+      #expect(bar.bar)
+      let baz = try #require(bar.baz)
+      #expect(baz.name == "Some")
+      #expect(baz.age == 100)
+      let bazz = try #require(bar.bazz)
+      #expect(bazz.name == "Other")
+      #expect(bazz.age == 101)
     }
   }
 
-  func testUnparsedNestedOptionalValue_Fails() {
-    XCTAssertThrowsError(try Bar.parse(["--baz", "xyz"]))
-    XCTAssertThrowsError(try Bar.parse(["--bazz", "xyz"]))
-    XCTAssertThrowsError(try Bar.parse(["--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--age", "123"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--age", "123"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz", "xyz"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz", "--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz", "xyz", "--name"]))
-    XCTAssertThrowsError(
-      try Bar.parse(["--bar", "--baz", "xyz", "--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz", "--age", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--baz", "xyz", "--age"]))
-    XCTAssertThrowsError(
-      try Bar.parse(["--bar", "--baz", "xyz", "--age", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "xyz"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "xyz", "--name"]))
-    XCTAssertThrowsError(
-      try Bar.parse(["--bar", "--bazz", "xyz", "--name", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "--age", "None"]))
-    XCTAssertThrowsError(try Bar.parse(["--bar", "--bazz", "xyz", "--age"]))
-    XCTAssertThrowsError(
-      try Bar.parse(["--bar", "--bazz", "xyz", "--age", "None"]))
+  @Test func unparsedNestedOptionalValue_Fails() {
+    #expect(throws: (any Error).self) { try Bar.parse(["--baz", "xyz"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--bazz", "xyz"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--name", "None"]) }
+    #expect(throws: (any Error).self) { try Bar.parse(["--age", "123"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--name", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--age", "123"])
+    }
+    #expect(throws: (any Error).self) { try Bar.parse(["--bar", "--baz"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "xyz"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "--name", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "xyz", "--name"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "xyz", "--name", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "--age", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "xyz", "--age"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--baz", "xyz", "--age", "None"])
+    }
+    #expect(throws: (any Error).self) { try Bar.parse(["--bar", "--bazz"]) }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "xyz"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "--name", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "xyz", "--name"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "xyz", "--name", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "--age", "None"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "xyz", "--age"])
+    }
+    #expect(throws: (any Error).self) {
+      try Bar.parse(["--bar", "--bazz", "xyz", "--age", "None"])
+    }
   }
 }
 
@@ -291,11 +328,11 @@ private struct Bamf: ParsableCommand {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testUnparsedNestedDictionary() {
-    AssertParse(Bamf.self, []) { bamf in
-      XCTAssertFalse(bamf.bamph)
-      XCTAssertEqual(bamf.bop, [:])
-      XCTAssertEqual(bamf.bopp, [:])
+  @Test func unparsedNestedDictionary() {
+    expectParse(Bamf.self, []) { bamf in
+      #expect(bamf.bamph == false)
+      #expect(bamf.bop == [:])
+      #expect(bamf.bopp == [:])
     }
   }
 }
@@ -320,10 +357,10 @@ private enum Qiqii: Codable, Equatable {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testUnparsedEnumWithAssociatedValues() {
-    AssertParse(Qiqi.self, []) { qiqi in
-      XCTAssertFalse(qiqi.qiqiqi)
-      XCTAssertEqual(qiqi.qiqii, .q(""))
+  @Test func unparsedEnumWithAssociatedValues() {
+    expectParse(Qiqi.self, []) { qiqi in
+      #expect(qiqi.qiqiqi == false)
+      #expect(qiqi.qiqii == .q(""))
     }
   }
 }
@@ -346,11 +383,11 @@ private final class Vig: Toks {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
 extension UnparsedValuesEndToEndTests {
-  func testUnparsedNestedInheritingClassType() {
-    AssertParse(Fry.self, []) { fry in
-      XCTAssertFalse(fry.c)
-      XCTAssertEqual(fry.toksVig.a, "hello")
-      XCTAssertEqual(fry.toksVig.b, "world")
+  @Test func unparsedNestedInheritingClassType() {
+    expectParse(Fry.self, []) { fry in
+      #expect(fry.c == false)
+      #expect(fry.toksVig.a == "hello")
+      #expect(fry.toksVig.b == "world")
     }
   }
 }


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift Argument Parser!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

-->
Migrate seven `ArgumentParserEndToEndTests` suites from XCTest to Swift
Testing:

- `SourceCompatEndToEndTests`
- `UnparsedValuesEndToEndTests`
- `DefaultSubcommandEndToEndTests`
- `FlagsEndToEndTests`
- `NestedCommandEndToEndTests`
- `RepeatingEndToEndTests`
- `RepeatingEndToEndTests+ParsingStrategy` (extension of the above)

`FlagsEndToEndTests` previously had a small `FlagsEndToEndTestsSWT`
Swift Testing suite alongside the XCTest class; fold its
`parsingCaseIterable_Help` test back into the main suite so all
flag-parsing tests live in one place.

`NestedCommandEndToEndTests` had a private `AssertParseFooCommand`
helper that curried `AssertParseCommand` with `Foo.self` as the root;
port it to `expectParseFooCommand` calling `expectParseCommand` for
the same purpose.

`DefaultSubcommandEndToEndTests` previously used
`AssertParseCommandErrorMessage` (XCTest-only, not ported to Swift
Testing yet). Inline the parse-and-check-message logic in that one
test with `#require` on `Test.current` semantics.

`RepeatingEndToEndTests+ParsingStrategy` is an extension of
`RepeatingEndToEndTests` and must be migrated in the same PR so
`extension RepeatingEndToEndTests` refers to the new `@Suite struct`
rather than the old `XCTestCase` class.

Relates to #710

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>