### PR TITLE
Fix parsing of empty long option values

### DIFF
--- a/Sources/ArgumentParser/Parsing/SplitArguments.swift
+++ b/Sources/ArgumentParser/Parsing/SplitArguments.swift
@@ -25,7 +25,7 @@ enum ParsedArgument: Equatable, CustomStringConvertible {
     )
     let name = Name(baseName)
     self =
-      value.isEmpty
+      indexOfEqualSign == str.endIndex
       ? .name(name)
       : .nameWithValue(name, String(value))
   }

--- a/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SimpleEndToEndTests.swift
@@ -49,6 +49,24 @@ extension SimpleEndToEndTests {
   }
 }
 
+// MARK: Empty option value
+
+private struct Qux: ParsableArguments {
+  @Option() var output: String
+  @Argument() var file: String
+}
+
+// swift-format-ignore: AlwaysUseLowerCamelCase
+// https://github.com/apple/swift-argument-parser/issues/710
+extension SimpleEndToEndTests {
+  func testParsing_EmptyOptionValue() throws {
+    AssertParse(Qux.self, ["--output=", "file.txt"]) { qux in
+      XCTAssertEqual(qux.output, "")
+      XCTAssertEqual(qux.file, "file.txt")
+    }
+  }
+}
+
 // MARK: Single value Int
 
 private struct Foo: ParsableArguments {

--- a/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
+++ b/Tests/ArgumentParserUnitTests/SplitArgumentTests.swift
@@ -119,6 +119,19 @@ private func expectElementEqual(
     #expect(sut.originalInput == ["--abc=def"])
   }
 
+  @Test func singleLongOptionWithEmptyValue() async throws {
+    let sut = try SplitArguments(arguments: ["--abc="])
+
+    #expect(sut.elements.count == 1)
+    try expectIndexEqual(sut, at: 0, inputIndex: 0, subIndex: .complete)
+    try expectElementEqual(
+      sut, at: 0, .option(.nameWithValue(.long("abc"), ""))
+    )
+
+    #expect(sut.originalInput.count == 1)
+    #expect(sut.originalInput == ["--abc="])
+  }
+
   @Test func multipleShortOptionsCombined() async throws {
     let sut = try SplitArguments(arguments: ["-abc"])
 


### PR DESCRIPTION
Fixes #958.

This change treats the presence of `=` in a long option as an explicit attached value, including empty values.

For example:

--output=

is now parsed as an option with an empty string value rather than being treated as a bare flag.

Tests:
- Added tokenizer coverage for empty long option values.
- Added an end-to-end regression test for `--output=`.
- Ran the full test suite and formatting checks.

Compatibility note: `--flag=` is now treated as a flag with an explicit empty attached value, consistent with the existing single-dash `-f=` behavior and the issue's explicit `=` rule.