### PR TITLE
Provide an interface for tools to implement `SIGINFO` handling.

### DIFF
--- a/Examples/info-provider/InfoProvider.swift
+++ b/Examples/info-provider/InfoProvider.swift
@@ -46,7 +46,7 @@ struct InfoProvider: AsyncParsableCommand, InfoProvidingParsableCommand {
   }
 
   @MainActor
-  func provideInfo() {
+  static func provideInfo() {
     let timeRunning = Date().timeIntervalSince(info.start)
     print("Running for \(timeRunning) seconds.")
 

--- a/Examples/info-provider/InfoProvider.swift
+++ b/Examples/info-provider/InfoProvider.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+
+@MainActor
+final class Info {
+  let start = Date()
+  var signalCount = 0
+}
+
+let info = Info()
+
+@main
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
+struct InfoProvider: AsyncParsableCommand, InfoProvidingParsableCommand {
+  func run() async throws {
+    _ = info
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || os(FreeBSD) || os(OpenBSD)
+    print("Press Ctrl+T to see process information.")
+    #elseif os(Linux) || os(Android)
+    print("Send SIGUSR1 to \(getpid()) to see process information.")
+    #elseif os(Windows)
+    print("Press Ctrl+Break to see process information.")
+    #endif
+
+    let dot = [UInt8(ascii: ".")]
+    while true {
+      try await Task.sleep(nanoseconds: 1_000_000_000)
+      if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+        try? FileHandle.standardOutput.write(contentsOf: dot)
+      } else {
+        FileHandle.standardOutput.write(Data(dot))
+      }
+    }
+  }
+
+  @MainActor
+  func provideInfo() {
+    let timeRunning = Date().timeIntervalSince(info.start)
+    print("Running for \(timeRunning) seconds.")
+
+    info.signalCount += 1
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || os(FreeBSD) || os(OpenBSD)
+    print("SIGINFO received \(info.signalCount) time(s)!")
+    #elseif os(Linux) || os(Android)
+    print("SIGUSR1 received \(info.signalCount) time(s)!")
+    #elseif os(Windows)
+    print("Ctrl+Break received \(info.signalCount) time(s)!")
+    #endif
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,11 @@ var package = Package(
       dependencies: ["ArgumentParser"],
       path: "Examples/default-as-flag"
     ),
+    .executableTarget(
+      name: "info-provider",
+      dependencies: ["ArgumentParser"],
+      path: "Examples/info-provider"
+    ),
 
     // Tools
     .executableTarget(

--- a/Sources/ArgumentParser/CMakeLists.txt
+++ b/Sources/ArgumentParser/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(ArgumentParser
   "Parsable Types/CommandConfiguration.swift"
   "Parsable Types/EnumerableFlag.swift"
   "Parsable Types/ExpressibleByArgument.swift"
+  "Parsable Types/InfoProvidingCommand.swift"
   "Parsable Types/ParsableArguments.swift"
   "Parsable Types/ParsableCommand.swift"
 
@@ -46,6 +47,7 @@ add_library(ArgumentParser
   Utilities/Foundation.swift
   Utilities/Platform.swift
   Utilities/SequenceExtensions.swift
+  Utilities/SIGINFOHandler.swift
   Utilities/StringExtensions.swift
   Utilities/SwiftExtensions.swift
   Utilities/Tree.swift

--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -67,8 +67,7 @@ extension AsyncParsableCommand {
       var command = try await asyncParseAsRoot(arguments)
 
       var siginfoHandler: SIGINFOHandler?
-      if let command = command as? any InfoProvidingParsableCommand
-      {
+      if let command = command as? any InfoProvidingParsableCommand {
         siginfoHandler = SIGINFOHandler(for: command)
       }
       siginfoHandler?.register()

--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -67,8 +67,7 @@ extension AsyncParsableCommand {
       var command = try await asyncParseAsRoot(arguments)
 
       var siginfoHandler: SIGINFOHandler?
-      if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *),
-        let command = command as? any InfoProvidingParsableCommand
+      if let command = command as? any InfoProvidingParsableCommand
       {
         siginfoHandler = SIGINFOHandler(for: command)
       }

--- a/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/AsyncParsableCommand.swift
@@ -65,6 +65,18 @@ extension AsyncParsableCommand {
   public static func main(_ arguments: [String]?) async {
     do {
       var command = try await asyncParseAsRoot(arguments)
+
+      var siginfoHandler: SIGINFOHandler?
+      if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *),
+        let command = command as? any InfoProvidingParsableCommand
+      {
+        siginfoHandler = SIGINFOHandler(for: command)
+      }
+      siginfoHandler?.register()
+      defer {
+        siginfoHandler?.unregister()
+      }
+
       if var asyncCommand = command as? AsyncParsableCommand {
         try await asyncCommand.run()
       } else {

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -26,7 +26,7 @@
 ///
 /// On platforms that do not support providing information, conformance to this
 /// protocol has no effect.
-@available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
   #if compiler(>=6.2)
   /// Provide information about the state of the process and about the
@@ -52,16 +52,18 @@ public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
 
 // MARK: -
 
-@available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 extension SIGINFOHandler {
   convenience init<T>(for command: T) where T: InfoProvidingParsableCommand {
     self.init {
+      guard #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *) else {
+        _ = Task {
+          await command.provideInfo()
+        }
+        return
+      }
       #if compiler(>=6.3)
       _ = Task.immediate {
-        await command.provideInfo()
-      }
-      #else
-      _ = Task {
         await command.provideInfo()
       }
       #endif

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -56,18 +56,18 @@ public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
 extension SIGINFOHandler {
   convenience init<T>(for command: T) where T: InfoProvidingParsableCommand {
     self.init {
-      guard #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
-      else {
-        _ = Task.detached {
+      #if compiler(>=6.3)
+      if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *) {
+        _ = Task.immediate {
           await command.provideInfo()
         }
         return
       }
-      #if compiler(>=6.3)
-      _ = Task.immediateDetached {
+      #endif
+
+      _ = Task {
         await command.provideInfo()
       }
-      #endif
     }
   }
 }

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -58,13 +58,13 @@ extension SIGINFOHandler {
     self.init {
       guard #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
       else {
-        _ = Task {
+        _ = Task.detached {
           await command.provideInfo()
         }
         return
       }
       #if compiler(>=6.3)
-      _ = Task.immediate {
+      _ = Task.immediateDetached {
         await command.provideInfo()
       }
       #endif

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -44,9 +44,9 @@ public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
   ///   If ``AsyncParsableCommand/run()`` never yields, the Swift runtime may
   ///   not be able to schedule calls to this function and it will appear to the
   ///   user as if it is not implemented.
-  nonisolated(nonsending) func provideInfo() async
+  nonisolated(nonsending) static func provideInfo() async
   #else
-  func provideInfo() async
+  static func provideInfo() async
   #endif
 }
 
@@ -59,14 +59,14 @@ extension SIGINFOHandler {
       #if compiler(>=6.3)
       if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *) {
         _ = Task.immediate {
-          await command.provideInfo()
+          await T.provideInfo()
         }
         return
       }
       #endif
 
       _ = Task {
-        await command.provideInfo()
+        await T.provideInfo()
       }
     }
   }

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A parsable command that can provide information back to the user while it
+/// runs.
+///
+/// The user may request information from a running process via a
+/// platform-specific mechanism:
+///
+/// - On Apple platforms, FreeBSD, and OpenBSD, by sending `SIGINFO` to the
+///   process or by pressing Ctrl+T in the Terminal application.
+/// - On Linux, by sending the `SIGUSR1` signal to the process.
+/// - On Windows, by pressing Ctrl+Break in the Terminal application.
+///
+/// If your root command conforms to this protocol, Swift Argument Parser
+/// automatically sets up a signal handler to listen for `SIGINFO` (or the
+/// platform-specific equivalent).
+///
+/// On platforms that do not support providing information, conformance to this
+/// protocol has no effect.
+@available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
+public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
+  #if compiler(>=6.2)
+  /// Provide information about the state of the process and about the
+  /// currently-running command.
+  ///
+  /// The information you provide is program-specific. Programs will often
+  /// provide a status update such as the percentage or count of work completed,
+  /// information about the currently-running work item, etc.
+  ///
+  /// - Important: Swift Argument Parser calls this function asynchronously
+  ///   while your program is running. If your command type is actor-isolated,
+  ///   ensure your ``AsyncParsableCommand/run()`` implementation periodically
+  ///   yields control by suspending, sleeping, or calling [`Task.yield()`](https://developer.apple.com/documentation/swift/task/yield()).
+  ///
+  ///   If ``AsyncParsableCommand/run()`` never yields, the Swift runtime may
+  ///   not be able to schedule calls to this function and it will appear to the
+  ///   user as if it is not implemented.
+  nonisolated(nonsending) func provideInfo() async
+  #else
+  func provideInfo() async
+  #endif
+}
+
+// MARK: -
+
+@available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
+extension SIGINFOHandler {
+  convenience init<T>(for command: T) where T: InfoProvidingParsableCommand {
+    self.init {
+      #if compiler(>=6.3)
+      _ = Task.immediate {
+        await command.provideInfo()
+      }
+      #else
+      _ = Task {
+        await command.provideInfo()
+      }
+      #endif
+    }
+  }
+}

--- a/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/InfoProvidingCommand.swift
@@ -56,7 +56,8 @@ public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
 extension SIGINFOHandler {
   convenience init<T>(for command: T) where T: InfoProvidingParsableCommand {
     self.init {
-      guard #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *) else {
+      guard #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *)
+      else {
         _ = Task {
           await command.provideInfo()
         }

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -158,6 +158,18 @@ extension ParsableCommand {
 
     do {
       var command = try parseAsRoot(arguments)
+
+      var siginfoHandler: SIGINFOHandler?
+      if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *),
+        let command = command as? any InfoProvidingParsableCommand
+      {
+        siginfoHandler = SIGINFOHandler(for: command)
+      }
+      siginfoHandler?.register()
+      defer {
+        siginfoHandler?.unregister()
+      }
+
       try command.run()
     } catch {
       exit(withError: error)

--- a/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
+++ b/Sources/ArgumentParser/Parsable Types/ParsableCommand.swift
@@ -160,7 +160,7 @@ extension ParsableCommand {
       var command = try parseAsRoot(arguments)
 
       var siginfoHandler: SIGINFOHandler?
-      if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *),
+      if #available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *),
         let command = command as? any InfoProvidingParsableCommand
       {
         siginfoHandler = SIGINFOHandler(for: command)

--- a/Sources/ArgumentParser/Utilities/SIGINFOHandler.swift
+++ b/Sources/ArgumentParser/Utilities/SIGINFOHandler.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Dispatch)
+private import Dispatch
+#endif
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(WinSDK)
+import WinSDK
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Android)
+import Android
+#endif
+
+/// A class whose instances represent `SIGINFO` handlers configured in this
+/// process.
+///
+/// - Note: This class is responsible for handling `SIGINFO`, `SIGUSR1` (Linux),
+///   and Ctrl+Break (Windows). Naming is hard.
+final class SIGINFOHandler: Sendable {
+  /// The set of `SIGINFO` handlers configured in this process.
+  ///
+  /// Generally, this array will contain no more than `1` element, but it can be
+  /// larger if multiple commands are made to run in a single process.
+  private static let allSIGINFOHandlers = Mutex<[SIGINFOHandler]>([])
+
+  #if canImport(Dispatch)
+  /// The queue on which SIGINFO handler callbacks are invoked.
+  ///
+  /// Perhaps the natural queue for signal handling is the main queue, but we do
+  /// not control user code and we cannot ensure that it doesn't block the main
+  /// queue/thread/actor for long periods of time, which would prevent our
+  /// dispatch source from ever firing its event handler.
+  private static let siginfoQueue = DispatchQueue(
+    label: "SIGINFO monitoring queue",
+    qos: .userInitiated,
+    autoreleaseFrequency: .workItem)
+
+  /// The dispatch source that listens for `SIGINFO` (or the platform-specific
+  /// equivalent).
+  ///
+  /// This declaration is annotated `nonisolated(unsafe)` because dispatch sources
+  /// do not conform to `Sendable` on non-Darwin targets.
+  private nonisolated(unsafe) static let siginfoSource: Any = {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || os(FreeBSD) || os(OpenBSD)
+    let source = DispatchSource.makeSignalSource(
+      signal: SIGINFO, queue: siginfoQueue)
+    #elseif os(Linux) || os(Android)
+    // On Linux, SIGINFO is not defined, so we'll use SIGUSR1 for this purpose.
+    let source = DispatchSource.makeSignalSource(
+      signal: SIGUSR1, queue: siginfoQueue)
+    #elseif os(Windows)
+    let source = DispatchSource.makeUserDataAddSource(queue: siginfoQueue)
+    SetConsoleCtrlHandler(
+      { ctrlType in
+        guard ctrlType == CTRL_BREAK_EVENT else {
+          // Let the system handle it normally.
+          return false
+        }
+        if let siginfoSource = siginfoSource as? any DispatchSourceUserDataAdd {
+          siginfoSource.add(data: 1)
+        }
+        return true
+      }, true)
+    #else
+    // This platform does not support SIGINFO or any equivalent. To keep this
+    // code relatively simple, we still create a no-op dispatch source.
+    let source = DispatchSource.makeUserDataAddSource(queue: siginfoQueue)
+    #endif
+
+    source.setEventHandler {
+      // Invoke all registered handler objects.
+      let handlers = allSIGINFOHandlers.withLock { $0 }
+      for handler in handlers {
+        handler.handler()
+      }
+    }
+    source.activate()
+    return source
+  }()
+  #endif
+
+  /// The handler function this instance represents.
+  private let handler: @Sendable () -> Void
+
+  init(handlingWith handler: @escaping @Sendable () -> Void) {
+    self.handler = handler
+  }
+
+  /// Register this handler and start using it to listen for signals.
+  func register() {
+    Self.allSIGINFOHandlers.withLock { all in
+      all.append(self)
+    }
+
+    #if canImport(Dispatch)
+    // Ensure we're listening for signals after adding this handler.
+    _ = Self.siginfoSource
+    #endif
+  }
+
+  /// Unregister this handler and stop using it to listen for signals.
+  func unregister() {
+    Self.allSIGINFOHandlers.withLock { all in
+      all.removeAll { $0 === self }
+    }
+  }
+}

--- a/Tests/ArgumentParserUnitTests/CMakeLists.txt
+++ b/Tests/ArgumentParserUnitTests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(UnitTests
   HelpGenerationTests+AtOption.swift
   HelpGenerationTests+GroupName.swift
   HelpGenerationTests+HelpBanner.swift
+  InfoProvidingTests.swift
   NameSpecificationTests.swift
   SerializedCompletionSuites.swift
   SplitArgumentTests.swift

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -50,6 +50,9 @@ extension InfoProvidingTests {
       // raise SIGUSR1 after the real signal handler has been set up, so ensure
       // we're ignoring it instead until that happens.
       signal(SIGUSR1, SIG_IGN)
+      #elseif os(Windows)
+      // As with Linux, Windows generates SIGBREAK by default.
+      SetConsoleCtrlHandler({ $0 == CTRL_BREAK_EVENT }, true)
       #endif
 
       try await withThrowingDiscardingTaskGroup { taskGroup in

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ArgumentParser
+
+@Suite struct InfoProvidingTests {
+  struct SeedCommand: InfoProvidingParsableCommand {
+    @Argument var seedValue: String
+
+    func run() {
+      while true {
+        Thread.sleep(forTimeInterval: 1.0)
+      }
+    }
+
+    func provideInfo() {
+      print("\(seedValue)")
+      Self.exit()
+    }
+  }
+}
+
+extension InfoProvidingTests {
+  static let seedValue = "c6466b3a7881998f6bef30616fcd1769"
+
+  #if compiler(>=6.2)
+  @Test func siginfoHandled() async throws {
+    #if os(macOS) || os(FreeBSD) || os(OpenBSD) || os(Linux) || os(Android) || os(Windows)
+    let results = try await #require(
+      processExitsWith: .success,
+      observing: [\.standardOutputContent]
+    ) {
+      #if os(Linux) || os(Android)
+      // The default signal handler for SIGUSR1 aborts, and we are in a race to
+      // raise SIGUSR1 after the real signal handler has been set up, so ensure
+      // we're ignoring it instead until that happens.
+      signal(SIGUSR1, SIG_IGN)
+      #endif
+
+      try await withThrowingDiscardingTaskGroup { taskGroup in
+        taskGroup.addTask {
+          SeedCommand.main([Self.seedValue])
+        }
+        taskGroup.addTask {
+          // The main function is running asynchronously in another task, so we
+          // can't really predict when it will have set up the signal handler
+          // without plumbing through an invasive hook/callback. Instead, just
+          // spam ourselves with the signal.
+          while true {
+            #if os(macOS) || os(FreeBSD) || os(OpenBSD)
+            raise(SIGINFO)
+            #elseif os(Linux) || os(Android)
+            kill(getpid(), SIGUSR1) // ignore-unacceptable-language
+            #elseif os(Windows)
+            GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0)
+            #endif
+          }
+        }
+      }
+    }
+
+    #expect(results.standardOutputContent.contains(Self.seedValue.utf8))
+    #else
+    try Test.cancel("Exit tests are unsupported on this platform")
+    #endif
+  }
+  #endif
+}

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -72,7 +72,7 @@ extension InfoProvidingTests {
             #elseif os(Windows)
             GenerateConsoleCtrlEvent(DWORD(CTRL_BREAK_EVENT), 0)
             #endif
-            await Task.yield()
+            try await Task.sleep(nanoseconds: 100_000_000)
           }
         }
       }

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -67,7 +67,7 @@ extension InfoProvidingTests {
             #elseif os(Linux) || os(Android)
             kill(getpid(), SIGUSR1)  // ignore-unacceptable-language
             #elseif os(Windows)
-            GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0)
+            GenerateConsoleCtrlEvent(DWORD(CTRL_BREAK_EVENT), 0)
             #endif
           }
         }

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -18,15 +18,15 @@ import Testing
 import WinSDK
 #endif
 
+let seedValue = "c6466b3a7881998f6bef30616fcd1769"
+
 @Suite struct InfoProvidingTests {
   struct SeedCommand: ParsableCommand, InfoProvidingParsableCommand {
-    @Argument var seedValue: String
-
     func run() {
       Thread.sleep(forTimeInterval: 1.0)
     }
 
-    func provideInfo() {
+    static func provideInfo() {
       print("\(seedValue)")
       Self.exit()
     }
@@ -34,8 +34,6 @@ import WinSDK
 }
 
 extension InfoProvidingTests {
-  static let seedValue = "c6466b3a7881998f6bef30616fcd1769"
-
   #if compiler(>=6.2)
   @Test func siginfoHandled() async throws {
     #if os(macOS) || os(FreeBSD) || os(OpenBSD) || os(Linux) || os(Android) || os(Windows)
@@ -55,7 +53,7 @@ extension InfoProvidingTests {
 
       try await withThrowingDiscardingTaskGroup { taskGroup in
         taskGroup.addTask {
-          SeedCommand.main([Self.seedValue])
+          SeedCommand.main([])
         }
         taskGroup.addTask {
           // The main function is running asynchronously in another task, so we
@@ -76,7 +74,7 @@ extension InfoProvidingTests {
       }
     }
 
-    #expect(results.standardOutputContent.contains(Self.seedValue.utf8))
+    #expect(results.standardOutputContent.contains(seedValue.utf8))
     #else
     try Test.cancel("Exit tests are unsupported on this platform")
     #endif

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -52,7 +52,7 @@ extension InfoProvidingTests {
       signal(SIGUSR1, SIG_IGN)
       #elseif os(Windows)
       // As with Linux, Windows generates SIGBREAK by default.
-      SetConsoleCtrlHandler({ $0 == CTRL_BREAK_EVENT }, true)
+      SetConsoleCtrlHandler({ WindowsBool($0 == CTRL_BREAK_EVENT) }, true)
       #endif
 
       try await withThrowingDiscardingTaskGroup { taskGroup in

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -12,11 +12,11 @@
 import Foundation
 import Testing
 
+@testable import ArgumentParser
+
 #if os(Windows)
 import WinSDK
 #endif
-
-@testable import ArgumentParser
 
 @Suite struct InfoProvidingTests {
   struct SeedCommand: InfoProvidingParsableCommand {
@@ -65,7 +65,7 @@ extension InfoProvidingTests {
             #if os(macOS) || os(FreeBSD) || os(OpenBSD)
             raise(SIGINFO)
             #elseif os(Linux) || os(Android)
-            kill(getpid(), SIGUSR1) // ignore-unacceptable-language
+            kill(getpid(), SIGUSR1)  // ignore-unacceptable-language
             #elseif os(Windows)
             GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0)
             #endif

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -19,13 +19,11 @@ import WinSDK
 #endif
 
 @Suite struct InfoProvidingTests {
-  struct SeedCommand: AsyncParsableCommand, InfoProvidingParsableCommand {
+  struct SeedCommand: ParsableCommand, InfoProvidingParsableCommand {
     @Argument var seedValue: String
 
-    func run() async {
-      while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
-      }
+    func run() {
+      Thread.sleep(forTimeInterval: 1.0)
     }
 
     func provideInfo() {
@@ -57,7 +55,7 @@ extension InfoProvidingTests {
 
       try await withThrowingDiscardingTaskGroup { taskGroup in
         taskGroup.addTask {
-          await SeedCommand.main([Self.seedValue])
+          SeedCommand.main([Self.seedValue])
         }
         taskGroup.addTask {
           // The main function is running asynchronously in another task, so we
@@ -72,7 +70,7 @@ extension InfoProvidingTests {
             #elseif os(Windows)
             GenerateConsoleCtrlEvent(DWORD(CTRL_BREAK_EVENT), 0)
             #endif
-            try await Task.sleep(nanoseconds: 100_000_000)
+            try await Task.yield()
           }
         }
       }

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -12,6 +12,10 @@
 import Foundation
 import Testing
 
+#if os(Windows)
+import WinSDK
+#endif
+
 @testable import ArgumentParser
 
 @Suite struct InfoProvidingTests {

--- a/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
+++ b/Tests/ArgumentParserUnitTests/InfoProvidingTests.swift
@@ -19,12 +19,12 @@ import WinSDK
 #endif
 
 @Suite struct InfoProvidingTests {
-  struct SeedCommand: InfoProvidingParsableCommand {
+  struct SeedCommand: AsyncParsableCommand, InfoProvidingParsableCommand {
     @Argument var seedValue: String
 
-    func run() {
-      while true {
-        Thread.sleep(forTimeInterval: 1.0)
+    func run() async {
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
       }
     }
 
@@ -57,14 +57,14 @@ extension InfoProvidingTests {
 
       try await withThrowingDiscardingTaskGroup { taskGroup in
         taskGroup.addTask {
-          SeedCommand.main([Self.seedValue])
+          await SeedCommand.main([Self.seedValue])
         }
         taskGroup.addTask {
           // The main function is running asynchronously in another task, so we
           // can't really predict when it will have set up the signal handler
           // without plumbing through an invasive hook/callback. Instead, just
           // spam ourselves with the signal.
-          while true {
+          while !Task.isCancelled {
             #if os(macOS) || os(FreeBSD) || os(OpenBSD)
             raise(SIGINFO)
             #elseif os(Linux) || os(Android)
@@ -72,6 +72,7 @@ extension InfoProvidingTests {
             #elseif os(Windows)
             GenerateConsoleCtrlEvent(DWORD(CTRL_BREAK_EVENT), 0)
             #endif
+            await Task.yield()
           }
         }
       }


### PR DESCRIPTION
### Description

This PR adds a new protocol, `InfoProvidingCommand`, to which root command types can conform to indicate they respond to `SIGINFO` or platform equivalents:

- On Darwin and the BSDs, the shell raises `SIGINFO` when you press Ctrl+T;
- On Linux, `SIGUSR1` is used by (weak) convention for this purpose and can be raised with `kill` or `pkill`.
- On Windows, Ctrl+Break serves the same purpose and triggers a Win32-specific callback.

### Detailed Design

The new API is an additional protocol that refines `ParsableCommand`:

```swift
/// A parsable command that can provide information back to the user while it
/// runs.
///
/// The user may request information from a running process via a
/// platform-specific mechanism:
///
/// - On Apple platforms, FreeBSD, and OpenBSD, by sending `SIGINFO` to the
///   process or by pressing Ctrl+T in the Terminal application.
/// - On Linux, by sending the `SIGUSR1` signal to the process.
/// - On Windows, by pressing Ctrl+Break in the Terminal application.
///
/// If your root command conforms to this protocol, Swift Argument Parser
/// automatically sets up a signal handler to listen for `SIGINFO` (or the
/// platform-specific equivalent).
///
/// On platforms that do not support providing information, conformance to this
/// protocol has no effect.
@available(anyAppleOS 26, *)
public protocol InfoProvidingParsableCommand: Sendable, ParsableCommand {
  /// Provide information about the state of the process and about the
  /// currently-running command.
  ///
  /// The information you provide is program-specific. Programs will often
  /// provide a status update such as the percentage or count of work completed,
  /// information about the currently-running work item, etc.
  ///
  /// - Important: Swift Argument Parser calls this function asynchronously
  ///   while your program is running. If your command type is actor-isolated,
  ///   ensure your ``AsyncParsableCommand/run()`` implementation periodically
  ///   yields control by suspending, sleeping, or calling [`Task.yield()`](https://developer.apple.com/documentation/swift/task/yield()).
  ///
  ///   If ``AsyncParsableCommand/run()`` never yields, the Swift runtime may
  ///   not be able to schedule calls to this function and it will appear to the
  ///   user as if it is not implemented.
  nonisolated(nonsending) func provideInfo() async
}
```

Types that conform to this protocol can then implement `provideInfo()` to print whatever information is meaningful at that moment. An example program is included to show how you might use it.

### Documentation Plan

I plan to scrabble something together after the design has been critiqued.

### Test Plan

Added a new unit test based on a Swift Testing exit test. Signals are generally hard to test, and I am open to adding more tests if folks have ideas.

The example program can also be run at desk to validate behavior in an interactive way.

### Source Impact

There should be no impact on existing code.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
