### PR TITLE
Migrate the remaining subcommand end-to-end test to Swift Testing

### DIFF
--- a/Sources/ArgumentParserTestHelpers/TestHelpers+SwiftTesting.swift
+++ b/Sources/ArgumentParserTestHelpers/TestHelpers+SwiftTesting.swift
@@ -23,6 +23,38 @@ private var _debugURL: URL {
     : bundleURL
 }
 
+public final class TestExpectation {
+  public private(set) var fulfilled = false
+
+  public init() {}
+
+  public func fulfill() {
+    fulfilled = true
+  }
+}
+
+public protocol TestableSwiftTestingParsableArguments: ParsableArguments {
+  var didValidateExpectation: TestExpectation { get }
+}
+
+extension TestableSwiftTestingParsableArguments {
+  public mutating func validate() throws {
+    didValidateExpectation.fulfill()
+  }
+}
+
+public protocol TestableSwiftTestingParsableCommand: ParsableCommand,
+  TestableSwiftTestingParsableArguments
+{
+  var didRunExpectation: TestExpectation { get }
+}
+
+extension TestableSwiftTestingParsableCommand {
+  public mutating func run() throws {
+    didRunExpectation.fulfill()
+  }
+}
+
 public func expectResultFailure<T, U: Error>(
   _ expression: @autoclosure () -> Result<T, U>,
   _ message: @autoclosure () -> String = "",

--- a/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
+++ b/Tests/ArgumentParserEndToEndTests/SubcommandEndToEndTests.swift
@@ -12,7 +12,6 @@
 import ArgumentParser
 import ArgumentParserTestHelpers
 import Testing
-import XCTest
 
 @Suite struct SubcommandEndToEndTests {}
 
@@ -209,9 +208,8 @@ extension BaseCommand {
 }
 
 extension BaseCommand.SubCommand {
-  struct SubSubCommand: ParsableCommand, TestableParsableArguments {
-    let didValidateExpectation = XCTestExpectation(
-      singleExpectation: "did validate subcommand")
+  struct SubSubCommand: ParsableCommand, TestableSwiftTestingParsableArguments {
+    let didValidateExpectation = TestExpectation()
 
     static let configuration = CommandConfiguration(
       commandName: "subsub"
@@ -228,17 +226,17 @@ extension BaseCommand.SubCommand {
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 // https://github.com/apple/swift-argument-parser/issues/710
-final class SubcommandEndToEndTestsXCTest: XCTestCase {
-  func testValidate_subcommands() {
+extension SubcommandEndToEndTests {
+  @Test func validate_subcommands() throws {
     // provide a value to base-flag that will throw
-    AssertErrorMessage(
+    expectErrorMessage(
       BaseCommand.self,
       ["--base-flag", "foo", "sub", "--sub-flag", "foo", "subsub"],
       "baseCommandFailure"
     )
 
     // provide a value to sub-flag that will throw
-    AssertErrorMessage(
+    expectErrorMessage(
       BaseCommand.self,
       [
         "--base-flag", BaseCommand.baseFlagValue, "sub", "--sub-flag", "foo",
@@ -248,7 +246,7 @@ final class SubcommandEndToEndTestsXCTest: XCTestCase {
     )
 
     // provide a valid command and make sure both validates succeed
-    AssertParseCommand(
+    expectParseCommand(
       BaseCommand.self,
       BaseCommand.SubCommand.SubSubCommand.self,
       [
@@ -256,11 +254,11 @@ final class SubcommandEndToEndTestsXCTest: XCTestCase {
         BaseCommand.SubCommand.subFlagValue, "subsub", "--sub-sub-flag",
       ]
     ) { cmd in
-      XCTAssertTrue(cmd.subSubFlag)
+      #expect(cmd.subSubFlag)
 
       // make sure that the instance of SubSubCommand provided
       // had its validate method called, not just that any instance of SubSubCommand was validated
-      wait(for: [cmd.didValidateExpectation], timeout: 0.1)
+      #expect(cmd.didValidateExpectation.fulfilled)
     }
   }
 }


### PR DESCRIPTION
Closes #962

Migrate the remaining `SubcommandEndToEndTestsXCTest` suite to Swift Testing. Add a synchronous reference-backed `TestExpectation` helper and Swift Testing protocol counterparts so the test verifies that the exact parsed subcommand instance was validated.

Validation:
- `swift test` (563 tests)
- `swift test --filter ArgumentParserEndToEndTests.SubcommandEndToEndTests`